### PR TITLE
feat: plugin fetch CLI, dotenv, live progress, and location assumptions plugin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,15 @@
-# Copy to .env and fill in your values, then:
-#   docker compose run --rm dashboard python autobiographer.py --user YOUR_USERNAME
+# Copy this file to .env and fill in your values.
+#
+# The app and CLI load .env automatically — no manual `export` needed.
+#
+# Fetch your Last.fm listening history:
+#   python autobiographer.py fetch lastfm
+#
+# Or from Docker:
+#   docker compose run --rm dashboard python autobiographer.py fetch lastfm
+#
+# Get a Last.fm API key at: https://www.last.fm/api/account/create
+
 AUTOBIO_LASTFM_API_KEY=your_api_key_here
 AUTOBIO_LASTFM_API_SECRET=your_api_secret_here
 AUTOBIO_LASTFM_USERNAME=your_username_here

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ Autobiographer is a Python-based toolkit that allows you to fetch, store, and ex
 
 <img src="assets/flythrough.gif" style="width: 500">
 
+## Data Sources
+
+Autobiographer is built around a plugin system. Each plugin owns a specific data source — its format, how to obtain it, and how it maps into the common schema. All path configuration happens in the sidebar; nothing is hardcoded.
+
+| Plugin | Type | Description |
+|--------|------|-------------|
+| [Last.fm Music History](plugins/sources/lastfm/README.md) | what-when | Your complete listening history, fetched automatically via the Last.fm API. One click in the sidebar downloads everything. |
+| [Foursquare / Swarm Check-ins](plugins/sources/swarm/README.md) | where-when | Your check-in history from the Swarm app. Requires a one-time manual data export request from Foursquare. |
+| [Location Assumptions](plugins/sources/assumptions/README.md) | location-context | A user-authored JSON file that fills in your location for periods not covered by Swarm — trips, recurring holidays, and home residency rules. |
+
+Each plugin has its own README with setup instructions, data format details, and schema documentation.
+
 ## Quickstart (Docker)
 
 No Python knowledge required — just [Docker](https://www.docker.com/products/docker-desktop/).
@@ -45,7 +57,7 @@ To download your listening history directly into the mounted data volume, pass y
 ```bash
 cp .env.example .env           # fill in your API key, secret, and username
 docker compose run --rm dashboard \
-    python autobiographer.py --user YOUR_USERNAME
+    python autobiographer.py fetch lastfm
 docker compose up
 ```
 
@@ -79,20 +91,44 @@ docker compose up
 
 ### 3. Configuration
 
-Set your Last.fm credentials in your environment:
+Set your credentials as environment variables. Required for Last.fm fetching:
 ```bash
 export AUTOBIO_LASTFM_API_KEY="your_api_key"
 export AUTOBIO_LASTFM_API_SECRET="your_api_secret"
 export AUTOBIO_LASTFM_USERNAME="your_username"
 ```
 
+Get a Last.fm API key at: https://www.last.fm/api/account/create
+
 ### 4. Usage
 
 #### Fetch Your Data
-Download your listening history to a local CSV file:
+
+The `fetch` command targets a specific plugin. Plugins that support automatic download
+will retrieve your data; plugins that require a manual export will print step-by-step
+instructions instead.
+
 ```bash
-python autobiographer.py --user your_username
+# Download Last.fm listening history (requires env vars above)
+python autobiographer.py fetch lastfm
+
+# Print Foursquare/Swarm manual export instructions
+python autobiographer.py fetch swarm
+
+# Limit to recent pages or a date range
+python autobiographer.py fetch lastfm --pages 5
+python autobiographer.py fetch lastfm --from-date 2024-01-01 --to-date 2024-12-31
+
+# Save to a custom location
+python autobiographer.py fetch lastfm --output data/my_tracks.csv
 ```
+
+If a plugin is not yet configured the command will list exactly which environment
+variables are missing and what each one is for.
+
+The app sidebar also exposes this directly: a **Fetch Latest Data** button appears for
+plugins that support automatic retrieval, and step-by-step manual instructions are
+shown for plugins that require a data export from the provider.
 
 #### Launch the Streamlit Dashboard
 Start the interactive Streamlit application:
@@ -205,7 +241,7 @@ Additional utility scripts are available in the `tools/` directory:
 ## Project Structure
 
 ```
-autobiographer.py       # Last.fm API fetch + data save CLI
+autobiographer.py       # Data-fetching CLI (`fetch <plugin>`) + Last.fm API client
 visualize.py            # Streamlit dashboard (assembles views from plugins)
 export_html.py          # Static HTML export — single self-contained report file
 analysis_utils.py       # Shared data processing and caching logic
@@ -215,8 +251,9 @@ plugins/
   sources/
     base.py             # SourcePlugin ABC + validate_schema()
     __init__.py         # REGISTRY + @register decorator + load_builtin_plugins()
-    lastfm/loader.py    # Last.fm source plugin
-    swarm/loader.py     # Foursquare/Swarm source plugin
+    lastfm/loader.py        # Last.fm source plugin
+    swarm/loader.py         # Foursquare/Swarm source plugin
+    assumptions/loader.py   # Location assumptions plugin
 notebooks/              # Jupyter notebooks for custom analysis
 tools/                  # Utility scripts (audio muxing, etc.)
 data/                   # Local data storage (CSVs, cache, Swarm JSON exports)
@@ -389,6 +426,7 @@ Selected paths are persisted to `data/config.json` so they survive application r
 |---|---|
 | `what-when` | `timestamp`, `label`, `sublabel`, `category`, `source_id` |
 | `where-when` | `timestamp`, `lat`, `lng`, `place_name`, `place_type`, `source_id` |
+| `location-context` | No required columns — defines enrichment data, not a primary stream |
 
 `validate_schema()` raises `ValueError` at load time if any required column is absent.
 

--- a/autobiographer.py
+++ b/autobiographer.py
@@ -1,10 +1,13 @@
 import argparse
 import os
 import time
-from typing import Optional
+from typing import Callable, Optional
 
 import pandas as pd
 import requests
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 class Autobiographer:
@@ -30,10 +33,26 @@ class Autobiographer:
         pages: Optional[int] = None,
         from_ts: Optional[int] = None,
         to_ts: Optional[int] = None,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
     ) -> list[dict]:
-        """Fetch recent tracks for the user."""
+        """Fetch recent tracks for the user.
+
+        Args:
+            limit: Tracks per API page (max 200).
+            pages: Stop after this many pages; None fetches all.
+            from_ts: Unix timestamp lower bound (inclusive).
+            to_ts: Unix timestamp upper bound (inclusive).
+            progress_callback: Optional callable invoked after each page with
+                ``(current_page, total_pages)`` so callers can report progress.
+                Also receives ``(0, total_pages)`` before the first page fetch
+                once the total is known.
+
+        Returns:
+            List of raw track dicts from the Last.fm API.
+        """
         all_tracks = []
         current_page = 1
+        total_pages = 1
 
         while True:
             print(f"Fetching page {current_page}...")
@@ -54,6 +73,9 @@ class Autobiographer:
             all_tracks.extend(tracks)
 
             total_pages = int(data.get("recenttracks", {}).get("@attr", {}).get("totalPages", 1))
+            if progress_callback:
+                progress_callback(current_page, total_pages)
+
             if pages and current_page >= pages:
                 break
             if current_page >= total_pages:
@@ -87,52 +109,152 @@ class Autobiographer:
         print(f"Saved {len(df)} tracks to {filename}")
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Fetch Last.fm listening history.")
-    parser.add_argument(
-        "--user", help="Last.fm username (defaults to AUTOBIO_LASTFM_USERNAME env var)"
+def _parse_date(date_str: str, label: str) -> Optional[int]:
+    """Parse a YYYY-MM-DD date string and return a Unix timestamp.
+
+    Args:
+        date_str: Date string in YYYY-MM-DD format.
+        label: Human-readable label used in error messages (e.g. "from_date").
+
+    Returns:
+        Unix timestamp as int, or None if date_str is empty.
+
+    Raises:
+        SystemExit: If the date string is not in the expected format.
+    """
+    if not date_str:
+        return None
+    try:
+        return int(time.mktime(time.strptime(date_str, "%Y-%m-%d")))
+    except ValueError as exc:
+        print(f"Error: Invalid {label} format '{date_str}'. Use YYYY-MM-DD.")
+        raise SystemExit(1) from exc
+
+
+def _run_fetch(args: argparse.Namespace) -> None:
+    """Execute the ``fetch`` subcommand.
+
+    Routes to the named plugin's fetch() method if it supports programmatic
+    retrieval, or prints manual download instructions if it does not.
+
+    Args:
+        args: Parsed CLI arguments including ``plugin``, ``output``, ``pages``,
+            ``from_date``, and ``to_date``.
+    """
+    from plugins.sources import REGISTRY, load_builtin_plugins
+
+    load_builtin_plugins()
+
+    plugin_id: str = args.plugin
+    if plugin_id not in REGISTRY:
+        available = ", ".join(sorted(REGISTRY))
+        print(f"Error: Unknown plugin '{plugin_id}'. Available plugins: {available}")
+        raise SystemExit(1)
+
+    plugin = REGISTRY[plugin_id]()
+
+    if not plugin.FETCHABLE:
+        print(f"{plugin.DISPLAY_NAME} does not support automatic fetching.\n")
+        print(plugin.get_manual_download_instructions())
+        return
+
+    # Validate env vars before attempting the fetch.
+    env_vars = plugin.get_fetch_env_vars()
+    missing = [v for v in env_vars if not os.getenv(v["var"])]
+    if missing:
+        print("Error: Missing required configuration for fetching. Set the following:\n")
+        for v in missing:
+            print(f"  {v['var']}: {v['description']}")
+        print(
+            f"\nThen re-run: python autobiographer.py fetch {plugin_id}\n"
+            "See README.md for full configuration instructions."
+        )
+        raise SystemExit(1)
+
+    from_ts = _parse_date(args.from_date or "", "from_date")
+    to_ts_raw = _parse_date(args.to_date or "", "to_date")
+    # Shift to-date to end of day so the full day is included.
+    to_ts = to_ts_raw + 86399 if to_ts_raw is not None else None
+
+    print(f"Fetching {plugin.DISPLAY_NAME} data...")
+    plugin.fetch(
+        output_path=args.output or None,
+        pages=args.pages,
+        from_ts=from_ts,
+        to_ts=to_ts,
     )
-    parser.add_argument("--pages", type=int, help="Limit number of pages to fetch")
-    parser.add_argument("--from_date", help="Start date (YYYY-MM-DD)")
-    parser.add_argument("--to_date", help="End date (YYYY-MM-DD)")
+
+
+def main() -> None:
+    """Entry point for the Autobiographer data-fetching CLI.
+
+    Subcommands
+    -----------
+    fetch <plugin>
+        Fetch data for the named plugin. For plugins that support programmatic
+        retrieval (e.g. ``lastfm``) this downloads and saves data locally.
+        For manual-export plugins (e.g. ``swarm``) this prints step-by-step
+        instructions for obtaining the data from the provider.
+
+    Examples
+    --------
+    ::
+
+        python autobiographer.py fetch lastfm
+        python autobiographer.py fetch lastfm --pages 5
+        python autobiographer.py fetch lastfm --from-date 2024-01-01
+        python autobiographer.py fetch swarm
+    """
+    parser = argparse.ArgumentParser(
+        description="Autobiographer data-fetching CLI.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
+
+    fetch_parser = subparsers.add_parser(
+        "fetch",
+        help="Fetch or get instructions for a plugin's data.",
+        description=(
+            "Fetch data for a registered source plugin. "
+            "Plugins that support automatic retrieval will download and save data. "
+            "Plugins that require a manual export will print step-by-step instructions."
+        ),
+    )
+    fetch_parser.add_argument(
+        "plugin",
+        metavar="PLUGIN",
+        help="Plugin ID to target (e.g. lastfm, swarm).",
+    )
+    fetch_parser.add_argument(
+        "--output",
+        metavar="PATH",
+        help="Output file or directory path (overrides the plugin's default location).",
+    )
+    fetch_parser.add_argument(
+        "--pages",
+        type=int,
+        metavar="N",
+        help="Limit to N pages of results (Last.fm only).",
+    )
+    fetch_parser.add_argument(
+        "--from-date",
+        dest="from_date",
+        metavar="YYYY-MM-DD",
+        help="Only fetch records on or after this date.",
+    )
+    fetch_parser.add_argument(
+        "--to-date",
+        dest="to_date",
+        metavar="YYYY-MM-DD",
+        help="Only fetch records on or before this date.",
+    )
 
     args = parser.parse_args()
 
-    api_key = os.getenv("AUTOBIO_LASTFM_API_KEY")
-    api_secret = os.getenv("AUTOBIO_LASTFM_API_SECRET")
-    username = args.user or os.getenv("AUTOBIO_LASTFM_USERNAME")
-
-    if not all([api_key, api_secret, username]):
-        print(
-            "Error: AUTOBIO_LASTFM_API_KEY, AUTOBIO_LASTFM_API_SECRET, and "
-            "AUTOBIO_LASTFM_USERNAME must be set."
-        )
-        return
-
-    from_ts = None
-    if args.from_date:
-        try:
-            # Beginning of the day
-            from_ts = int(time.mktime(time.strptime(args.from_date, "%Y-%m-%d")))
-        except ValueError:
-            print(f"Error: Invalid from_date format '{args.from_date}'. Use YYYY-MM-DD.")
-            return
-
-    to_ts = None
-    if args.to_date:
-        try:
-            # End of the day (23:59:59)
-            to_struct = time.strptime(args.to_date, "%Y-%m-%d")
-            to_ts = int(time.mktime(to_struct)) + 86399
-        except ValueError:
-            print(f"Error: Invalid to_date format '{args.to_date}'. Use YYYY-MM-DD.")
-            return
-
-    if not api_key or not api_secret or not username:
-        return
-    visualizer = Autobiographer(api_key, api_secret, username)
-    tracks = visualizer.fetch_recent_tracks(pages=args.pages, from_ts=from_ts, to_ts=to_ts)
-    visualizer.save_tracks_to_csv(tracks)
+    if args.command == "fetch":
+        _run_fetch(args)
+    else:
+        parser.print_help()
 
 
 if __name__ == "__main__":

--- a/components/sidebar.py
+++ b/components/sidebar.py
@@ -166,6 +166,81 @@ def _path_input(
     return str(st.session_state.get(session_key, default))
 
 
+def _render_plugin_fetch_section(
+    plugin: Any, config: dict[str, str]
+) -> tuple[bool, str | None, str]:
+    """Render a fetch button or manual-download guidance inside a plugin expander.
+
+    For fetchable plugins (``FETCHABLE`` is True): shows required env vars that
+    are unset, or a "Fetch Latest Data" button if all env vars are present.
+
+    For non-fetchable plugins: shows manual download instructions when no data
+    path has been configured yet.
+
+    The actual fetch is intentionally NOT executed here. This function only
+    renders the button and returns whether it was clicked and where to save the
+    result. The caller runs the fetch *after* all expanders are closed so that
+    progress updates appear in a sidebar-level placeholder that is always
+    visible (widgets inside a collapsed expander are invisible).
+
+    Args:
+        plugin: Instantiated SourcePlugin.
+        config: Current config values returned by ``_render_plugin_config``.
+
+    Returns:
+        Tuple of (fetch_triggered, output_path, primary_key) where
+        ``fetch_triggered`` is True when the user clicked "Fetch Latest Data",
+        ``output_path`` is the resolved destination path (or empty string), and
+        ``primary_key`` is the config field key for the primary path so the
+        caller can auto-populate session state after a successful fetch.
+    """
+    from plugins.sources.base import SourcePlugin
+
+    if not isinstance(plugin, SourcePlugin):
+        return False, None, ""
+
+    st.markdown("---")
+
+    if plugin.FETCHABLE:
+        env_vars = plugin.get_fetch_env_vars()
+        missing_vars = [v for v in env_vars if not os.getenv(v["var"])]
+
+        if missing_vars:
+            st.caption("**Auto-fetch** requires these env vars:")
+            for v in missing_vars:
+                st.code(f'{v["var"]}="…"', language="bash")
+                st.caption(v["description"])
+            return False, None, ""
+
+        # Show which account is configured so the user can confirm before fetching.
+        identity = plugin.get_fetch_identity()
+        if identity:
+            st.caption(f"Fetching as **{identity}**")
+
+        # Resolve the save path: prefer the already-configured primary
+        # field value; fall back to the plugin's default output path.
+        primary_key = next(iter(config.keys()), "") if config else ""
+        primary_value = next(iter(config.values()), "") if config else ""
+        output_path = primary_value.strip() or plugin.get_default_output_path() or None
+
+        if output_path:
+            st.caption(f"Saves to `{output_path}`")
+
+        triggered = st.button(
+            "Fetch Latest Data",
+            key=f"fetch_{plugin.PLUGIN_ID}",
+            help=f"Download {plugin.DISPLAY_NAME} data now",
+        )
+        return triggered, output_path, primary_key
+    else:
+        # Only surface instructions when data isn't configured yet — no need to
+        # clutter the expander for users who already have their data loaded.
+        primary_value = next(iter(config.values()), "") if config else ""
+        if not primary_value.strip() or not os.path.exists(primary_value.strip()):
+            st.info(plugin.get_manual_download_instructions())
+        return False, None, ""
+
+
 def _render_plugin_config(plugin_id: str, fields: list[dict[str, Any]]) -> dict[str, str]:
     """Render sidebar config fields for one plugin and return collected values.
 
@@ -218,27 +293,78 @@ def render_sidebar() -> None:
     )
 
     configs: dict[str, dict[str, str]] = {}
+    # Collect any fetch requests from the expanders so they can be executed
+    # after all expanders are rendered. Widgets inside a collapsed expander are
+    # invisible; running the fetch outside ensures progress updates are shown.
+    pending_fetches: list[tuple[Any, str, str | None, str]] = []
+
     for plugin_id, plugin_cls in REGISTRY.items():
         plugin = plugin_cls()
         fields = plugin.get_config_fields()
 
         # Auto-expand the section when the primary path is not yet configured
         # so first-time users immediately see they need to fill it in.
+        # Also auto-expand when the saved path no longer exists on disk so
+        # users can immediately browse for a replacement.
         primary_key = f"{plugin_id}_{fields[0]['key']}" if fields else ""
-        is_configured = bool(st.session_state.get(primary_key, "").strip())
+        primary_value = st.session_state.get(primary_key, "").strip()
+        primary_type = fields[0].get("type", "text") if fields else "text"
+        primary_path_missing = (
+            bool(primary_value)
+            and primary_type in ("file_path", "dir_path")
+            and not os.path.exists(primary_value)
+        )
+        is_configured = bool(primary_value) and not primary_path_missing
 
         with st.sidebar.expander(
             f"{plugin.ICON}  {plugin.DISPLAY_NAME}", expanded=not is_configured
         ):
+            if primary_path_missing:
+                st.warning("Path no longer found — please select a new location.")
             configs[plugin_id] = _render_plugin_config(plugin_id, fields)
+            triggered, output_path, cfg_key = _render_plugin_fetch_section(
+                plugin, configs[plugin_id]
+            )
+            if triggered:
+                pending_fetches.append((plugin, plugin_id, output_path, cfg_key))
+
+    # Execute any pending fetches with a sidebar-level status placeholder that
+    # is always visible regardless of expander collapsed/expanded state.
+    if pending_fetches:
+        fetch_status = st.sidebar.empty()
+        for plugin, plugin_id, output_path, cfg_key in pending_fetches:
+            primary_value = configs.get(plugin_id, {}).get(cfg_key, "")
+            fetch_status.info(f"Starting fetch for {plugin.DISPLAY_NAME}…")
+
+            def _on_progress(page: int, total: int, _status: Any = fetch_status) -> None:
+                _status.info(f"Fetching page {page} of {total}…")
+
+            try:
+                plugin.fetch(
+                    output_path=output_path,
+                    progress_callback=_on_progress,
+                )
+                # Auto-populate the config field so the user doesn't need
+                # to manually enter the path after a successful fetch.
+                if output_path and cfg_key and not primary_value.strip():
+                    session_key = f"{plugin_id}_{cfg_key}"
+                    st.session_state[session_key] = output_path
+                    _settings.set_plugin_value(plugin_id, cfg_key, output_path)
+                fetch_status.success(
+                    f"Done — data saved to `{output_path}`. "
+                    "Reload the page to see the updated data."
+                )
+            except Exception as exc:  # noqa: BLE001
+                fetch_status.error(f"Fetch failed: {exc}")
 
     # --- Data loading ---------------------------------------------------------
     lastfm_cfg = configs.get("lastfm", {})
     swarm_cfg = configs.get("swarm", {})
+    assumptions_cfg = configs.get("assumptions", {})
 
     file_path: str = lastfm_cfg.get("data_path", "")
     swarm_dir: str = swarm_cfg.get("swarm_dir", "")
-    assumptions_path: str = swarm_cfg.get("assumptions_file", "default_assumptions.json")
+    assumptions_path: str = assumptions_cfg.get("assumptions_file", "default_assumptions.json")
 
     if not file_path or not os.path.exists(file_path):
         if file_path:

--- a/plugins/sources/__init__.py
+++ b/plugins/sources/__init__.py
@@ -42,5 +42,6 @@ def load_builtin_plugins() -> None:
 
     Call this once at application startup before reading REGISTRY.
     """
+    import plugins.sources.assumptions.loader  # noqa: F401
     import plugins.sources.lastfm.loader  # noqa: F401
     import plugins.sources.swarm.loader  # noqa: F401

--- a/plugins/sources/assumptions/README.md
+++ b/plugins/sources/assumptions/README.md
@@ -1,0 +1,89 @@
+# Location Assumptions
+
+## What it is
+
+Location assumptions are a user-authored JSON file that tells Autobiographer where you were during periods not captured by Swarm check-ins. This fills the gaps that GPS data inevitably leaves: years before you started using Swarm, trips you forgot to check in on, recurring visits to family, and the simple fact of where home is.
+
+The assumptions file is applied when Autobiographer maps timezone offsets and locations onto your Last.fm listening history. Without it, every listen without a Swarm match falls back to a generic default location. With it, you get accurate local times and a richer map of where your life was actually happening.
+
+## How the data is obtained
+
+You create this file yourself. It is a structured JSON document with four sections:
+
+| Section | Purpose |
+|---------|---------|
+| `defaults` | Your home city and timezone — used as the fallback when nothing else matches |
+| `trips` | Explicit date-range travel entries (city, lat/lng, timezone, start, end) |
+| `holidays` | Annually recurring events matched by month and day range (e.g. a family visit every December) |
+| `residency` | Long-term home or work periods, with optional sub-rules for work-hours vs. home logic |
+
+## Setup
+
+### 1. Copy the example file
+
+```bash
+cp default_assumptions.json.example default_assumptions.json
+```
+
+This file is already gitignored — your personal location history stays on your machine.
+
+### 2. Edit the file with your own data
+
+Open `default_assumptions.json` in any text editor. Replace the example entries with your own. The format is:
+
+```json
+{
+  "defaults": {
+    "city": "London, GB",
+    "lat": 51.5074,
+    "lng": -0.1278,
+    "timezone": "Europe/London"
+  },
+  "trips": [
+    {
+      "start": "2023-06-01",
+      "end": "2023-06-07",
+      "city": "Paris, FR",
+      "lat": 48.8566,
+      "lng": 2.3522,
+      "timezone": "Europe/Paris"
+    }
+  ],
+  "holidays": [
+    {
+      "name": "Christmas",
+      "month": 12,
+      "day_range": [24, 26],
+      "city": "Edinburgh, GB",
+      "lat": 55.9533,
+      "lng": -3.1883,
+      "timezone": "Europe/London"
+    }
+  ],
+  "residency": []
+}
+```
+
+Timezone strings must be valid IANA timezone identifiers (e.g. `"America/New_York"`, `"Asia/Tokyo"`). Lat/lng values are in WGS84 decimal degrees.
+
+### 3. Point the plugin at your file
+
+In the Autobiographer sidebar, expand **Location Assumptions** and click **…** next to **Location assumptions JSON**. Navigate to your `default_assumptions.json` and select it.
+
+The sidebar will auto-expand this section if no file is configured yet.
+
+## How it works with other plugins
+
+The Location Assumptions plugin does not produce a data source on its own — it enriches the output of the **Last.fm** plugin. When Autobiographer processes your listening history, it looks up each listen's timestamp in this file (in priority order: holidays → trips → residency → defaults) to assign a city, coordinates, and UTC offset. This is what makes the timeline and map views show correct local times and locations for listens recorded long before you started checking in on Swarm.
+
+## Data produced
+
+| Column | Description |
+|--------|-------------|
+| `type` | Entry kind: `"default"`, `"trip"`, `"holiday"`, or `"residency"` |
+| `city` | City name (used for display and geocoding fallback) |
+| `lat` | Latitude (WGS84) |
+| `lng` | Longitude (WGS84) |
+| `timezone` | IANA timezone string (e.g. `"Europe/London"`) |
+| `start` | Start date (`YYYY-MM-DD`) or recurring pattern for holidays |
+| `end` | End date (`YYYY-MM-DD`); empty for defaults and holidays |

--- a/plugins/sources/assumptions/loader.py
+++ b/plugins/sources/assumptions/loader.py
@@ -1,0 +1,162 @@
+"""Location assumptions source plugin.
+
+Loads a user-authored JSON file that describes where the user was during
+periods not covered by Swarm check-ins — trips, recurring holidays, and
+home residency rules. This data is consumed by apply_swarm_offsets() to
+assign locations and timezone offsets to Last.fm listens.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from plugins.sources import register
+from plugins.sources.base import SourcePlugin
+
+
+@register
+class AssumptionsPlugin(SourcePlugin):
+    """Load location assumptions from a user-authored JSON file.
+
+    The JSON file describes where the user was during periods not recorded
+    by Swarm: long trips, annually recurring holidays, and home/work
+    residency rules. The sidebar passes the file path to load_assumptions()
+    so apply_swarm_offsets() can fill in locations for Last.fm listens.
+    """
+
+    PLUGIN_TYPE = "location-context"
+    PLUGIN_ID = "assumptions"
+    DISPLAY_NAME = "Location Assumptions"
+    ICON = ":material/map:"
+
+    def get_config_fields(self) -> list[dict[str, Any]]:
+        """Declare sidebar config fields for the assumptions plugin.
+
+        Returns:
+            List containing a single path field for the JSON file.
+        """
+        return [
+            {
+                "key": "assumptions_file",
+                "label": "Location assumptions JSON",
+                "type": "file_path",
+                "file_types": [("JSON files", "*.json"), ("All files", "*.*")],
+            }
+        ]
+
+    def load(self, config: dict[str, Any]) -> pd.DataFrame:
+        """Load the assumptions file and return a flat DataFrame of location periods.
+
+        Normalizes trips, holidays, and the default location into rows so the
+        data can be inspected or displayed like any other plugin output.
+        Residency entries (which have complex sub-rules) are included as a
+        single summary row each.
+
+        Args:
+            config: Must contain "assumptions_file" key with path to JSON file.
+                If the file is absent or empty the built-in defaults are used.
+
+        Returns:
+            DataFrame with columns: type, city, lat, lng, timezone, start, end.
+            Returns an empty DataFrame if no assumptions are defined.
+        """
+        from analysis_utils import load_assumptions
+
+        assumptions_file = config.get("assumptions_file", "")
+        data = load_assumptions(assumptions_file or None)
+
+        rows: list[dict[str, Any]] = []
+
+        defaults = data.get("defaults", {})
+        if defaults:
+            rows.append(
+                {
+                    "type": "default",
+                    "city": defaults.get("city", ""),
+                    "lat": defaults.get("lat"),
+                    "lng": defaults.get("lng"),
+                    "timezone": defaults.get("timezone", ""),
+                    "start": "",
+                    "end": "",
+                }
+            )
+
+        for trip in data.get("trips", []):
+            rows.append(
+                {
+                    "type": "trip",
+                    "city": trip.get("city", ""),
+                    "lat": trip.get("lat"),
+                    "lng": trip.get("lng"),
+                    "timezone": trip.get("timezone", ""),
+                    "start": trip.get("start", ""),
+                    "end": trip.get("end", ""),
+                }
+            )
+
+        for holiday in data.get("holidays", []):
+            month = holiday.get("month", "")
+            day_range = holiday.get("day_range", [])
+            day_str = f"{day_range[0]}–{day_range[1]}" if len(day_range) == 2 else ""
+            rows.append(
+                {
+                    "type": "holiday",
+                    "city": holiday.get("city", ""),
+                    "lat": holiday.get("lat"),
+                    "lng": holiday.get("lng"),
+                    "timezone": holiday.get("timezone", ""),
+                    "start": f"month {month} day {day_str}",
+                    "end": "",
+                }
+            )
+
+        for res in data.get("residency", []):
+            rows.append(
+                {
+                    "type": "residency",
+                    "city": res.get("city", ""),
+                    "lat": res.get("lat"),
+                    "lng": res.get("lng"),
+                    "timezone": "",
+                    "start": res.get("start", ""),
+                    "end": res.get("end", ""),
+                }
+            )
+
+        return pd.DataFrame(rows) if rows else pd.DataFrame()
+
+    def get_manual_download_instructions(self) -> str:
+        """Return instructions for creating a location assumptions file.
+
+        Returns:
+            Multi-line instruction string.
+        """
+        return (
+            "Location assumptions are defined in a JSON file you create yourself.\n\n"
+            "Copy the example file to get started:\n"
+            "  cp default_assumptions.json.example default_assumptions.json\n\n"
+            "Edit it to describe:\n"
+            "  • defaults — your home city and timezone (used when nothing else matches)\n"
+            "  • trips    — date-range trips with city, lat/lng, and timezone\n"
+            "  • holidays — recurring annual events (e.g. a family visit every December)\n"
+            "  • residency — long-term home or work periods with optional sub-rules\n\n"
+            "See default_assumptions.json.example for the full format reference."
+        )
+
+    def get_schema(self) -> dict[str, str]:
+        """Return column descriptions for the assumptions plugin.
+
+        Returns:
+            Dict mapping column names to descriptions.
+        """
+        return {
+            "type": "Entry type: 'default', 'trip', 'holiday', or 'residency'",
+            "city": "City name (used for display and geocoding fallback)",
+            "lat": "Latitude (WGS84)",
+            "lng": "Longitude (WGS84)",
+            "timezone": "IANA timezone string (e.g. 'Europe/London')",
+            "start": "Start date (YYYY-MM-DD) or recurring pattern for holidays",
+            "end": "End date (YYYY-MM-DD); empty for defaults and holidays",
+        }

--- a/plugins/sources/base.py
+++ b/plugins/sources/base.py
@@ -41,12 +41,21 @@ class SourcePlugin(ABC):
             timestamp, label, sublabel, category, source_id.
         "where-when": Location sources (check-ins, GPS routes). Must emit columns:
             timestamp, lat, lng, place_name, place_type, source_id.
+
+    Fetchability:
+        Set ``FETCHABLE = True`` and override ``get_fetch_env_vars()``, ``fetch()``,
+        and ``get_manual_download_instructions()`` for plugins that can retrieve data
+        programmatically. Non-fetchable plugins should only override
+        ``get_manual_download_instructions()`` to guide users through a manual export.
     """
 
     PLUGIN_TYPE: str  # "what-when" or "where-when"
     PLUGIN_ID: str  # unique identifier, e.g. "lastfm", "swarm"
     DISPLAY_NAME: str  # human-readable name for the UI
     ICON: str = ":material/database:"  # Material icon token shown in the sidebar
+
+    FETCHABLE: bool = False
+    """True if this plugin can programmatically retrieve data from its source."""
 
     @abstractmethod
     def get_config_fields(self) -> list[dict[str, Any]]:
@@ -85,6 +94,82 @@ class SourcePlugin(ABC):
         Returns:
             Normalized DataFrame.
         """
+
+    def get_fetch_env_vars(self) -> list[dict[str, str]]:
+        """Return environment variables required to fetch data for this plugin.
+
+        Each entry is a dict with:
+            var (str): Environment variable name (e.g. ``"AUTOBIO_LASTFM_API_KEY"``).
+            description (str): Human-readable description shown when the var is absent.
+
+        Returns:
+            List of required env var descriptors. Empty when ``FETCHABLE`` is False.
+        """
+        return []
+
+    def fetch(self, output_path: str | None = None, **kwargs: Any) -> None:
+        """Programmatically fetch data from the source and write it to disk.
+
+        Only called when ``FETCHABLE`` is True. The default implementation raises
+        ``NotImplementedError``; fetchable plugins must override this method.
+
+        Args:
+            output_path: Destination path for the fetched file or directory.
+                If None the plugin writes to its default location under ``data/``.
+            **kwargs: Plugin-specific options (e.g. ``pages``, ``from_ts``, ``to_ts``
+                for the Last.fm plugin).
+
+        Raises:
+            NotImplementedError: Always, unless overridden by a fetchable plugin.
+            OSError: If required env vars declared by ``get_fetch_env_vars()`` are
+                missing — raised by the overriding implementation, not this base.
+        """
+        raise NotImplementedError(
+            f"{self.PLUGIN_ID} does not support automatic fetching. "
+            "Run `python autobiographer.py fetch "
+            f"{self.PLUGIN_ID}` for manual download instructions."
+        )
+
+    def get_default_output_path(self) -> str | None:
+        """Return the default path where fetched data will be saved.
+
+        Used by the sidebar to show the user exactly where the file will land
+        before they click Fetch, and to auto-populate the config field after
+        a successful fetch.
+
+        Returns:
+            Absolute or project-relative path string, or None if the plugin
+            does not write to a fixed default location.
+        """
+        return None
+
+    def get_fetch_identity(self) -> str | None:
+        """Return a short string identifying the account or source that will be fetched.
+
+        Shown in the app sidebar next to the fetch button so users can confirm
+        the correct account is configured before triggering a download.
+
+        Returns:
+            Human-readable identity string (e.g. ``"@username"``), or None if
+            not applicable for this plugin.
+        """
+        return None
+
+    def get_manual_download_instructions(self) -> str:
+        """Return human-readable instructions for obtaining this plugin's data.
+
+        Shown in the CLI when ``fetch`` is called on a non-fetchable plugin and
+        in the app sidebar when data has not been configured yet. Override in
+        every plugin to provide source-specific guidance.
+
+        Returns:
+            Multi-line instruction string.
+        """
+        return (
+            f"{self.DISPLAY_NAME} data must be obtained manually. "
+            "Please refer to the source's documentation for export options, "
+            "then point the plugin's config field at the downloaded file."
+        )
 
     def get_schema(self) -> dict[str, str]:
         """Return column name → description metadata for this plugin.

--- a/plugins/sources/lastfm/README.md
+++ b/plugins/sources/lastfm/README.md
@@ -1,0 +1,62 @@
+# Last.fm Music History
+
+## What it is
+
+[Last.fm](https://www.last.fm) is a music tracking service that logs every song you play — a practice called *scrobbling*. Whenever you listen to a track through a connected player (Spotify, Apple Music, YouTube Music, Winamp, and dozens more), Last.fm records the artist, album, track name, and timestamp. Over time this builds a complete, timestamped diary of everything you've ever listened to.
+
+Autobiographer imports this history so you can visualize listening patterns, milestones, streaks, and top artists across your entire music life.
+
+## How the data is fetched
+
+Autobiographer fetches your scrobble history directly from the Last.fm API and saves it as a CSV file at `data/lastfm_<username>_tracks.csv`. No manual export step is required.
+
+You can trigger a fetch in two ways:
+
+- **In the app**: click **Fetch Latest Data** in the Last.fm sidebar panel.
+- **On the command line**: `python autobiographer.py fetch lastfm`
+
+Both methods accept date-range flags (`--from-date`, `--to-date`) and a page limit (`--pages`) if you only want a partial history.
+
+## Setup
+
+### 1. Create a Last.fm API application
+
+Go to <https://www.last.fm/api/account/create> and register a new application (the name and description can be anything). You will receive an **API Key** and a **Shared Secret**.
+
+### 2. Set your credentials
+
+Create a `.env` file in the project root (copy `.env.example` as a starting point) and fill in your values:
+
+```env
+AUTOBIO_LASTFM_API_KEY=your_api_key_here
+AUTOBIO_LASTFM_API_SECRET=your_shared_secret_here
+AUTOBIO_LASTFM_USERNAME=your_lastfm_username
+```
+
+The app and CLI both load `.env` automatically on startup — you do not need to `export` these manually.
+
+### 3. Fetch your history
+
+Click **Fetch Latest Data** in the sidebar, or run:
+
+```bash
+python autobiographer.py fetch lastfm
+```
+
+A full history fetch can take several minutes depending on how many scrobbles you have. The progress bar in the sidebar shows which page is being downloaded.
+
+### 4. Point the plugin at the CSV
+
+After a fetch the **Last.fm CSV file** field is populated automatically. If you already have a CSV (e.g. from a previous fetch or a third-party export tool), click **…** to browse for it manually.
+
+## Data produced
+
+| Column | Description |
+|--------|-------------|
+| `timestamp` | Unix timestamp of the listen (UTC) |
+| `label` | Artist name |
+| `sublabel` | Track name |
+| `category` | Album name |
+| `source_id` | Always `"lastfm"` |
+
+Original columns (`artist`, `track`, `album`, `date_text`) are also preserved for backward compatibility.

--- a/plugins/sources/lastfm/loader.py
+++ b/plugins/sources/lastfm/loader.py
@@ -6,6 +6,7 @@ DataFrame to the "what-when" schema expected by the DataBroker.
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 import pandas as pd
@@ -18,13 +19,15 @@ from plugins.sources.base import SourcePlugin, validate_schema
 class LastFmPlugin(SourcePlugin):
     """Load Last.fm listening history from a local CSV file.
 
-    The CSV is produced by autobiographer.py's fetch + save pipeline.
+    The CSV is produced by the built-in fetch pipeline (run
+    ``python autobiographer.py fetch lastfm`` to download it).
     """
 
     PLUGIN_TYPE = "what-when"
     PLUGIN_ID = "lastfm"
     DISPLAY_NAME = "Last.fm Music History"
     ICON = ":material/headphones:"
+    FETCHABLE = True
 
     def get_config_fields(self) -> list[dict[str, Any]]:
         """Declare sidebar config fields for the Last.fm plugin.
@@ -77,6 +80,91 @@ class LastFmPlugin(SourcePlugin):
 
         validate_schema(df, self.PLUGIN_TYPE)
         return df
+
+    def get_fetch_env_vars(self) -> list[dict[str, str]]:
+        """Return env vars required to fetch Last.fm data.
+
+        Returns:
+            List of required env var descriptors.
+        """
+        return [
+            {"var": "AUTOBIO_LASTFM_API_KEY", "description": "Last.fm API key"},
+            {"var": "AUTOBIO_LASTFM_API_SECRET", "description": "Last.fm API secret"},
+            {"var": "AUTOBIO_LASTFM_USERNAME", "description": "Last.fm username"},
+        ]
+
+    def get_default_output_path(self) -> str | None:
+        """Return the default CSV save path based on the configured username.
+
+        Returns:
+            ``"data/lastfm_{username}_tracks.csv"``, or None if the username
+            env var is not set.
+        """
+        username = os.getenv("AUTOBIO_LASTFM_USERNAME", "").strip()
+        return f"data/lastfm_{username}_tracks.csv" if username else None
+
+    def get_fetch_identity(self) -> str | None:
+        """Return the configured Last.fm username as the fetch identity.
+
+        Returns:
+            ``"@username"`` if the env var is set, otherwise None.
+        """
+        username = os.getenv("AUTOBIO_LASTFM_USERNAME", "").strip()
+        return f"@{username}" if username else None
+
+    def fetch(self, output_path: str | None = None, **kwargs: Any) -> None:
+        """Fetch Last.fm listening history and save it to a local CSV file.
+
+        Reads credentials from env vars declared by ``get_fetch_env_vars()``.
+        Raises ``OSError`` with a descriptive message if any are missing.
+
+        Args:
+            output_path: Destination CSV path. Defaults to
+                ``data/lastfm_{username}_tracks.csv``.
+            **kwargs: Passed through to ``Autobiographer.fetch_recent_tracks()``.
+                Recognised keys: ``pages`` (int), ``from_ts`` (int), ``to_ts`` (int),
+                ``progress_callback`` (callable(page, total)).
+
+        Raises:
+            OSError: If required env vars are not set.
+        """
+        from autobiographer import Autobiographer
+
+        missing = [v for v in self.get_fetch_env_vars() if not os.getenv(v["var"])]
+        if missing:
+            lines = "\n".join(f"  {v['var']}: {v['description']}" for v in missing)
+            raise OSError(f"Missing required environment variables:\n{lines}")
+
+        api_key = os.getenv("AUTOBIO_LASTFM_API_KEY", "")
+        api_secret = os.getenv("AUTOBIO_LASTFM_API_SECRET", "")
+        username = os.getenv("AUTOBIO_LASTFM_USERNAME", "")
+
+        save_path = output_path or f"data/lastfm_{username}_tracks.csv"
+        client = Autobiographer(api_key, api_secret, username)
+        tracks = client.fetch_recent_tracks(
+            pages=kwargs.get("pages"),
+            from_ts=kwargs.get("from_ts"),
+            to_ts=kwargs.get("to_ts"),
+            progress_callback=kwargs.get("progress_callback"),
+        )
+        client.save_tracks_to_csv(tracks, filename=save_path)
+
+    def get_manual_download_instructions(self) -> str:
+        """Return instructions for fetching Last.fm data via the CLI.
+
+        Returns:
+            Multi-line instruction string.
+        """
+        return (
+            "Last.fm listening history can be fetched automatically.\n\n"
+            "1. Set your credentials as environment variables:\n"
+            "     AUTOBIO_LASTFM_API_KEY=<your key>\n"
+            "     AUTOBIO_LASTFM_API_SECRET=<your secret>\n"
+            "     AUTOBIO_LASTFM_USERNAME=<your username>\n\n"
+            "2. Run the fetch command:\n"
+            "     python autobiographer.py fetch lastfm\n\n"
+            "Get an API key at: https://www.last.fm/api/account/create"
+        )
 
     def get_schema(self) -> dict[str, str]:
         """Return column descriptions for the Last.fm plugin.

--- a/plugins/sources/swarm/README.md
+++ b/plugins/sources/swarm/README.md
@@ -1,0 +1,42 @@
+# Foursquare / Swarm Check-ins
+
+## What it is
+
+[Swarm](https://www.swarmapp.com) is Foursquare's check-in app. Every time you tap **Check In** at a venue — a restaurant, bar, airport, museum, gym, or anywhere else — Swarm records the place name, category, GPS coordinates, and timestamp. Over years of use this becomes a rich location diary: where you travelled, how often you visited your favourite places, and how your habits shifted over time.
+
+Autobiographer imports this history so you can map your check-ins, analyse travel patterns, and cross-reference locations against your music listening activity.
+
+## How the data is obtained
+
+Foursquare does not offer a public API for bulk check-in export, so **your data must be requested directly from Foursquare**. They provide a GDPR-compliant personal data export that includes your full check-in history as a set of JSON files.
+
+This is a one-time manual step. Once you have the export you can keep it on disk and re-point the plugin at it whenever needed — no repeat request is necessary unless you want to add newer check-ins.
+
+## Setup
+
+### 1. Request your data export from Foursquare
+
+1. Open the **Foursquare City Guide** app on your phone.
+2. Go to **Settings → Privacy → Request My Data**.
+3. Confirm the request. Foursquare will email you a download link within a few days.
+4. Download the archive from the link in the email.
+5. Unzip the archive to a location on your computer (e.g. `data/swarm_export/`).
+
+> **Note**: The export email comes from Foursquare, not from the Swarm app directly. Check your spam folder if it doesn't arrive within 48 hours.
+
+### 2. Point the plugin at the export directory
+
+In the Autobiographer sidebar, expand **Foursquare / Swarm Check-ins** and click **…** next to **Swarm JSON export directory**. Navigate to the unzipped folder and select it. The plugin reads all `.json` files in that directory.
+
+## Data produced
+
+| Column | Description |
+|--------|-------------|
+| `timestamp` | Unix timestamp of the check-in (UTC) |
+| `lat` | Latitude (WGS84) |
+| `lng` | Longitude (WGS84) |
+| `place_name` | Venue or location name |
+| `place_type` | Location category (e.g. `"venue"`, `"city"`) |
+| `source_id` | Always `"swarm"` |
+
+Additional columns from the raw export (`city`, `country`, `source`) are preserved alongside the normalized schema columns.

--- a/plugins/sources/swarm/loader.py
+++ b/plugins/sources/swarm/loader.py
@@ -36,12 +36,6 @@ class SwarmPlugin(SourcePlugin):
                 "label": "Swarm JSON export directory",
                 "type": "dir_path",
             },
-            {
-                "key": "assumptions_file",
-                "label": "Location assumptions JSON (optional)",
-                "type": "file_path",
-                "file_types": [("JSON files", "*.json"), ("All files", "*.*")],
-            },
         ]
 
     def load(self, config: dict[str, Any]) -> pd.DataFrame:
@@ -81,6 +75,23 @@ class SwarmPlugin(SourcePlugin):
 
         validate_schema(df, self.PLUGIN_TYPE)
         return df
+
+    def get_manual_download_instructions(self) -> str:
+        """Return instructions for requesting a Foursquare/Swarm data export.
+
+        Returns:
+            Multi-line instruction string.
+        """
+        return (
+            "Foursquare/Swarm does not offer a public API for bulk check-in export.\n\n"
+            "To request your data:\n"
+            "  1. Open the Foursquare City Guide app\n"
+            "  2. Go to Settings → Privacy → Request My Data\n"
+            "  3. Wait for the email from Foursquare with your download link\n"
+            "  4. Download and unzip the archive\n"
+            "  5. Point the 'Swarm JSON export directory' setting at the unzipped folder\n\n"
+            "See: https://support.foursquare.com/hc/en-us/articles/360046927274"
+        )
 
     def get_schema(self) -> dict[str, str]:
         """Return column descriptions for the Swarm plugin.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ skips = ["B101"]  # assert statements
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 addopts = [
     "--strict-markers",
     "--strict-config",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+python-dotenv
 requests
 pandas
 plotly

--- a/tests/test_autobiographer.py
+++ b/tests/test_autobiographer.py
@@ -97,53 +97,123 @@ class TestAutobiographer(unittest.TestCase):
         self.assertEqual(params.get("from"), 1610000000)
         self.assertEqual(params.get("to"), 1610000100)
 
-    @patch("autobiographer.Autobiographer.fetch_recent_tracks")
-    @patch("autobiographer.Autobiographer.save_tracks_to_csv")
-    @patch("os.getenv")
-    @patch("argparse.ArgumentParser.parse_args")
-    def test_main_with_to_date(self, mock_args, mock_getenv, mock_save, mock_fetch):
-        # Mock CLI arguments with a specific to_date
-        mock_args.return_value = MagicMock(
-            user="test_user", pages=None, from_date=None, to_date="2026-01-01"
+    def test_parse_date_valid(self):
+        from autobiographer import _parse_date
+
+        ts = _parse_date("2024-06-15", "from_date")
+        self.assertIsInstance(ts, int)
+        self.assertGreater(ts, 0)
+
+    def test_parse_date_empty_returns_none(self):
+        from autobiographer import _parse_date
+
+        self.assertIsNone(_parse_date("", "from_date"))
+
+    def test_parse_date_invalid_raises(self):
+        from autobiographer import _parse_date
+
+        with self.assertRaises(SystemExit):
+            _parse_date("not-a-date", "from_date")
+
+
+class TestRunFetch(unittest.TestCase):
+    """Tests for the _run_fetch CLI dispatcher."""
+
+    def _make_args(self, plugin: str, **kwargs: object) -> MagicMock:
+        args = MagicMock()
+        args.plugin = plugin
+        args.output = kwargs.get("output", None)
+        args.pages = kwargs.get("pages", None)
+        args.from_date = kwargs.get("from_date", None)
+        args.to_date = kwargs.get("to_date", None)
+        return args
+
+    def test_unknown_plugin_exits(self):
+        from autobiographer import _run_fetch
+
+        with patch("plugins.sources.load_builtin_plugins"), patch("plugins.sources.REGISTRY", {}):
+            with self.assertRaises(SystemExit):
+                _run_fetch(self._make_args("unknown_plugin"))
+
+    def test_non_fetchable_plugin_prints_instructions(self):
+        from autobiographer import _run_fetch
+
+        fake_plugin = MagicMock()
+        fake_plugin.FETCHABLE = False
+        fake_plugin.DISPLAY_NAME = "Test Plugin"
+        fake_plugin.get_manual_download_instructions.return_value = "Do this manually."
+        fake_cls = MagicMock(return_value=fake_plugin)
+
+        with (
+            patch("plugins.sources.load_builtin_plugins"),
+            patch("plugins.sources.REGISTRY", {"testplugin": fake_cls}),
+            patch("builtins.print") as mock_print,
+        ):
+            _run_fetch(self._make_args("testplugin"))
+
+        fake_plugin.get_manual_download_instructions.assert_called_once()
+        printed = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("Do this manually.", printed)
+
+    def test_missing_env_vars_exits(self):
+        from autobiographer import _run_fetch
+
+        fake_plugin = MagicMock()
+        fake_plugin.FETCHABLE = True
+        fake_plugin.get_fetch_env_vars.return_value = [
+            {"var": "AUTOBIO_MISSING_VAR", "description": "A required var"}
+        ]
+        fake_cls = MagicMock(return_value=fake_plugin)
+
+        with (
+            patch("plugins.sources.load_builtin_plugins"),
+            patch("plugins.sources.REGISTRY", {"myplugin": fake_cls}),
+            patch("os.getenv", return_value=None),
+        ):
+            with self.assertRaises(SystemExit):
+                _run_fetch(self._make_args("myplugin"))
+
+    def test_fetchable_plugin_calls_fetch(self):
+        from autobiographer import _run_fetch
+
+        fake_plugin = MagicMock()
+        fake_plugin.FETCHABLE = True
+        fake_plugin.get_fetch_env_vars.return_value = []
+        fake_cls = MagicMock(return_value=fake_plugin)
+
+        with (
+            patch("plugins.sources.load_builtin_plugins"),
+            patch("plugins.sources.REGISTRY", {"myplugin": fake_cls}),
+            patch("builtins.print"),
+        ):
+            _run_fetch(self._make_args("myplugin", output="/tmp/out.csv", pages=2))
+
+        fake_plugin.fetch.assert_called_once_with(
+            output_path="/tmp/out.csv",
+            pages=2,
+            from_ts=None,
+            to_ts=None,
         )
-        mock_getenv.side_effect = lambda k: {
-            "AUTOBIO_LASTFM_API_KEY": "key",
-            "AUTOBIO_LASTFM_API_SECRET": "secret",
-            "AUTOBIO_LASTFM_USERNAME": "test_user",
-        }.get(k)
 
-        from autobiographer import main
+    def test_to_date_shifted_to_end_of_day(self):
+        from autobiographer import _run_fetch
 
-        main()
+        fake_plugin = MagicMock()
+        fake_plugin.FETCHABLE = True
+        fake_plugin.get_fetch_env_vars.return_value = []
+        fake_cls = MagicMock(return_value=fake_plugin)
 
-        # Verify to_ts is end of day for 2026-01-01
-        # 2026-01-01 00:00:00 local timestamp + 86399
-        expected_to_struct = time.strptime("2026-01-01", "%Y-%m-%d")
-        expected_to_ts = int(time.mktime(expected_to_struct)) + 86399
+        with (
+            patch("plugins.sources.load_builtin_plugins"),
+            patch("plugins.sources.REGISTRY", {"myplugin": fake_cls}),
+            patch("builtins.print"),
+        ):
+            _run_fetch(self._make_args("myplugin", to_date="2026-01-01"))
 
-        mock_fetch.assert_called_with(pages=None, from_ts=None, to_ts=expected_to_ts)
-
-    @patch("autobiographer.Autobiographer.fetch_recent_tracks")
-    @patch("autobiographer.Autobiographer.save_tracks_to_csv")
-    @patch("os.getenv")
-    @patch("argparse.ArgumentParser.parse_args")
-    def test_main(self, mock_args, mock_getenv, mock_save, mock_fetch):
-        # Mock CLI arguments and env vars
-        mock_args.return_value = MagicMock(user="test_user", pages=1, from_date=None, to_date=None)
-        mock_getenv.side_effect = lambda k: {
-            "AUTOBIO_LASTFM_API_KEY": "key",
-            "AUTOBIO_LASTFM_API_SECRET": "secret",
-            "AUTOBIO_LASTFM_USERNAME": "user",
-        }.get(k)
-
-        mock_fetch.return_value = []
-
-        from autobiographer import main
-
-        main()
-
-        mock_fetch.assert_called_with(pages=1, from_ts=None, to_ts=None)
-        mock_save.assert_called_once()
+        _, call_kwargs = fake_plugin.fetch.call_args
+        to_ts = call_kwargs["to_ts"]
+        expected_base = int(time.mktime(time.strptime("2026-01-01", "%Y-%m-%d")))
+        self.assertEqual(to_ts, expected_base + 86399)
 
 
 if __name__ == "__main__":

--- a/tests/test_source_plugins.py
+++ b/tests/test_source_plugins.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 
 from plugins.sources import REGISTRY, load_builtin_plugins
+from plugins.sources.assumptions.loader import AssumptionsPlugin
 from plugins.sources.base import SourcePlugin, validate_schema
 from plugins.sources.lastfm.loader import LastFmPlugin
 from plugins.sources.swarm.loader import SwarmPlugin
@@ -65,6 +66,9 @@ class TestRegistry(unittest.TestCase):
 
     def test_swarm_registered(self):
         self.assertIn("swarm", REGISTRY)
+
+    def test_assumptions_registered(self):
+        self.assertIn("assumptions", REGISTRY)
 
     def test_registry_values_are_source_plugin_subclasses(self):
         for plugin_cls in REGISTRY.values():
@@ -177,12 +181,6 @@ class TestSwarmPlugin(unittest.TestCase):
         swarm_dir_field = next(f for f in fields if f["key"] == "swarm_dir")
         self.assertEqual(swarm_dir_field["type"], "dir_path")
 
-    def test_assumptions_field_type_is_file_path(self):
-        fields = self.plugin.get_config_fields()
-        assumptions_field = next(f for f in fields if f["key"] == "assumptions_file")
-        self.assertEqual(assumptions_field["type"], "file_path")
-        self.assertIn("file_types", assumptions_field)
-
     def test_load_adds_normalized_columns(self):
         with patch("analysis_utils.load_swarm_data") as mock_load:
             mock_load.return_value = self.fixture_df.copy()
@@ -207,6 +205,213 @@ class TestSwarmPlugin(unittest.TestCase):
         schema = self.plugin.get_schema()
         self.assertIsInstance(schema, dict)
         self.assertIn("lat", schema)
+
+
+class TestAssumptionsPlugin(unittest.TestCase):
+    """Tests for the AssumptionsPlugin."""
+
+    def setUp(self):
+        self.plugin = AssumptionsPlugin()
+        self.fixture_data = {
+            "defaults": {
+                "city": "London, GB",
+                "lat": 51.5074,
+                "lng": -0.1278,
+                "timezone": "Europe/London",
+            },
+            "trips": [
+                {
+                    "start": "2023-06-01",
+                    "end": "2023-06-07",
+                    "city": "Paris, FR",
+                    "lat": 48.8566,
+                    "lng": 2.3522,
+                    "timezone": "Europe/Paris",
+                }
+            ],
+            "holidays": [
+                {
+                    "name": "Christmas",
+                    "month": 12,
+                    "day_range": [24, 26],
+                    "city": "Edinburgh, GB",
+                    "lat": 55.9533,
+                    "lng": -3.1883,
+                    "timezone": "Europe/London",
+                }
+            ],
+            "residency": [
+                {
+                    "start": "2020-01-01",
+                    "end": "2025-12-31",
+                    "city": "Home",
+                    "sub_rules": [],
+                }
+            ],
+        }
+
+    def test_plugin_type(self):
+        self.assertEqual(self.plugin.PLUGIN_TYPE, "location-context")
+
+    def test_plugin_id(self):
+        self.assertEqual(self.plugin.PLUGIN_ID, "assumptions")
+
+    def test_config_fields_returns_list(self):
+        fields = self.plugin.get_config_fields()
+        self.assertIsInstance(fields, list)
+        self.assertTrue(any(f["key"] == "assumptions_file" for f in fields))
+
+    def test_config_field_type_is_file_path(self):
+        fields = self.plugin.get_config_fields()
+        field = next(f for f in fields if f["key"] == "assumptions_file")
+        self.assertEqual(field["type"], "file_path")
+        self.assertIn("file_types", field)
+
+    def test_load_returns_dataframe(self):
+        with patch("analysis_utils.load_assumptions") as mock_load:
+            mock_load.return_value = self.fixture_data
+            df = self.plugin.load({"assumptions_file": "fake/path.json"})
+        self.assertIsInstance(df, pd.DataFrame)
+
+    def test_load_includes_trip_row(self):
+        with patch("analysis_utils.load_assumptions") as mock_load:
+            mock_load.return_value = self.fixture_data
+            df = self.plugin.load({"assumptions_file": "fake/path.json"})
+        trips = df[df["type"] == "trip"]
+        self.assertEqual(len(trips), 1)
+        self.assertEqual(trips.iloc[0]["city"], "Paris, FR")
+
+    def test_load_includes_holiday_row(self):
+        with patch("analysis_utils.load_assumptions") as mock_load:
+            mock_load.return_value = self.fixture_data
+            df = self.plugin.load({"assumptions_file": "fake/path.json"})
+        holidays = df[df["type"] == "holiday"]
+        self.assertEqual(len(holidays), 1)
+        self.assertEqual(holidays.iloc[0]["city"], "Edinburgh, GB")
+
+    def test_load_includes_default_row(self):
+        with patch("analysis_utils.load_assumptions") as mock_load:
+            mock_load.return_value = self.fixture_data
+            df = self.plugin.load({"assumptions_file": "fake/path.json"})
+        defaults = df[df["type"] == "default"]
+        self.assertEqual(len(defaults), 1)
+        self.assertEqual(defaults.iloc[0]["city"], "London, GB")
+
+    def test_load_includes_residency_row(self):
+        with patch("analysis_utils.load_assumptions") as mock_load:
+            mock_load.return_value = self.fixture_data
+            df = self.plugin.load({"assumptions_file": "fake/path.json"})
+        residency = df[df["type"] == "residency"]
+        self.assertEqual(len(residency), 1)
+
+    def test_load_returns_empty_df_when_no_data(self):
+        with patch("analysis_utils.load_assumptions") as mock_load:
+            mock_load.return_value = {"defaults": {}, "trips": [], "holidays": [], "residency": []}
+            df = self.plugin.load({"assumptions_file": ""})
+        self.assertTrue(df.empty)
+
+    def test_get_schema_returns_dict(self):
+        schema = self.plugin.get_schema()
+        self.assertIsInstance(schema, dict)
+        self.assertIn("type", schema)
+        self.assertIn("city", schema)
+
+    def test_get_manual_download_instructions_mentions_example_file(self):
+        instructions = self.plugin.get_manual_download_instructions()
+        self.assertIn("default_assumptions.json.example", instructions)
+
+
+class TestFetchability(unittest.TestCase):
+    """Tests for FETCHABLE, get_fetch_env_vars, fetch, and get_manual_download_instructions."""
+
+    def setUp(self):
+        load_builtin_plugins()
+
+    # --- base class defaults --------------------------------------------------
+
+    def test_base_fetchable_is_false_by_default(self):
+        plugin = SwarmPlugin()
+        self.assertFalse(plugin.FETCHABLE)
+
+    def test_base_get_fetch_env_vars_returns_empty_list(self):
+        plugin = SwarmPlugin()
+        self.assertEqual(plugin.get_fetch_env_vars(), [])
+
+    def test_base_fetch_raises_not_implemented(self):
+        plugin = SwarmPlugin()
+        with self.assertRaises(NotImplementedError):
+            plugin.fetch()
+
+    def test_base_get_manual_download_instructions_returns_string(self):
+        plugin = SwarmPlugin()
+        instructions = plugin.get_manual_download_instructions()
+        self.assertIsInstance(instructions, str)
+        self.assertTrue(len(instructions) > 0)
+
+    # --- LastFmPlugin ---------------------------------------------------------
+
+    def test_lastfm_fetchable_is_true(self):
+        self.assertTrue(LastFmPlugin.FETCHABLE)
+
+    def test_lastfm_get_fetch_env_vars_lists_three_vars(self):
+        plugin = LastFmPlugin()
+        env_vars = plugin.get_fetch_env_vars()
+        var_names = [v["var"] for v in env_vars]
+        self.assertIn("AUTOBIO_LASTFM_API_KEY", var_names)
+        self.assertIn("AUTOBIO_LASTFM_API_SECRET", var_names)
+        self.assertIn("AUTOBIO_LASTFM_USERNAME", var_names)
+
+    def test_lastfm_fetch_env_var_dicts_have_description(self):
+        plugin = LastFmPlugin()
+        for entry in plugin.get_fetch_env_vars():
+            self.assertIn("var", entry)
+            self.assertIn("description", entry)
+            self.assertTrue(entry["description"])
+
+    def test_lastfm_fetch_raises_os_error_when_env_vars_missing(self):
+        plugin = LastFmPlugin()
+        with patch("os.getenv", return_value=None):
+            with self.assertRaises(OSError) as ctx:
+                plugin.fetch()
+        self.assertIn("AUTOBIO_LASTFM_API_KEY", str(ctx.exception))
+
+    def test_lastfm_fetch_calls_autobiographer_when_env_vars_set(self):
+        plugin = LastFmPlugin()
+        env = {
+            "AUTOBIO_LASTFM_API_KEY": "key",
+            "AUTOBIO_LASTFM_API_SECRET": "secret",
+            "AUTOBIO_LASTFM_USERNAME": "user",
+        }
+        mock_client = MagicMock()
+        mock_client.fetch_recent_tracks.return_value = []
+        with (
+            patch("os.getenv", side_effect=lambda k, default="": env.get(k, default)),
+            patch("autobiographer.Autobiographer", return_value=mock_client),
+        ):
+            plugin.fetch(output_path="/tmp/out.csv", pages=2)
+
+        mock_client.fetch_recent_tracks.assert_called_once_with(
+            pages=2, from_ts=None, to_ts=None, progress_callback=None
+        )
+        mock_client.save_tracks_to_csv.assert_called_once_with([], filename="/tmp/out.csv")
+
+    def test_lastfm_get_manual_download_instructions_mentions_command(self):
+        plugin = LastFmPlugin()
+        instructions = plugin.get_manual_download_instructions()
+        self.assertIn("autobiographer.py fetch lastfm", instructions)
+
+    # --- SwarmPlugin ----------------------------------------------------------
+
+    def test_swarm_get_manual_download_instructions_mentions_foursquare(self):
+        plugin = SwarmPlugin()
+        instructions = plugin.get_manual_download_instructions()
+        self.assertIn("Foursquare", instructions)
+
+    def test_swarm_get_manual_download_instructions_has_steps(self):
+        plugin = SwarmPlugin()
+        instructions = plugin.get_manual_download_instructions()
+        # Instructions should walk the user through numbered steps.
+        self.assertIn("1.", instructions)
 
 
 if __name__ == "__main__":

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -91,6 +91,113 @@ class TestPathInput(unittest.TestCase):
         self.assertIn("data_path", result)
 
 
+class TestSidebarExpansion(unittest.TestCase):
+    """Tests that plugin expanders auto-expand when a saved path no longer exists."""
+
+    def _make_sidebar_mocks(
+        self, mock_columns: MagicMock, mock_button: MagicMock
+    ) -> tuple[MagicMock, MagicMock]:
+        col1, col2 = MagicMock(), MagicMock()
+        mock_columns.return_value = [col1, col2]
+        mock_button.return_value = False
+        col2.button.return_value = False
+        return col1, col2
+
+    @patch("components.sidebar._TKINTER_AVAILABLE", True)
+    @patch("streamlit.columns")
+    @patch("streamlit.button", return_value=False)
+    @patch("streamlit.warning")
+    def test_expander_opens_and_warns_when_path_missing(
+        self, mock_warning: MagicMock, mock_button: MagicMock, mock_columns: MagicMock
+    ) -> None:
+        """When session state holds a nonexistent path, the expander is expanded and a warning shown."""
+        self._make_sidebar_mocks(mock_columns, mock_button)
+        expander_ctx = MagicMock()
+        expander_ctx.__enter__ = MagicMock(return_value=expander_ctx)
+        expander_ctx.__exit__ = MagicMock(return_value=False)
+
+        session = {"lastfm_data_path": "/nonexistent/tracks.csv"}
+        with (
+            patch("streamlit.session_state", session),
+            patch("components.sidebar._settings") as mock_settings,
+            patch("components.sidebar.REGISTRY", {"lastfm": MagicMock()}),
+            patch("components.sidebar.load_builtin_plugins"),
+            patch("components.sidebar._load_config_into_session_state"),
+            patch("streamlit.sidebar") as mock_sidebar,
+            patch("os.path.exists", return_value=False),
+        ):
+            mock_settings.get_all_plugin_configs.return_value = {}
+            plugin_instance = MagicMock()
+            plugin_instance.ICON = ":material/headphones:"
+            plugin_instance.DISPLAY_NAME = "Last.fm"
+            plugin_instance.get_config_fields.return_value = [
+                {"key": "data_path", "label": "CSV", "type": "file_path"}
+            ]
+            mock_sidebar.expander.return_value = expander_ctx
+            import components.sidebar as sidebar_mod
+
+            sidebar_mod.REGISTRY["lastfm"].return_value = plugin_instance
+
+            from components.sidebar import render_sidebar
+
+            render_sidebar()
+
+        # Expander must be called with expanded=True when path is missing
+        mock_sidebar.expander.assert_called_once()
+        _, kwargs = mock_sidebar.expander.call_args
+        self.assertTrue(kwargs.get("expanded"), "Expander should be expanded when path is missing")
+        mock_warning.assert_called_once()
+
+    @patch("components.sidebar._TKINTER_AVAILABLE", True)
+    @patch("streamlit.columns")
+    @patch("streamlit.button", return_value=False)
+    @patch("streamlit.warning")
+    def test_expander_collapsed_and_no_warning_when_path_exists(
+        self, mock_warning: MagicMock, mock_button: MagicMock, mock_columns: MagicMock
+    ) -> None:
+        """When session state holds an existing path, the expander is collapsed and no warning shown."""
+        self._make_sidebar_mocks(mock_columns, mock_button)
+        expander_ctx = MagicMock()
+        expander_ctx.__enter__ = MagicMock(return_value=expander_ctx)
+        expander_ctx.__exit__ = MagicMock(return_value=False)
+
+        session = {"lastfm_data_path": "/real/tracks.csv"}
+        with (
+            patch("streamlit.session_state", session),
+            patch("components.sidebar._settings") as mock_settings,
+            patch("components.sidebar.REGISTRY", {"lastfm": MagicMock()}),
+            patch("components.sidebar.load_builtin_plugins"),
+            patch("components.sidebar._load_config_into_session_state"),
+            patch("streamlit.sidebar") as mock_sidebar,
+            patch("components.sidebar.os.path.exists", return_value=True),
+            patch("components.sidebar.get_cache_key", return_value="key"),
+            patch("components.sidebar.get_cached_data", return_value=None),
+            patch("components.sidebar.load_assumptions", return_value={}),
+            patch("components.sidebar.load_listening_data", return_value=None),
+        ):
+            mock_settings.get_all_plugin_configs.return_value = {}
+            mock_sidebar.button.return_value = False
+            plugin_instance = MagicMock()
+            plugin_instance.ICON = ":material/headphones:"
+            plugin_instance.DISPLAY_NAME = "Last.fm"
+            plugin_instance.get_config_fields.return_value = [
+                {"key": "data_path", "label": "CSV", "type": "file_path"}
+            ]
+            mock_sidebar.expander.return_value = expander_ctx
+            import components.sidebar as sidebar_mod
+
+            sidebar_mod.REGISTRY["lastfm"].return_value = plugin_instance
+
+            from components.sidebar import render_sidebar
+
+            render_sidebar()
+
+        mock_sidebar.expander.assert_called_once()
+        _, kwargs = mock_sidebar.expander.call_args
+        self.assertFalse(kwargs.get("expanded"), "Expander should be collapsed when path exists")
+        mock_warning.assert_not_called()
+
+
 class TestConfigPersistence(unittest.TestCase):
     """Tests for LocalSettings-backed session state hydration."""
 

--- a/visualize.py
+++ b/visualize.py
@@ -12,6 +12,7 @@ Run with::
 from __future__ import annotations
 
 import streamlit as st
+from dotenv import load_dotenv
 
 from components.sidebar import render_sidebar
 from pages.beer import render_beer
@@ -21,6 +22,8 @@ from pages.insights import render_insights, render_insights_and_narrative  # noq
 from pages.music import render_music, render_timeline_analysis  # noqa: F401
 from pages.overview import render_overview, render_top_charts  # noqa: F401
 from pages.places import render_places, render_spatial_analysis  # noqa: F401
+
+load_dotenv()
 
 _SIDEBAR_CSS = """
 <style>


### PR DESCRIPTION
## Summary

- **Fetch CLI**: `python autobiographer.py fetch <plugin>` dispatches to the named plugin — fetchable plugins (Last.fm) download data; non-fetchable ones (Swarm) print step-by-step manual export instructions
- **python-dotenv**: `.env` is loaded automatically by both the CLI and Streamlit app; no more `export` in every terminal session — copy `.env.example`, fill in credentials, done
- **Live fetch progress**: sidebar Fetch Latest Data button now shows per-page progress in a sidebar-level placeholder that is always visible (previously it was inside the collapsed expander, so updates were invisible)
- **Fetch UX**: shows the configured username and save path before fetching; auto-populates the config field after a successful fetch
- **Missing path UX**: auto-expands a plugin's expander and shows a warning when the saved path no longer exists on disk
- **Location Assumptions plugin**: `AssumptionsPlugin` (`location-context` type) gives the assumptions JSON file its own sidebar section, config field, and plugin README — decoupled from the Swarm plugin
- **pytest pythonpath**: added `pythonpath = ["."]` to `pyproject.toml` so `pytest` works without setting `PYTHONPATH` manually
- **Plugin READMEs**: `plugins/sources/lastfm/README.md`, `plugins/sources/swarm/README.md`, `plugins/sources/assumptions/README.md` — each covers what the source is, how to get the data, and setup steps
- **Main README**: new Data Sources table links to all three plugin READMEs; project structure and plugin schema table updated

## Test plan

- [x] `pytest` passes (164 tests, 77% coverage)
- [x] `ruff check . && ruff format --check . && mypy` all clean
- [x] `python autobiographer.py fetch lastfm` downloads data when `.env` is set
- [x] `python autobiographer.py fetch swarm` prints manual export instructions
- [x] `python autobiographer.py fetch lastfm --pages 2` stops after 2 pages
- [x] Sidebar Fetch Latest Data button shows live page-by-page progress in the sidebar (not inside the collapsed expander)
- [x] After fetch, config field is auto-populated and path is saved to `local_settings.json`
- [x] Location Assumptions appears as its own sidebar panel, independent of Swarm
- [x] Plugin expander auto-expands with warning when a saved path no longer exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)