### PR TITLE
feat: Data Sources page with health dashboard and versioned fetch history

### DIFF
--- a/components/plugin_config.py
+++ b/components/plugin_config.py
@@ -82,8 +82,12 @@ def path_input(
         value = str(st.session_state.pop(pending_key))
         st.session_state[session_key] = value
         on_persist(value)
-    elif session_key not in st.session_state:
-        st.session_state[session_key] = default
+    elif not st.session_state.get(session_key):
+        # Restore from default (disk value) if absent or blank.  Blank can
+        # occur when Streamlit clears widget-bound keys on page navigation
+        # before load_config_into_session_state() has a chance to re-set them.
+        if default:
+            st.session_state[session_key] = default
 
     def _on_change() -> None:
         on_persist(str(st.session_state.get(session_key, "")))
@@ -142,9 +146,11 @@ def render_plugin_config_fields(plugin_id: str, fields: list[dict[str, Any]]) ->
         Dict mapping each field key to its current value.
     """
     config: dict[str, str] = {}
+    saved_cfg = settings.get_plugin_config(plugin_id)
     for field in fields:
         env_key = f"AUTOBIO_{plugin_id.upper()}_{field['key'].upper()}"
-        default = os.getenv(env_key, "")
+        # Env var overrides disk; disk value is the fallback over blank.
+        default = os.getenv(env_key, "") or saved_cfg.get(field["key"], "")
         is_dir = field.get("type") == "dir_path"
         field_key = field["key"]
 

--- a/components/plugin_config.py
+++ b/components/plugin_config.py
@@ -20,21 +20,18 @@ try:
 except Exception:
     _TKINTER_AVAILABLE = False
 
-_CONFIG_LOADED_KEY = "_autobio_config_loaded"
-
 # Module-level singleton — reads local_settings.json once on first import.
 settings = LocalSettings()
 
 
 def load_config_into_session_state() -> None:
-    """Hydrate session state from local_settings.json once per browser session.
+    """Hydrate session state from local_settings.json.
 
-    Only runs on the first script execution in a new browser session. Skips
-    non-string values (e.g. the ``fetch_history`` list) so they are never
-    written into session state.
+    Called on every page render. Only sets keys that are absent from session
+    state, so in-session widget edits are never overwritten. Running on every
+    render ensures config values are restored from disk when Streamlit clears
+    widget-bound session state keys during page navigation.
     """
-    if st.session_state.get(_CONFIG_LOADED_KEY):
-        return
     for plugin_id, plugin_cfg in settings.get_all_plugin_configs().items():
         for field_key, value in plugin_cfg.items():
             if not isinstance(value, str):
@@ -42,7 +39,6 @@ def load_config_into_session_state() -> None:
             session_key = f"{plugin_id}_{field_key}"
             if session_key not in st.session_state:
                 st.session_state[session_key] = value
-    st.session_state[_CONFIG_LOADED_KEY] = True
 
 
 def path_input(

--- a/components/plugin_config.py
+++ b/components/plugin_config.py
@@ -1,0 +1,186 @@
+"""Shared plugin configuration utilities used by both the sidebar and Data Sources page.
+
+Extracted from ``components/sidebar.py`` so the same path-input widgets and
+session-state hydration logic can be reused without duplication.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Callable
+
+import streamlit as st
+
+from core.local_settings import LocalSettings
+
+try:
+    import tkinter as _tk  # noqa: F401
+
+    _TKINTER_AVAILABLE = True
+except Exception:
+    _TKINTER_AVAILABLE = False
+
+_CONFIG_LOADED_KEY = "_autobio_config_loaded"
+
+# Module-level singleton — reads local_settings.json once on first import.
+settings = LocalSettings()
+
+
+def load_config_into_session_state() -> None:
+    """Hydrate session state from local_settings.json once per browser session.
+
+    Only runs on the first script execution in a new browser session. Skips
+    non-string values (e.g. the ``fetch_history`` list) so they are never
+    written into session state.
+    """
+    if st.session_state.get(_CONFIG_LOADED_KEY):
+        return
+    for plugin_id, plugin_cfg in settings.get_all_plugin_configs().items():
+        for field_key, value in plugin_cfg.items():
+            if not isinstance(value, str):
+                continue
+            session_key = f"{plugin_id}_{field_key}"
+            if session_key not in st.session_state:
+                st.session_state[session_key] = value
+    st.session_state[_CONFIG_LOADED_KEY] = True
+
+
+def path_input(
+    label: str,
+    session_key: str,
+    on_persist: Callable[[str], None],
+    default: str = "",
+    file_types: list[tuple[str, str]] | None = None,
+    is_dir: bool = False,
+) -> str:
+    """Render a path text input with a native browse button.
+
+    The browse button opens a tkinter file or directory dialog on the local
+    machine. This is valid because the Streamlit server is localhost for this
+    application.
+
+    Streamlit forbids writing to a session state key that is already bound to a
+    widget in the same script run. We work around this with a pending-key
+    pattern: the browse dialog stores its result under ``_pending_{session_key}``
+    and triggers a rerun. At the top of the *next* run this value is transferred
+    to the widget key before the widget is instantiated, which is always allowed.
+
+    Args:
+        label: Display label for the text input.
+        session_key: Session state key used to persist the path value.
+        on_persist: Callback invoked with the new path string whenever the value
+            changes; responsible for writing to ``local_settings.json``.
+        default: Default path value when neither session state nor the saved
+            config has an entry for this key.
+        file_types: List of (description, glob pattern) tuples for the file
+            dialog filter, e.g. ``[("CSV files", "*.csv")]``. Ignored when
+            ``is_dir`` is True.
+        is_dir: If True, open a directory picker; otherwise open a file picker.
+
+    Returns:
+        The current path string from session state.
+    """
+    pending_key = f"_pending_{session_key}"
+
+    if pending_key in st.session_state:
+        value = str(st.session_state.pop(pending_key))
+        st.session_state[session_key] = value
+        on_persist(value)
+    elif session_key not in st.session_state:
+        st.session_state[session_key] = default
+
+    def _on_change() -> None:
+        on_persist(str(st.session_state.get(session_key, "")))
+
+    if _TKINTER_AVAILABLE:
+        col1, col2 = st.columns([4, 1])
+        col1.text_input(label, key=session_key, on_change=_on_change)
+
+        if col2.button("...", key=f"browse_{session_key}", help="Browse for path"):
+            import threading
+
+            _result: list[str] = []
+
+            def _open_dialog() -> None:
+                import tkinter as tk
+                from tkinter import filedialog
+
+                root = tk.Tk()
+                root.withdraw()
+                try:
+                    root.wm_attributes("-topmost", 1)
+                except Exception:  # noqa: S110 — not available on all platforms
+                    pass
+                if is_dir:
+                    path = filedialog.askdirectory(title=label)
+                else:
+                    path = filedialog.askopenfilename(
+                        title=label,
+                        filetypes=file_types or [("All files", "*.*")],
+                    )
+                root.destroy()
+                if path:
+                    _result.append(path)
+
+            t = threading.Thread(target=_open_dialog, daemon=True)
+            t.start()
+            t.join()
+
+            if _result:
+                st.session_state[pending_key] = _result[0]
+                st.rerun()
+    else:
+        st.text_input(label, key=session_key, on_change=_on_change)
+
+    return str(st.session_state.get(session_key, default))
+
+
+def render_plugin_config_fields(plugin_id: str, fields: list[dict[str, Any]]) -> dict[str, str]:
+    """Render config fields for one plugin and return collected values.
+
+    Args:
+        plugin_id: The plugin's PLUGIN_ID, used to namespace session state keys.
+        fields: Field descriptor list from ``plugin.get_config_fields()``.
+
+    Returns:
+        Dict mapping each field key to its current value.
+    """
+    config: dict[str, str] = {}
+    for field in fields:
+        env_key = f"AUTOBIO_{plugin_id.upper()}_{field['key'].upper()}"
+        default = os.getenv(env_key, "")
+        is_dir = field.get("type") == "dir_path"
+        field_key = field["key"]
+
+        def _make_persist(fk: str = field_key) -> Callable[[str], None]:
+            def _persist(path: str) -> None:
+                settings.set_plugin_value(plugin_id, fk, path)
+
+            return _persist
+
+        value = path_input(
+            label=field["label"],
+            session_key=f"{plugin_id}_{field['key']}",
+            on_persist=_make_persist(),
+            default=default,
+            file_types=field.get("file_types"),
+            is_dir=is_dir,
+        )
+        config[field["key"]] = value
+    return config
+
+
+def get_plugin_config_from_session(plugin_id: str, fields: list[dict[str, Any]]) -> dict[str, str]:
+    """Read current config values from session state without rendering any widgets.
+
+    Args:
+        plugin_id: The plugin's PLUGIN_ID.
+        fields: Field descriptor list from ``plugin.get_config_fields()``.
+
+    Returns:
+        Dict mapping each field key to its current session state value.
+    """
+    return {
+        field["key"]: str(st.session_state.get(f"{plugin_id}_{field['key']}", ""))
+        for field in fields
+    }

--- a/components/plugin_config.py
+++ b/components/plugin_config.py
@@ -82,12 +82,8 @@ def path_input(
         value = str(st.session_state.pop(pending_key))
         st.session_state[session_key] = value
         on_persist(value)
-    elif not st.session_state.get(session_key):
-        # Restore from default (disk value) if absent or blank.  Blank can
-        # occur when Streamlit clears widget-bound keys on page navigation
-        # before load_config_into_session_state() has a chance to re-set them.
-        if default:
-            st.session_state[session_key] = default
+    elif session_key not in st.session_state:
+        st.session_state[session_key] = default
 
     def _on_change() -> None:
         on_persist(str(st.session_state.get(session_key, "")))

--- a/components/sidebar.py
+++ b/components/sidebar.py
@@ -1,8 +1,10 @@
-"""Shared sidebar component — shows plugin health badges and loads data.
+"""Shared sidebar component — silently loads data and provides the global date filter.
 
-Plugin configuration and fetch controls have moved to the Data Sources page
-(``pages/data_sources.py``). The sidebar now shows a compact health indicator
-per plugin and handles data loading into ``st.session_state["df"]``.
+Plugin health badges and cache management have moved to the Data Sources pages.
+This module's only responsibilities are:
+  1. Hydrate session state from disk.
+  2. Load and process the active dataset into ``st.session_state["df"]``.
+  3. Expose the global date-range filter.
 """
 
 from __future__ import annotations
@@ -24,47 +26,26 @@ from analysis_utils import (
 from components.plugin_config import (
     get_plugin_config_from_session,
     load_config_into_session_state,
-    settings,
 )
 from plugins.sources import REGISTRY, load_builtin_plugins
 
-_HEALTH_BADGES: dict[str, str] = {
-    "healthy": "✅",
-    "stale": "⚠️",
-    "error": "❌",
-    "unconfigured": "◻️",
-}
-
 
 def render_sidebar() -> None:
-    """Render the sidebar health indicators and populate ``st.session_state['df']``.
+    """Hydrate config, load the dataset, and render the global date filter.
 
-    Loads persisted path config from disk, renders a one-line health badge per
-    source plugin, then loads Last.fm + Swarm data (with local caching), applies
-    location assumptions, and stores the resulting DataFrame under
-    ``st.session_state['df']`` so every page can access it.
+    Populates ``st.session_state["df"]`` with the processed DataFrame (or None
+    if no Last.fm file is configured).  Stores ``st.session_state["_cache_status"]``
+    as ``"hit"`` or ``"miss"`` for the Cache Management tab on the Data Sources page.
     """
     load_builtin_plugins()
     load_config_into_session_state()
 
-    st.sidebar.markdown(
-        '<p class="autobio-section-header">Data Sources</p>', unsafe_allow_html=True
-    )
-
     configs: dict[str, dict[str, str]] = {}
-
     for plugin_id, plugin_cls in REGISTRY.items():
         plugin = plugin_cls()
         fields = plugin.get_config_fields()
-        config = get_plugin_config_from_session(plugin_id, fields)
-        configs[plugin_id] = config
+        configs[plugin_id] = get_plugin_config_from_session(plugin_id, fields)
 
-        history = settings.get_fetch_history(plugin_id)
-        health = plugin.get_health_status(config, history)
-        badge = _HEALTH_BADGES.get(health["status"], "◻️")
-        st.sidebar.markdown(f"{plugin.DISPLAY_NAME}&nbsp;&nbsp;{badge}")
-
-    # --- Data loading ---------------------------------------------------------
     lastfm_cfg = configs.get("lastfm", {})
     swarm_cfg = configs.get("swarm", {})
     assumptions_cfg = configs.get("assumptions", {})
@@ -74,50 +55,28 @@ def render_sidebar() -> None:
     assumptions_path: str = assumptions_cfg.get("assumptions_file", "default_assumptions.json")
 
     if not file_path or not os.path.exists(file_path):
-        if file_path:
-            st.sidebar.error(f"File not found: '{file_path}'")
         st.session_state["df"] = None
         return
 
     assumptions = load_assumptions(assumptions_path)
 
-    st.sidebar.markdown(
-        '<p class="autobio-section-header">Cache Management</p>', unsafe_allow_html=True
-    )
     cache_key = get_cache_key(file_path, swarm_dir, assumptions_path)
     df: pd.DataFrame | None = get_cached_data(cache_key)
 
     if df is None:
+        st.session_state["_cache_status"] = "miss"
         df = load_listening_data(file_path)
         if df is not None:
-            with st.spinner("Adjusting timezones and geocoding..."):
+            with st.spinner("Adjusting timezones and geocoding…"):
                 swarm_df = (
                     load_swarm_data(swarm_dir)
                     if swarm_dir and os.path.exists(swarm_dir)
                     else pd.DataFrame()
                 )
                 df = apply_swarm_offsets(df, swarm_df, assumptions)
-
-                if not swarm_df.empty:
-                    st.sidebar.success(f"Applied offsets from {len(swarm_df)} checkins.")
-                elif os.path.exists(assumptions_path):
-                    st.sidebar.info("Applied location assumptions from file.")
-                else:
-                    st.sidebar.warning("No Swarm data or assumptions found; using default.")
-
             save_to_cache(df, cache_key)
-            st.sidebar.info("Data processed and cached locally.")
     else:
-        st.sidebar.success("Loaded from local cache.")
-
-    if st.sidebar.button("Clear Local Cache"):
-        cache_dir = "data/cache"
-        if os.path.exists(cache_dir):
-            import shutil
-
-            shutil.rmtree(cache_dir)
-            st.sidebar.success("Cache cleared!")
-            st.rerun()
+        st.session_state["_cache_status"] = "hit"
 
     if df is not None:
         st.sidebar.markdown(

--- a/components/sidebar.py
+++ b/components/sidebar.py
@@ -1,18 +1,13 @@
-"""Shared sidebar component for data source configuration and loading.
+"""Shared sidebar component — shows plugin health badges and loads data.
 
-Iterates over the registered source plugins, renders a file-path selector for
-each declared config field, then loads the active DataFrame into
-``st.session_state["df"]`` so every page can access it without reloading.
-
-Path selections are persisted to ``local_settings.json`` (gitignored) via
-:class:`~core.local_settings.LocalSettings` so they survive application
-restarts and do not need to be re-entered each session.
+Plugin configuration and fetch controls have moved to the Data Sources page
+(``pages/data_sources.py``). The sidebar now shows a compact health indicator
+per plugin and handles data loading into ``st.session_state["df"]``.
 """
 
 from __future__ import annotations
 
 import os
-from typing import Any, Callable
 
 import pandas as pd
 import streamlit as st
@@ -26,336 +21,48 @@ from analysis_utils import (
     load_swarm_data,
     save_to_cache,
 )
-from core.local_settings import LocalSettings
+from components.plugin_config import (
+    get_plugin_config_from_session,
+    load_config_into_session_state,
+    settings,
+)
 from plugins.sources import REGISTRY, load_builtin_plugins
 
-# Detect tkinter availability at import time so the browse button is only
-# shown in environments where a display is available (e.g. not in CI).
-try:
-    import tkinter as _tk  # noqa: F401
-
-    _TKINTER_AVAILABLE = True
-except Exception:
-    _TKINTER_AVAILABLE = False
-
-_CONFIG_LOADED_KEY = "_autobio_config_loaded"
-
-# Module-level singleton — reads local_settings.json once on first import.
-_settings = LocalSettings()
-
-
-def _load_config_into_session_state() -> None:
-    """Hydrate session state from local_settings.json (once per browser session).
-
-    Only runs on the first script execution in a new browser session. Existing
-    session state keys are not overwritten so that in-session changes take
-    precedence over the saved config.
-    """
-    if st.session_state.get(_CONFIG_LOADED_KEY):
-        return
-    for plugin_id, plugin_cfg in _settings.get_all_plugin_configs().items():
-        for field_key, value in plugin_cfg.items():
-            session_key = f"{plugin_id}_{field_key}"
-            if session_key not in st.session_state:
-                st.session_state[session_key] = value
-    st.session_state[_CONFIG_LOADED_KEY] = True
-
-
-def _path_input(
-    label: str,
-    session_key: str,
-    on_persist: Callable[[str], None],
-    default: str = "",
-    file_types: list[tuple[str, str]] | None = None,
-    is_dir: bool = False,
-) -> str:
-    """Render a path text input with a native browse button.
-
-    The browse button opens a tkinter file or directory dialog on the local
-    machine. This is valid because the Streamlit server is localhost for this
-    application.
-
-    Streamlit forbids writing to a session state key that is already bound to a
-    widget in the same script run. We work around this with a pending-key
-    pattern: the browse dialog stores its result under ``_pending_{session_key}``
-    and triggers a rerun. At the top of the *next* run this value is transferred
-    to the widget key before the widget is instantiated, which is always allowed.
-
-    Any path selected via the dialog or typed into the text input is passed to
-    ``on_persist`` so it can be saved to ``local_settings.json``.
-
-    Args:
-        label: Display label for the text input.
-        session_key: Session state key used to persist the path value.
-        on_persist: Callback invoked with the new path string whenever the value
-            changes; responsible for writing to ``local_settings.json``.
-        default: Default path value when neither session state nor the saved
-            config has an entry for this key.
-        file_types: List of (description, glob pattern) tuples for the file
-            dialog filter, e.g. ``[("CSV files", "*.csv")]``. Ignored when
-            ``is_dir`` is True.
-        is_dir: If True, open a directory picker; otherwise open a file picker.
-
-    Returns:
-        The current path string from session state.
-    """
-    pending_key = f"_pending_{session_key}"
-
-    # Transfer any pending value from a previous browse action BEFORE the
-    # widget is instantiated so Streamlit allows the assignment.
-    if pending_key in st.session_state:
-        value = str(st.session_state.pop(pending_key))
-        st.session_state[session_key] = value
-        on_persist(value)
-    elif session_key not in st.session_state:
-        st.session_state[session_key] = default
-
-    def _on_change() -> None:
-        on_persist(str(st.session_state.get(session_key, "")))
-
-    if _TKINTER_AVAILABLE:
-        # Use st.columns / st.text_input (not st.sidebar.*) so widgets render
-        # inside whatever container is currently active — critically, inside the
-        # expander when called from _render_plugin_config.
-        col1, col2 = st.columns([4, 1])
-        col1.text_input(label, key=session_key, on_change=_on_change)
-
-        if col2.button("...", key=f"browse_{session_key}", help="Browse for path"):
-            import threading
-
-            # Streamlit's script runner executes on a background thread.
-            # Tkinter requires its event loop to be owned by the thread that
-            # creates the Tk() root, and on Windows it cannot share the main
-            # thread's message loop. Spawning a dedicated thread for each
-            # dialog call avoids the "main thread is not in main loop" error.
-            _result: list[str] = []
-
-            def _open_dialog() -> None:
-                import tkinter as tk
-                from tkinter import filedialog
-
-                root = tk.Tk()
-                root.withdraw()
-                try:
-                    root.wm_attributes("-topmost", 1)
-                except Exception:  # noqa: S110 — not available on all platforms
-                    pass
-                if is_dir:
-                    path = filedialog.askdirectory(title=label)
-                else:
-                    path = filedialog.askopenfilename(
-                        title=label,
-                        filetypes=file_types or [("All files", "*.*")],
-                    )
-                root.destroy()
-                if path:
-                    _result.append(path)
-
-            t = threading.Thread(target=_open_dialog, daemon=True)
-            t.start()
-            t.join()
-
-            # Store under pending_key, not session_key — the widget bound to
-            # session_key has already been instantiated this run.
-            if _result:
-                st.session_state[pending_key] = _result[0]
-                st.rerun()
-    else:
-        st.text_input(label, key=session_key, on_change=_on_change)
-
-    return str(st.session_state.get(session_key, default))
-
-
-def _render_plugin_fetch_section(
-    plugin: Any, config: dict[str, str]
-) -> tuple[bool, str | None, str]:
-    """Render a fetch button or manual-download guidance inside a plugin expander.
-
-    For fetchable plugins (``FETCHABLE`` is True): shows required env vars that
-    are unset, or a "Fetch Latest Data" button if all env vars are present.
-
-    For non-fetchable plugins: shows manual download instructions when no data
-    path has been configured yet.
-
-    The actual fetch is intentionally NOT executed here. This function only
-    renders the button and returns whether it was clicked and where to save the
-    result. The caller runs the fetch *after* all expanders are closed so that
-    progress updates appear in a sidebar-level placeholder that is always
-    visible (widgets inside a collapsed expander are invisible).
-
-    Args:
-        plugin: Instantiated SourcePlugin.
-        config: Current config values returned by ``_render_plugin_config``.
-
-    Returns:
-        Tuple of (fetch_triggered, output_path, primary_key) where
-        ``fetch_triggered`` is True when the user clicked "Fetch Latest Data",
-        ``output_path`` is the resolved destination path (or empty string), and
-        ``primary_key`` is the config field key for the primary path so the
-        caller can auto-populate session state after a successful fetch.
-    """
-    from plugins.sources.base import SourcePlugin
-
-    if not isinstance(plugin, SourcePlugin):
-        return False, None, ""
-
-    st.markdown("---")
-
-    if plugin.FETCHABLE:
-        env_vars = plugin.get_fetch_env_vars()
-        missing_vars = [v for v in env_vars if not os.getenv(v["var"])]
-
-        if missing_vars:
-            st.caption("**Auto-fetch** requires these env vars:")
-            for v in missing_vars:
-                st.code(f'{v["var"]}="…"', language="bash")
-                st.caption(v["description"])
-            return False, None, ""
-
-        # Show which account is configured so the user can confirm before fetching.
-        identity = plugin.get_fetch_identity()
-        if identity:
-            st.caption(f"Fetching as **{identity}**")
-
-        # Resolve the save path: prefer the already-configured primary
-        # field value; fall back to the plugin's default output path.
-        primary_key = next(iter(config.keys()), "") if config else ""
-        primary_value = next(iter(config.values()), "") if config else ""
-        output_path = primary_value.strip() or plugin.get_default_output_path() or None
-
-        if output_path:
-            st.caption(f"Saves to `{output_path}`")
-
-        triggered = st.button(
-            "Fetch Latest Data",
-            key=f"fetch_{plugin.PLUGIN_ID}",
-            help=f"Download {plugin.DISPLAY_NAME} data now",
-        )
-        return triggered, output_path, primary_key
-    else:
-        # Only surface instructions when data isn't configured yet — no need to
-        # clutter the expander for users who already have their data loaded.
-        primary_value = next(iter(config.values()), "") if config else ""
-        if not primary_value.strip() or not os.path.exists(primary_value.strip()):
-            st.info(plugin.get_manual_download_instructions())
-        return False, None, ""
-
-
-def _render_plugin_config(plugin_id: str, fields: list[dict[str, Any]]) -> dict[str, str]:
-    """Render sidebar config fields for one plugin and return collected values.
-
-    Args:
-        plugin_id: The plugin's PLUGIN_ID, used to namespace session state keys.
-        fields: Field descriptor list from ``plugin.get_config_fields()``.
-
-    Returns:
-        Dict mapping each field key to its current path value.
-    """
-    config: dict[str, str] = {}
-    for field in fields:
-        env_key = f"AUTOBIO_{plugin_id.upper()}_{field['key'].upper()}"
-        default = os.getenv(env_key, "")
-        is_dir = field.get("type") == "dir_path"
-        field_key = field["key"]
-
-        def _make_persist(fk: str = field_key) -> Callable[[str], None]:
-            def _persist(path: str) -> None:
-                _settings.set_plugin_value(plugin_id, fk, path)
-
-            return _persist
-
-        value = _path_input(
-            label=field["label"],
-            session_key=f"{plugin_id}_{field['key']}",
-            on_persist=_make_persist(),
-            default=default,
-            file_types=field.get("file_types"),
-            is_dir=is_dir,
-        )
-        config[field["key"]] = value
-    return config
+_HEALTH_BADGES: dict[str, str] = {
+    "healthy": "✅",
+    "stale": "⚠️",
+    "error": "❌",
+    "unconfigured": "◻️",
+}
 
 
 def render_sidebar() -> None:
-    """Render the data-source sidebar and populate ``st.session_state['df']``.
+    """Render the sidebar health indicators and populate ``st.session_state['df']``.
 
-    Loads persisted path config from disk, loads the plugin registry, renders a
-    labelled file-path selector for every config field declared by each plugin,
-    then loads Last.fm + Swarm data (with local caching), applies location
-    assumptions, and stores the resulting DataFrame under
-    ``st.session_state['df']``.
+    Loads persisted path config from disk, renders a one-line health badge per
+    source plugin, then loads Last.fm + Swarm data (with local caching), applies
+    location assumptions, and stores the resulting DataFrame under
+    ``st.session_state['df']`` so every page can access it.
     """
     load_builtin_plugins()
-    _load_config_into_session_state()
+    load_config_into_session_state()
 
     st.sidebar.markdown(
         '<p class="autobio-section-header">Data Sources</p>', unsafe_allow_html=True
     )
 
     configs: dict[str, dict[str, str]] = {}
-    # Collect any fetch requests from the expanders so they can be executed
-    # after all expanders are rendered. Widgets inside a collapsed expander are
-    # invisible; running the fetch outside ensures progress updates are shown.
-    pending_fetches: list[tuple[Any, str, str | None, str]] = []
 
     for plugin_id, plugin_cls in REGISTRY.items():
         plugin = plugin_cls()
         fields = plugin.get_config_fields()
+        config = get_plugin_config_from_session(plugin_id, fields)
+        configs[plugin_id] = config
 
-        # Auto-expand the section when the primary path is not yet configured
-        # so first-time users immediately see they need to fill it in.
-        # Also auto-expand when the saved path no longer exists on disk so
-        # users can immediately browse for a replacement.
-        primary_key = f"{plugin_id}_{fields[0]['key']}" if fields else ""
-        primary_value = st.session_state.get(primary_key, "").strip()
-        primary_type = fields[0].get("type", "text") if fields else "text"
-        primary_path_missing = (
-            bool(primary_value)
-            and primary_type in ("file_path", "dir_path")
-            and not os.path.exists(primary_value)
-        )
-        is_configured = bool(primary_value) and not primary_path_missing
-
-        with st.sidebar.expander(
-            f"{plugin.ICON}  {plugin.DISPLAY_NAME}", expanded=not is_configured
-        ):
-            if primary_path_missing:
-                st.warning("Path no longer found — please select a new location.")
-            configs[plugin_id] = _render_plugin_config(plugin_id, fields)
-            triggered, output_path, cfg_key = _render_plugin_fetch_section(
-                plugin, configs[plugin_id]
-            )
-            if triggered:
-                pending_fetches.append((plugin, plugin_id, output_path, cfg_key))
-
-    # Execute any pending fetches with a sidebar-level status placeholder that
-    # is always visible regardless of expander collapsed/expanded state.
-    if pending_fetches:
-        fetch_status = st.sidebar.empty()
-        for plugin, plugin_id, output_path, cfg_key in pending_fetches:
-            primary_value = configs.get(plugin_id, {}).get(cfg_key, "")
-            fetch_status.info(f"Starting fetch for {plugin.DISPLAY_NAME}…")
-
-            def _on_progress(page: int, total: int, _status: Any = fetch_status) -> None:
-                _status.info(f"Fetching page {page} of {total}…")
-
-            try:
-                plugin.fetch(
-                    output_path=output_path,
-                    progress_callback=_on_progress,
-                )
-                # Auto-populate the config field so the user doesn't need
-                # to manually enter the path after a successful fetch.
-                if output_path and cfg_key and not primary_value.strip():
-                    session_key = f"{plugin_id}_{cfg_key}"
-                    st.session_state[session_key] = output_path
-                    _settings.set_plugin_value(plugin_id, cfg_key, output_path)
-                fetch_status.success(
-                    f"Done — data saved to `{output_path}`. "
-                    "Reload the page to see the updated data."
-                )
-            except Exception as exc:  # noqa: BLE001
-                fetch_status.error(f"Fetch failed: {exc}")
+        history = settings.get_fetch_history(plugin_id)
+        health = plugin.get_health_status(config, history)
+        badge = _HEALTH_BADGES.get(health["status"], "◻️")
+        st.sidebar.markdown(f"{plugin.DISPLAY_NAME}&nbsp;&nbsp;{badge}")
 
     # --- Data loading ---------------------------------------------------------
     lastfm_cfg = configs.get("lastfm", {})

--- a/core/local_settings.py
+++ b/core/local_settings.py
@@ -101,6 +101,43 @@ class LocalSettings:
         plugin_cfg[field_key] = value
         self._save()
 
+    # ── Fetch history helpers ─────────────────────────────────────────────────
+
+    _MAX_HISTORY = 20
+
+    def add_fetch_history(
+        self, plugin_id: str, timestamp: str, record_count: int, file_path: str
+    ) -> None:
+        """Prepend a fetch record to the plugin's history list.
+
+        Keeps at most ``_MAX_HISTORY`` entries, newest first.
+
+        Args:
+            plugin_id: Plugin identifier (e.g. ``"lastfm"``).
+            timestamp: ISO-format timestamp string for the fetch.
+            record_count: Number of records in the fetched file.
+            file_path: Path where the versioned snapshot was saved.
+        """
+        plugins: dict[str, Any] = self._data.setdefault("plugins", {})
+        plugin_cfg: dict[str, Any] = plugins.setdefault(plugin_id, {})
+        history: list[dict[str, Any]] = plugin_cfg.setdefault("fetch_history", [])
+        entry = {"timestamp": timestamp, "record_count": record_count, "file_path": file_path}
+        history.insert(0, entry)
+        plugin_cfg["fetch_history"] = history[: self._MAX_HISTORY]
+        self._save()
+
+    def get_fetch_history(self, plugin_id: str) -> list[dict[str, Any]]:
+        """Return the fetch history list for a plugin, newest first.
+
+        Args:
+            plugin_id: Plugin identifier (e.g. ``"lastfm"``).
+
+        Returns:
+            List of ``{timestamp, record_count, file_path}`` dicts. Empty if none.
+        """
+        raw = self.get_plugin_config(plugin_id).get("fetch_history", [])
+        return raw if isinstance(raw, list) else []
+
     # ── General key/value helpers ─────────────────────────────────────────────
 
     def get(self, key: str, default: Any = None) -> Any:

--- a/pages/data_sources.py
+++ b/pages/data_sources.py
@@ -18,6 +18,7 @@ from components.plugin_config import (
     settings,
 )
 from plugins.sources import REGISTRY, load_builtin_plugins
+from plugins.sources.base import _count_records_at_path
 
 _STATUS_META: dict[str, tuple[str, str]] = {
     "healthy": ("✅", "Healthy"),
@@ -25,23 +26,6 @@ _STATUS_META: dict[str, tuple[str, str]] = {
     "error": ("❌", "Error"),
     "unconfigured": ("◻️", "Not configured"),
 }
-
-
-def _count_records(file_path: str) -> int | None:
-    """Return the number of data rows in a CSV or top-level items in a JSON list."""
-    try:
-        ext = os.path.splitext(file_path)[1].lower()
-        if ext == ".csv":
-            import pandas as pd
-
-            return len(pd.read_csv(file_path))
-        import json
-
-        with open(file_path) as f:
-            data = json.load(f)
-        return len(data) if isinstance(data, list) else None
-    except Exception:  # noqa: BLE001
-        return None
 
 
 def _render_plugin_tab(plugin_id: str, plugin: Any) -> dict[str, Any]:
@@ -138,7 +122,7 @@ def _render_plugin_tab(plugin_id: str, plugin: Any) -> dict[str, Any]:
                 os.makedirs(parent, exist_ok=True)
             plugin.fetch(output_path=versioned_path, progress_callback=_on_progress)
 
-            record_count = _count_records(versioned_path) or 0
+            record_count = _count_records_at_path(versioned_path) or 0
             ts = datetime.now(tz=timezone.utc).isoformat()
             settings.add_fetch_history(plugin_id, ts, record_count, versioned_path)
 

--- a/pages/data_sources.py
+++ b/pages/data_sources.py
@@ -1,0 +1,209 @@
+"""Data Sources management page.
+
+Provides a full-screen tabbed interface for each source plugin: health status,
+configuration, fetch controls with progress output, and versioned fetch history.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import streamlit as st
+
+from components.plugin_config import (
+    get_plugin_config_from_session,
+    load_config_into_session_state,
+    render_plugin_config_fields,
+    settings,
+)
+from plugins.sources import REGISTRY, load_builtin_plugins
+
+_STATUS_META: dict[str, tuple[str, str]] = {
+    "healthy": ("✅", "Healthy"),
+    "stale": ("⚠️", "Stale"),
+    "error": ("❌", "Error"),
+    "unconfigured": ("◻️", "Not configured"),
+}
+
+
+def _count_records(file_path: str) -> int | None:
+    """Return the number of data rows in a CSV or top-level items in a JSON list."""
+    try:
+        ext = os.path.splitext(file_path)[1].lower()
+        if ext == ".csv":
+            import pandas as pd
+
+            return len(pd.read_csv(file_path))
+        import json
+
+        with open(file_path) as f:
+            data = json.load(f)
+        return len(data) if isinstance(data, list) else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _render_plugin_tab(plugin_id: str, plugin: Any, health: dict[str, Any]) -> None:
+    """Render the full management UI for one plugin inside its tab.
+
+    Args:
+        plugin_id: Plugin identifier string.
+        plugin: Instantiated SourcePlugin.
+        health: Health dict from ``plugin.get_health_status()``.
+    """
+    icon, label = _STATUS_META.get(health["status"], ("◻️", health["status"]))
+
+    # ── Status ──────────────────────────────────────────────────────────────
+    st.subheader("Status")
+    c1, c2, c3 = st.columns(3)
+    c1.metric("Health", f"{icon} {label}")
+    rc = health["record_count"]
+    c2.metric("Records", f"{rc:,}" if isinstance(rc, int) else "—")
+    last = health.get("last_fetch") or ""
+    c3.metric("Last Fetch", last[:10] if last else "—")
+
+    st.divider()
+
+    # ── Configuration ────────────────────────────────────────────────────────
+    st.subheader("Configuration")
+    fields = plugin.get_config_fields()
+    config = render_plugin_config_fields(plugin_id, fields)
+
+    primary_path_missing = False
+    if fields:
+        primary_val = config.get(fields[0]["key"], "").strip()
+        primary_type = fields[0].get("type", "text")
+        is_path_field = primary_type in ("file_path", "dir_path")
+        if primary_val and is_path_field and not os.path.exists(primary_val):
+            st.warning("Configured path no longer exists — please select a new location.")
+            primary_path_missing = True
+
+    st.divider()
+
+    # ── Fetch ────────────────────────────────────────────────────────────────
+    st.subheader("Fetch Data")
+
+    pending_fetch: tuple[str] | None = None  # (versioned_path,)
+
+    if plugin.FETCHABLE:
+        env_vars = plugin.get_fetch_env_vars()
+        missing_vars = [v for v in env_vars if not os.getenv(v["var"])]
+        if missing_vars:
+            st.warning("Auto-fetch requires these environment variables:")
+            for v in missing_vars:
+                st.code(f'{v["var"]}="…"', language="bash")
+                st.caption(v["description"])
+        else:
+            identity = plugin.get_fetch_identity()
+            if identity:
+                st.caption(f"Fetching as **{identity}**")
+            versioned_path = plugin.get_versioned_output_path()
+            st.caption(f"Will save to `{versioned_path}`")
+            if st.button("Fetch Latest Data", key=f"fetch_{plugin_id}"):
+                pending_fetch = (versioned_path,)
+    else:
+        primary_value = next(iter(config.values()), "").strip() if config else ""
+        if not primary_value or not os.path.exists(primary_value) or primary_path_missing:
+            st.info(plugin.get_manual_download_instructions())
+        else:
+            st.caption("Data loaded from manual export. No auto-fetch available for this source.")
+
+    # Execute pending fetch after button block so progress renders correctly.
+    if pending_fetch is not None:
+        (versioned_path,) = pending_fetch
+        status_ph = st.empty()
+
+        def _on_progress(page: int, total: int) -> None:
+            status_ph.info(f"Fetching page {page} of {total}…")
+
+        status_ph.info("Starting fetch…")
+        try:
+            parent = os.path.dirname(versioned_path)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            plugin.fetch(output_path=versioned_path, progress_callback=_on_progress)
+
+            record_count = _count_records(versioned_path) or 0
+            ts = datetime.now(tz=timezone.utc).isoformat()
+            settings.add_fetch_history(plugin_id, ts, record_count, versioned_path)
+
+            # Point the active config path at the new versioned file.
+            if fields:
+                primary_key = fields[0]["key"]
+                session_key = f"{plugin_id}_{primary_key}"
+                st.session_state[session_key] = versioned_path
+                settings.set_plugin_value(plugin_id, primary_key, versioned_path)
+
+            status_ph.success(
+                f"Fetch complete — {record_count:,} records saved to `{versioned_path}`"
+            )
+            st.rerun()
+        except Exception as exc:  # noqa: BLE001
+            status_ph.error(f"Fetch failed: {exc}")
+
+    st.divider()
+
+    # ── Fetch History ────────────────────────────────────────────────────────
+    st.subheader("Fetch History")
+    history = settings.get_fetch_history(plugin_id)
+    if not history:
+        st.caption("No fetch history recorded yet.")
+    else:
+        header_cols = st.columns([3, 2, 5, 1])
+        header_cols[0].caption("**Timestamp**")
+        header_cols[1].caption("**Records**")
+        header_cols[2].caption("**File**")
+        header_cols[3].caption("**Use**")
+
+        for i, entry in enumerate(history):
+            ts = str(entry.get("timestamp", ""))[:19]
+            rc = entry.get("record_count", "?")
+            fp = str(entry.get("file_path", ""))
+            row = st.columns([3, 2, 5, 1])
+            row[0].text(ts or "—")
+            row[1].text(f"{rc:,}" if isinstance(rc, int) else str(rc))
+            row[2].text(fp)
+            if row[3].button("→", key=f"use_{plugin_id}_{i}", help="Set as active version"):
+                if fields and fp:
+                    primary_key = fields[0]["key"]
+                    st.session_state[f"{plugin_id}_{primary_key}"] = fp
+                    settings.set_plugin_value(plugin_id, primary_key, fp)
+                    st.rerun()
+
+
+def render_data_sources() -> None:
+    """Render the Data Sources management page with per-plugin tabs."""
+    load_builtin_plugins()
+    load_config_into_session_state()
+
+    st.title("Data Sources")
+    st.caption("Configure sources, fetch latest data, and manage version history.")
+
+    plugins_list = [(pid, cls()) for pid, cls in REGISTRY.items()]
+
+    # Compute health for the summary row before rendering tabs.
+    all_health: list[dict[str, Any]] = []
+    for plugin_id, plugin in plugins_list:
+        config = get_plugin_config_from_session(plugin_id, plugin.get_config_fields())
+        history = settings.get_fetch_history(plugin_id)
+        all_health.append(plugin.get_health_status(config, history))
+
+    counts: dict[str, int] = {"healthy": 0, "stale": 0, "error": 0, "unconfigured": 0}
+    for h in all_health:
+        counts[h["status"]] = counts.get(h["status"], 0) + 1
+
+    c1, c2, c3 = st.columns(3)
+    c1.metric("Healthy", counts["healthy"])
+    c2.metric("Stale", counts["stale"])
+    c3.metric("Issues", counts["error"] + counts["unconfigured"])
+
+    st.divider()
+
+    tab_labels = [plugin.DISPLAY_NAME for _, plugin in plugins_list]
+    tabs = st.tabs(tab_labels)
+
+    for tab, (plugin_id, plugin), health in zip(tabs, plugins_list, all_health):
+        with tab:
+            _render_plugin_tab(plugin_id, plugin, health)

--- a/pages/data_sources.py
+++ b/pages/data_sources.py
@@ -13,7 +13,6 @@ from typing import Any
 import streamlit as st
 
 from components.plugin_config import (
-    get_plugin_config_from_session,
     load_config_into_session_state,
     render_plugin_config_fields,
     settings,
@@ -45,28 +44,26 @@ def _count_records(file_path: str) -> int | None:
         return None
 
 
-def _render_plugin_tab(plugin_id: str, plugin: Any, health: dict[str, Any]) -> None:
-    """Render the full management UI for one plugin inside its tab.
+def _render_plugin_tab(plugin_id: str, plugin: Any) -> dict[str, Any]:
+    """Render the full management UI for one plugin and return its computed health.
+
+    Health is computed *after* ``render_plugin_config_fields`` runs so that the
+    browse-button pending-key is processed before the status card is filled in.
+    An ``st.empty()`` placeholder keeps Status visually at the top of the tab
+    even though it is filled after Configuration is rendered.
 
     Args:
         plugin_id: Plugin identifier string.
         plugin: Instantiated SourcePlugin.
-        health: Health dict from ``plugin.get_health_status()``.
+
+    Returns:
+        Health dict from ``plugin.get_health_status()``.
     """
-    icon, label = _STATUS_META.get(health["status"], ("◻️", health["status"]))
-
-    # ── Status ──────────────────────────────────────────────────────────────
-    st.subheader("Status")
-    c1, c2, c3 = st.columns(3)
-    c1.metric("Health", f"{icon} {label}")
-    rc = health["record_count"]
-    c2.metric("Records", f"{rc:,}" if isinstance(rc, int) else "—")
-    last = health.get("last_fetch") or ""
-    c3.metric("Last Fetch", last[:10] if last else "—")
-
-    st.divider()
+    # Reserve a slot at the top — filled after config fields process any pending keys.
+    status_ph = st.empty()
 
     # ── Configuration ────────────────────────────────────────────────────────
+    st.divider()
     st.subheader("Configuration")
     fields = plugin.get_config_fields()
     config = render_plugin_config_fields(plugin_id, fields)
@@ -79,6 +76,22 @@ def _render_plugin_tab(plugin_id: str, plugin: Any, health: dict[str, Any]) -> N
         if primary_val and is_path_field and not os.path.exists(primary_val):
             st.warning("Configured path no longer exists — please select a new location.")
             primary_path_missing = True
+
+    # Health is accurate now because render_plugin_config_fields has processed
+    # any pending browse-button result into session state.
+    history = settings.get_fetch_history(plugin_id)
+    health: dict[str, Any] = plugin.get_health_status(config, history)
+
+    # ── Status (fills the placeholder at the top) ────────────────────────────
+    with status_ph.container():
+        st.subheader("Status")
+        icon, label = _STATUS_META.get(health["status"], ("◻️", health["status"]))
+        c1, c2, c3 = st.columns(3)
+        c1.metric("Health", f"{icon} {label}")
+        rc = health["record_count"]
+        c2.metric("Records", f"{rc:,}" if isinstance(rc, int) else "—")
+        last = health.get("last_fetch") or ""
+        c3.metric("Last Fetch", last[:10] if last else "—")
 
     st.divider()
 
@@ -113,12 +126,12 @@ def _render_plugin_tab(plugin_id: str, plugin: Any, health: dict[str, Any]) -> N
     # Execute pending fetch after button block so progress renders correctly.
     if pending_fetch is not None:
         (versioned_path,) = pending_fetch
-        status_ph = st.empty()
+        fetch_status_ph = st.empty()
 
         def _on_progress(page: int, total: int) -> None:
-            status_ph.info(f"Fetching page {page} of {total}…")
+            fetch_status_ph.info(f"Fetching page {page} of {total}…")
 
-        status_ph.info("Starting fetch…")
+        fetch_status_ph.info("Starting fetch…")
         try:
             parent = os.path.dirname(versioned_path)
             if parent:
@@ -136,12 +149,12 @@ def _render_plugin_tab(plugin_id: str, plugin: Any, health: dict[str, Any]) -> N
                 st.session_state[session_key] = versioned_path
                 settings.set_plugin_value(plugin_id, primary_key, versioned_path)
 
-            status_ph.success(
+            fetch_status_ph.success(
                 f"Fetch complete — {record_count:,} records saved to `{versioned_path}`"
             )
             st.rerun()
         except Exception as exc:  # noqa: BLE001
-            status_ph.error(f"Fetch failed: {exc}")
+            fetch_status_ph.error(f"Fetch failed: {exc}")
 
     st.divider()
 
@@ -172,6 +185,8 @@ def _render_plugin_tab(plugin_id: str, plugin: Any, health: dict[str, Any]) -> N
                     settings.set_plugin_value(plugin_id, primary_key, fp)
                     st.rerun()
 
+    return health
+
 
 def render_data_sources() -> None:
     """Render the Data Sources management page with per-plugin tabs."""
@@ -183,27 +198,27 @@ def render_data_sources() -> None:
 
     plugins_list = [(pid, cls()) for pid, cls in REGISTRY.items()]
 
-    # Compute health for the summary row before rendering tabs.
-    all_health: list[dict[str, Any]] = []
-    for plugin_id, plugin in plugins_list:
-        config = get_plugin_config_from_session(plugin_id, plugin.get_config_fields())
-        history = settings.get_fetch_history(plugin_id)
-        all_health.append(plugin.get_health_status(config, history))
-
-    counts: dict[str, int] = {"healthy": 0, "stale": 0, "error": 0, "unconfigured": 0}
-    for h in all_health:
-        counts[h["status"]] = counts.get(h["status"], 0) + 1
-
-    c1, c2, c3 = st.columns(3)
-    c1.metric("Healthy", counts["healthy"])
-    c2.metric("Stale", counts["stale"])
-    c3.metric("Issues", counts["error"] + counts["unconfigured"])
+    # Summary metrics slot — filled after tabs so health reflects current config.
+    summary_ph = st.empty()
 
     st.divider()
 
     tab_labels = [plugin.DISPLAY_NAME for _, plugin in plugins_list]
     tabs = st.tabs(tab_labels)
 
-    for tab, (plugin_id, plugin), health in zip(tabs, plugins_list, all_health):
+    all_health: list[dict[str, Any]] = []
+    for tab, (plugin_id, plugin) in zip(tabs, plugins_list):
         with tab:
-            _render_plugin_tab(plugin_id, plugin, health)
+            health = _render_plugin_tab(plugin_id, plugin)
+            all_health.append(health)
+
+    # Fill summary now that all tabs have computed accurate health.
+    counts: dict[str, int] = {"healthy": 0, "stale": 0, "error": 0, "unconfigured": 0}
+    for h in all_health:
+        counts[h["status"]] = counts.get(h["status"], 0) + 1
+
+    with summary_ph.container():
+        c1, c2, c3 = st.columns(3)
+        c1.metric("Healthy", counts["healthy"])
+        c2.metric("Stale", counts["stale"])
+        c3.metric("Issues", counts["error"] + counts["unconfigured"])

--- a/pages/data_sources.py
+++ b/pages/data_sources.py
@@ -181,11 +181,16 @@ def render_plugin_page(plugin_id: str) -> None:
     Called by ``st.Page`` entries in ``visualize.py`` — one page per plugin
     under the Sources nav group.
 
+    Streamlit widgets read their display value from the session state snapshot
+    taken at the *start* of each script run, not from values set *during* that
+    run.  When page navigation clears widget-bound keys, we must hydrate
+    session state and trigger one extra rerun so the widgets in the following
+    run see the correct values.
+
     Args:
         plugin_id: The plugin's PLUGIN_ID string (registry key).
     """
     load_builtin_plugins()
-    load_config_into_session_state()
 
     plugin_cls = REGISTRY.get(plugin_id)
     if plugin_cls is None:
@@ -193,6 +198,23 @@ def render_plugin_page(plugin_id: str) -> None:
         return
 
     plugin = plugin_cls()
+    fields = plugin.get_config_fields()
+
+    # Check BEFORE hydration whether any config field is blank in session state
+    # but has a saved value on disk.
+    saved_cfg = settings.get_plugin_config(plugin_id)
+    needs_rerun = any(
+        saved_cfg.get(f["key"]) and not st.session_state.get(f"{plugin_id}_{f['key']}")
+        for f in fields
+    )
+
+    load_config_into_session_state()
+
+    if needs_rerun:
+        # Values were just written into session state this run; rerun so the
+        # next script execution's widget snapshot includes them.
+        st.rerun()
+
     st.title(plugin.DISPLAY_NAME)
     _render_plugin_tab(plugin_id, plugin)
 

--- a/pages/data_sources.py
+++ b/pages/data_sources.py
@@ -1,12 +1,15 @@
 """Data Sources management page.
 
-Provides a full-screen tabbed interface for each source plugin: health status,
-configuration, fetch controls with progress output, and versioned fetch history.
+``render_data_sources`` is the overview hub: summary health metrics and
+Cache Management.  Each plugin has its own dedicated page rendered by
+``render_plugin_page``, which is wired into ``st.navigation`` by
+``visualize.py``.
 """
 
 from __future__ import annotations
 
 import os
+import shutil
 from datetime import datetime, timezone
 from typing import Any
 
@@ -29,12 +32,12 @@ _STATUS_META: dict[str, tuple[str, str]] = {
 
 
 def _render_plugin_tab(plugin_id: str, plugin: Any) -> dict[str, Any]:
-    """Render the full management UI for one plugin and return its computed health.
+    """Render status, config, fetch, and history UI for one plugin.
 
     Health is computed *after* ``render_plugin_config_fields`` runs so that the
     browse-button pending-key is processed before the status card is filled in.
-    An ``st.empty()`` placeholder keeps Status visually at the top of the tab
-    even though it is filled after Configuration is rendered.
+    An ``st.empty()`` placeholder keeps Status visually at the top even though
+    it is filled after Configuration is rendered.
 
     Args:
         plugin_id: Plugin identifier string.
@@ -172,37 +175,117 @@ def _render_plugin_tab(plugin_id: str, plugin: Any) -> dict[str, Any]:
     return health
 
 
+def render_plugin_page(plugin_id: str) -> None:
+    """Render the standalone management page for a single plugin.
+
+    Called by ``st.Page`` entries in ``visualize.py`` — one page per plugin
+    under the Sources nav group.
+
+    Args:
+        plugin_id: The plugin's PLUGIN_ID string (registry key).
+    """
+    load_builtin_plugins()
+    load_config_into_session_state()
+
+    plugin_cls = REGISTRY.get(plugin_id)
+    if plugin_cls is None:
+        st.error(f"Plugin '{plugin_id}' not found in registry.")
+        return
+
+    plugin = plugin_cls()
+    st.title(plugin.DISPLAY_NAME)
+    _render_plugin_tab(plugin_id, plugin)
+
+
+def _render_cache_tab() -> None:
+    """Render the Cache Management tab content."""
+    cache_dir = "data/cache"
+
+    st.subheader("Cache Status")
+    cache_status = st.session_state.get("_cache_status", "unknown")
+    if cache_status == "hit":
+        st.success("Active dataset loaded from local cache.")
+    elif cache_status == "miss":
+        st.info("Dataset was processed fresh and saved to cache.")
+    else:
+        st.caption("Load the app with a configured Last.fm file to populate cache status.")
+
+    st.divider()
+    st.subheader("Cached Files")
+
+    if os.path.exists(cache_dir):
+        files = [f for f in os.listdir(cache_dir) if not f.startswith(".")]
+        if files:
+            total_bytes = sum(
+                os.path.getsize(os.path.join(cache_dir, f))
+                for f in files
+                if os.path.isfile(os.path.join(cache_dir, f))
+            )
+            st.caption(f"{len(files)} file(s) — {total_bytes / 1024:.1f} KB total")
+            for fname in sorted(files):
+                st.text(fname)
+        else:
+            st.caption("Cache directory is empty.")
+    else:
+        st.caption("No cache directory found.")
+
+    st.divider()
+    if st.button("Clear Local Cache", type="primary"):
+        if os.path.exists(cache_dir):
+            shutil.rmtree(cache_dir)
+            st.session_state.pop("_cache_status", None)
+            st.success("Cache cleared.")
+            st.rerun()
+        else:
+            st.info("Nothing to clear — cache directory does not exist.")
+
+
 def render_data_sources() -> None:
-    """Render the Data Sources management page with per-plugin tabs."""
+    """Render the Data Sources overview page (summary metrics + Cache tab)."""
     load_builtin_plugins()
     load_config_into_session_state()
 
     st.title("Data Sources")
-    st.caption("Configure sources, fetch latest data, and manage version history.")
+    st.caption("Health summary across all configured sources.")
 
-    plugins_list = [(pid, cls()) for pid, cls in REGISTRY.items()]
+    overview_tab, cache_tab = st.tabs(["Overview", "Cache Management"])
 
-    # Summary metrics slot — filled after tabs so health reflects current config.
-    summary_ph = st.empty()
+    with overview_tab:
+        plugins_list = [(pid, cls()) for pid, cls in REGISTRY.items()]
 
-    st.divider()
+        # Summary metric row — filled after all plugins report health.
+        summary_ph = st.empty()
+        st.divider()
 
-    tab_labels = [plugin.DISPLAY_NAME for _, plugin in plugins_list]
-    tabs = st.tabs(tab_labels)
+        all_health: list[dict[str, Any]] = []
+        for plugin_id, plugin in plugins_list:
+            fields = plugin.get_config_fields()
+            from components.plugin_config import get_plugin_config_from_session
 
-    all_health: list[dict[str, Any]] = []
-    for tab, (plugin_id, plugin) in zip(tabs, plugins_list):
-        with tab:
-            health = _render_plugin_tab(plugin_id, plugin)
+            config = get_plugin_config_from_session(plugin_id, fields)
+            history = settings.get_fetch_history(plugin_id)
+            health: dict[str, Any] = plugin.get_health_status(config, history)
             all_health.append(health)
 
-    # Fill summary now that all tabs have computed accurate health.
-    counts: dict[str, int] = {"healthy": 0, "stale": 0, "error": 0, "unconfigured": 0}
-    for h in all_health:
-        counts[h["status"]] = counts.get(h["status"], 0) + 1
+            icon, label = _STATUS_META.get(health["status"], ("◻️", health["status"]))
+            rc = health["record_count"]
+            last = (health.get("last_fetch") or "")[:10]
 
-    with summary_ph.container():
-        c1, c2, c3 = st.columns(3)
-        c1.metric("Healthy", counts["healthy"])
-        c2.metric("Stale", counts["stale"])
-        c3.metric("Issues", counts["error"] + counts["unconfigured"])
+            cols = st.columns([3, 1, 2, 2])
+            cols[0].markdown(f"**{plugin.DISPLAY_NAME}**")
+            cols[1].markdown(f"{icon} {label}")
+            cols[2].caption(f"{rc:,} records" if isinstance(rc, int) else "—")
+            cols[3].caption(last or "—")
+
+        counts: dict[str, int] = {"healthy": 0, "stale": 0, "error": 0, "unconfigured": 0}
+        for h in all_health:
+            counts[h["status"]] = counts.get(h["status"], 0) + 1
+
+        with summary_ph.container():
+            c1, c2, c3 = st.columns(3)
+            c1.metric("Healthy", counts["healthy"])
+            c2.metric("Stale", counts["stale"])
+            c3.metric("Issues", counts["error"] + counts["unconfigured"])
+
+    with cache_tab:
+        _render_cache_tab()

--- a/plugins/sources/base.py
+++ b/plugins/sources/base.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 from abc import ABC, abstractmethod
+from datetime import datetime, timezone
 from typing import Any
 
 import pandas as pd
@@ -170,6 +172,97 @@ class SourcePlugin(ABC):
             "Please refer to the source's documentation for export options, "
             "then point the plugin's config field at the downloaded file."
         )
+
+    def get_health_status(
+        self, config: dict[str, Any], history: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        """Return health status derived from the current config and fetch history.
+
+        Status values:
+            ``"healthy"``      — data file exists and is not stale.
+            ``"stale"``        — fetchable plugin whose last fetch exceeds the
+                                 staleness threshold (default 24 h, overridable
+                                 via ``AUTOBIO_STALE_THRESHOLD_HOURS``).
+            ``"error"``        — configured path no longer exists on disk.
+            ``"unconfigured"`` — no primary config value has been set yet.
+
+        Args:
+            config: Dict of field_key → value from the plugin's config fields.
+            history: Fetch history list from ``LocalSettings.get_fetch_history()``.
+
+        Returns:
+            Dict with keys ``status``, ``record_count`` (int or None),
+            ``last_fetch`` (ISO string or None), ``data_path`` (str or None).
+        """
+        fields = self.get_config_fields()
+        primary_key = fields[0]["key"] if fields else None
+        data_path = config.get(primary_key, "").strip() if primary_key else ""
+
+        def _result(status: str, rc: int | None = None, lf: str | None = None) -> dict[str, Any]:
+            return {"status": status, "record_count": rc, "last_fetch": lf, "data_path": data_path}
+
+        if not data_path:
+            return {
+                "status": "unconfigured",
+                "record_count": None,
+                "last_fetch": None,
+                "data_path": None,
+            }
+
+        if not os.path.exists(data_path):
+            return _result("error")
+
+        record_count: int | None = None
+        last_fetch: str | None = None
+        if history:
+            latest = history[0]
+            last_fetch = latest.get("timestamp")
+            record_count = latest.get("record_count")
+
+        if not self.FETCHABLE:
+            return _result("healthy", record_count, last_fetch)
+
+        stale_seconds = int(os.getenv("AUTOBIO_STALE_THRESHOLD_HOURS", "24")) * 3600
+        now = datetime.now(tz=timezone.utc)
+
+        if last_fetch:
+            try:
+                last_dt = datetime.fromisoformat(last_fetch)
+                if last_dt.tzinfo is None:
+                    last_dt = last_dt.replace(tzinfo=timezone.utc)
+                elapsed = (now - last_dt).total_seconds()
+                status = "stale" if elapsed > stale_seconds else "healthy"
+            except ValueError:
+                status = "healthy"
+        else:
+            # No history — fall back to file mtime for staleness detection.
+            try:
+                mtime = os.path.getmtime(data_path)
+                last_mtime = datetime.fromtimestamp(mtime, tz=timezone.utc)
+                last_fetch = last_mtime.isoformat()
+                elapsed = (now - last_mtime).total_seconds()
+                status = "stale" if elapsed > stale_seconds else "healthy"
+            except OSError:
+                status = "healthy"
+
+        return _result(status, record_count, last_fetch)
+
+    def get_versioned_output_path(self) -> str:
+        """Return a timestamped file path for a new fetch snapshot.
+
+        Derives the base name and extension from ``get_default_output_path()``,
+        inserting an ISO timestamp before the extension. Falls back to
+        ``data/{plugin_id}/{plugin_id}_{ts}.csv`` when no default is available.
+
+        Returns:
+            Path string with format ``<base>_<YYYY-MM-DDTHHMMSS><ext>``.
+        """
+        ts = datetime.now().strftime("%Y-%m-%dT%H%M%S")
+        default = self.get_default_output_path()
+        if default:
+            base, ext = os.path.splitext(default)
+            return f"{base}_{ts}{ext or '.csv'}"
+        return f"data/{self.PLUGIN_ID}/{self.PLUGIN_ID}_{ts}.csv"
 
     def get_schema(self) -> dict[str, str]:
         """Return column name → description metadata for this plugin.

--- a/plugins/sources/base.py
+++ b/plugins/sources/base.py
@@ -16,6 +16,36 @@ _REQUIRED_COLUMNS: dict[str, list[str]] = {
 }
 
 
+def _count_records_at_path(path: str) -> int | None:
+    """Return a record count for a file or directory.
+
+    CSV → row count; JSON file → top-level list length; directory → total
+    items across all .json files in the directory.  Returns None on any error.
+    """
+    try:
+        if os.path.isdir(path):
+            import json
+
+            total = 0
+            for fname in os.listdir(path):
+                if fname.lower().endswith(".json"):
+                    with open(os.path.join(path, fname)) as f:
+                        data = json.load(f)
+                    if isinstance(data, list):
+                        total += len(data)
+            return total or None
+        ext = os.path.splitext(path)[1].lower()
+        if ext == ".csv":
+            return len(pd.read_csv(path))
+        import json
+
+        with open(path) as f:
+            data = json.load(f)
+        return len(data) if isinstance(data, list) else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def validate_schema(df: pd.DataFrame, plugin_type: str) -> None:
     """Raise ValueError if df is missing required columns for plugin_type.
 
@@ -212,14 +242,23 @@ class SourcePlugin(ABC):
         if not os.path.exists(data_path):
             return _result("error")
 
-        record_count: int | None = None
+        # Count records directly from the file/directory — history may be absent
+        # for non-fetchable plugins or on first run.
+        record_count: int | None = _count_records_at_path(data_path)
         last_fetch: str | None = None
         if history:
-            latest = history[0]
-            last_fetch = latest.get("timestamp")
-            record_count = latest.get("record_count")
+            last_fetch = history[0].get("timestamp")
 
         if not self.FETCHABLE:
+            # Use the file/directory creation time as a proxy for when the data
+            # was last obtained.  os.path.getctime() returns creation time on
+            # Windows and inode-change time on POSIX (closest available proxy).
+            if not last_fetch:
+                try:
+                    ctime = os.path.getctime(data_path)
+                    last_fetch = datetime.fromtimestamp(ctime, tz=timezone.utc).isoformat()
+                except OSError:
+                    pass
             return _result("healthy", record_count, last_fetch)
 
         stale_seconds = int(os.getenv("AUTOBIO_STALE_THRESHOLD_HOURS", "24")) * 3600

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dev = [
 ]
 
 
+[tool.setuptools.packages.find]
+exclude = ["data*", "assets*", "notebooks*", "tests*", "venv*", ".venv*"]
+
 [tool.ruff]
 target-version = "py39"
 line-length = 100

--- a/tests/test_data_sources_ux.py
+++ b/tests/test_data_sources_ux.py
@@ -136,6 +136,27 @@ class TestGetHealthStatus(unittest.TestCase):
         finally:
             os.unlink(tmp_path)
 
+    def test_record_count_read_from_csv_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False, mode="w") as f:
+            f.write("artist,track\nRadiohead,Karma Police\nPortishead,Sour Times\n")
+            tmp_path = f.name
+        try:
+            health = self.lastfm.get_health_status({"data_path": tmp_path}, [])
+            self.assertEqual(health["record_count"], 2)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_non_fetchable_last_fetch_from_file_ctime(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            f.write(b"[]")
+            tmp_path = f.name
+        try:
+            health = self.swarm.get_health_status({"swarm_dir": tmp_path}, [])
+            # last_fetch should be set from file ctime, not None
+            self.assertIsNotNone(health["last_fetch"])
+        finally:
+            os.unlink(tmp_path)
+
     def test_health_uses_file_mtime_when_no_history(self):
         with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
             tmp_path = f.name

--- a/tests/test_data_sources_ux.py
+++ b/tests/test_data_sources_ux.py
@@ -1,0 +1,194 @@
+"""Tests for the Data Sources UX: health status, versioned paths, and fetch history."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from core.local_settings import LocalSettings
+from plugins.sources.lastfm.loader import LastFmPlugin
+from plugins.sources.swarm.loader import SwarmPlugin
+
+
+class TestLocalSettingsFetchHistory(unittest.TestCase):
+    """Tests for add_fetch_history and get_fetch_history."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".json", delete=False)
+        self.tmp.close()
+        os.unlink(self.tmp.name)
+        self.settings = LocalSettings(self.tmp.name)
+
+    def tearDown(self):
+        if os.path.exists(self.tmp.name):
+            os.unlink(self.tmp.name)
+
+    def test_get_fetch_history_returns_empty_when_no_history(self):
+        self.assertEqual(self.settings.get_fetch_history("lastfm"), [])
+
+    def test_add_fetch_history_stores_entry(self):
+        self.settings.add_fetch_history("lastfm", "2026-04-28T12:00:00", 1000, "data/file.csv")
+        history = self.settings.get_fetch_history("lastfm")
+        self.assertEqual(len(history), 1)
+        self.assertEqual(history[0]["timestamp"], "2026-04-28T12:00:00")
+        self.assertEqual(history[0]["record_count"], 1000)
+        self.assertEqual(history[0]["file_path"], "data/file.csv")
+
+    def test_add_fetch_history_newest_first(self):
+        self.settings.add_fetch_history("lastfm", "2026-01-01T00:00:00", 100, "a.csv")
+        self.settings.add_fetch_history("lastfm", "2026-04-28T12:00:00", 200, "b.csv")
+        history = self.settings.get_fetch_history("lastfm")
+        self.assertEqual(history[0]["timestamp"], "2026-04-28T12:00:00")
+        self.assertEqual(history[1]["timestamp"], "2026-01-01T00:00:00")
+
+    def test_add_fetch_history_caps_at_max(self):
+        for i in range(25):
+            self.settings.add_fetch_history(
+                "lastfm", f"2026-01-{i + 1:02d}T00:00:00", i, f"file_{i}.csv"
+            )
+        history = self.settings.get_fetch_history("lastfm")
+        self.assertEqual(len(history), LocalSettings._MAX_HISTORY)
+
+    def test_add_fetch_history_persists_to_disk(self):
+        self.settings.add_fetch_history("lastfm", "2026-04-28T12:00:00", 500, "data/f.csv")
+        reloaded = LocalSettings(self.tmp.name)
+        self.assertEqual(len(reloaded.get_fetch_history("lastfm")), 1)
+
+    def test_fetch_history_does_not_pollute_plugin_config(self):
+        self.settings.add_fetch_history("lastfm", "2026-04-28T12:00:00", 500, "data/f.csv")
+        cfg = self.settings.get_plugin_config("lastfm")
+        # fetch_history is present in plugin config but is a list, not a string
+        self.assertIsInstance(cfg.get("fetch_history"), list)
+
+    def test_get_fetch_history_independent_per_plugin(self):
+        self.settings.add_fetch_history("lastfm", "2026-04-28T12:00:00", 100, "a.csv")
+        self.assertEqual(self.settings.get_fetch_history("swarm"), [])
+
+
+class TestGetHealthStatus(unittest.TestCase):
+    """Tests for SourcePlugin.get_health_status."""
+
+    def setUp(self):
+        self.lastfm = LastFmPlugin()
+        self.swarm = SwarmPlugin()
+
+    def test_unconfigured_when_no_data_path(self):
+        health = self.lastfm.get_health_status({"data_path": ""}, [])
+        self.assertEqual(health["status"], "unconfigured")
+        self.assertIsNone(health["record_count"])
+        self.assertIsNone(health["data_path"])
+
+    def test_error_when_path_does_not_exist(self):
+        health = self.lastfm.get_health_status({"data_path": "/nonexistent/file.csv"}, [])
+        self.assertEqual(health["status"], "error")
+        self.assertEqual(health["data_path"], "/nonexistent/file.csv")
+
+    def test_healthy_fetchable_with_recent_history(self):
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            f.write(b"artist,track\nRadiohead,Karma Police\n")
+            tmp_path = f.name
+        try:
+            recent_ts = datetime.now(tz=timezone.utc).isoformat()
+            history = [{"timestamp": recent_ts, "record_count": 1, "file_path": tmp_path}]
+            health = self.lastfm.get_health_status({"data_path": tmp_path}, history)
+            self.assertEqual(health["status"], "healthy")
+            self.assertEqual(health["record_count"], 1)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_stale_fetchable_with_old_history(self):
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            f.write(b"artist,track\nRadiohead,Karma Police\n")
+            tmp_path = f.name
+        try:
+            old_ts = (datetime.now(tz=timezone.utc) - timedelta(hours=48)).isoformat()
+            history = [{"timestamp": old_ts, "record_count": 1, "file_path": tmp_path}]
+            health = self.lastfm.get_health_status({"data_path": tmp_path}, history)
+            self.assertEqual(health["status"], "stale")
+        finally:
+            os.unlink(tmp_path)
+
+    def test_non_fetchable_always_healthy_when_file_exists(self):
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            tmp_path = f.name
+        try:
+            # No history, old file — non-fetchable plugins are always healthy
+            old_ts = (datetime.now(tz=timezone.utc) - timedelta(hours=48)).isoformat()
+            history = [{"timestamp": old_ts, "record_count": 0, "file_path": tmp_path}]
+            health = self.swarm.get_health_status({"swarm_dir": tmp_path}, history)
+            self.assertEqual(health["status"], "healthy")
+        finally:
+            os.unlink(tmp_path)
+
+    def test_custom_stale_threshold_env_var(self):
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            tmp_path = f.name
+        try:
+            # 2 hours old, threshold = 1 hour → stale
+            old_ts = (datetime.now(tz=timezone.utc) - timedelta(hours=2)).isoformat()
+            history = [{"timestamp": old_ts, "record_count": 1, "file_path": tmp_path}]
+            with patch.dict(os.environ, {"AUTOBIO_STALE_THRESHOLD_HOURS": "1"}):
+                health = self.lastfm.get_health_status({"data_path": tmp_path}, history)
+            self.assertEqual(health["status"], "stale")
+        finally:
+            os.unlink(tmp_path)
+
+    def test_health_uses_file_mtime_when_no_history(self):
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            tmp_path = f.name
+        try:
+            # Set mtime to 48 hours ago so it reads as stale
+            old_time = (datetime.now(tz=timezone.utc) - timedelta(hours=48)).timestamp()
+            os.utime(tmp_path, (old_time, old_time))
+            health = self.lastfm.get_health_status({"data_path": tmp_path}, [])
+            self.assertEqual(health["status"], "stale")
+        finally:
+            os.unlink(tmp_path)
+
+
+class TestGetVersionedOutputPath(unittest.TestCase):
+    """Tests for SourcePlugin.get_versioned_output_path."""
+
+    def setUp(self):
+        self.lastfm = LastFmPlugin()
+
+    def test_returns_string(self):
+        with patch.dict(os.environ, {"AUTOBIO_LASTFM_USERNAME": "testuser"}):
+            path = self.lastfm.get_versioned_output_path()
+        self.assertIsInstance(path, str)
+
+    def test_embeds_timestamp(self):
+        with patch.dict(os.environ, {"AUTOBIO_LASTFM_USERNAME": "testuser"}):
+            path = self.lastfm.get_versioned_output_path()
+        # Path should contain a timestamp segment like _2026-04-28T120000
+        self.assertRegex(path, r"_\d{4}-\d{2}-\d{2}T\d{6}")
+
+    def test_preserves_extension(self):
+        with patch.dict(os.environ, {"AUTOBIO_LASTFM_USERNAME": "testuser"}):
+            path = self.lastfm.get_versioned_output_path()
+        self.assertTrue(path.endswith(".csv"))
+
+    def test_fallback_when_no_default_path(self):
+        # Swarm has no get_default_output_path, falls back to data/{id}/{id}_{ts}.csv
+        from plugins.sources.swarm.loader import SwarmPlugin
+
+        swarm = SwarmPlugin()
+        path = swarm.get_versioned_output_path()
+        self.assertIn("swarm", path)
+        self.assertTrue(path.endswith(".csv"))
+
+    def test_different_calls_produce_different_timestamps(self):
+        import time
+
+        with patch.dict(os.environ, {"AUTOBIO_LASTFM_USERNAME": "testuser"}):
+            path1 = self.lastfm.get_versioned_output_path()
+            time.sleep(1.1)
+            path2 = self.lastfm.get_versioned_output_path()
+        self.assertNotEqual(path1, path2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -95,82 +95,67 @@ class TestPathInput(unittest.TestCase):
         self.assertIn("data_path", result)
 
 
-class TestSidebarHealthBadges(unittest.TestCase):
-    """Tests that the sidebar displays health badges reflecting plugin status."""
+class TestSidebarDataLoading(unittest.TestCase):
+    """Tests that the sidebar loads data and sets session state correctly."""
 
-    def _make_plugin(self, data_path: str) -> MagicMock:
-        plugin_instance = MagicMock()
-        plugin_instance.DISPLAY_NAME = "Last.fm"
-        plugin_instance.get_config_fields.return_value = [
+    def test_render_sidebar_sets_df_none_when_no_file_path(self) -> None:
+        """render_sidebar sets df=None when no Last.fm file is configured."""
+        plugin_cls = MagicMock(return_value=MagicMock())
+        plugin_cls.return_value.get_config_fields.return_value = [
             {"key": "data_path", "label": "CSV", "type": "file_path"}
         ]
-        plugin_instance.get_health_status.return_value = {
-            "status": "error" if not data_path else "healthy",
-            "record_count": None,
-            "last_fetch": None,
-            "data_path": data_path or None,
-        }
-        return plugin_instance
-
-    def test_render_sidebar_calls_get_health_status_per_plugin(self) -> None:
-        """render_sidebar calls get_health_status for each registered plugin."""
-        plugin_instance = self._make_plugin("/real/tracks.csv")
-        plugin_cls = MagicMock(return_value=plugin_instance)
-
-        session = {"lastfm_data_path": "/real/tracks.csv"}
-        with (
-            patch("streamlit.session_state", session),
-            patch("components.plugin_config.settings") as mock_settings,
-            patch("components.sidebar.settings", mock_settings),
-            patch("components.sidebar.REGISTRY", {"lastfm": plugin_cls}),
-            patch("components.sidebar.load_builtin_plugins"),
-            patch("components.sidebar.load_config_into_session_state"),
-            patch("streamlit.sidebar") as mock_sidebar,
-            patch("components.sidebar.os.path.exists", return_value=False),
-        ):
-            mock_settings.get_fetch_history.return_value = []
-            mock_sidebar.button.return_value = False
-
-            from components.sidebar import render_sidebar
-
-            render_sidebar()
-
-        plugin_instance.get_health_status.assert_called_once()
-
-    def test_render_sidebar_shows_error_badge_for_missing_path(self) -> None:
-        """When health status is 'error', sidebar markdown includes the ❌ badge."""
-        plugin_instance = self._make_plugin("")
-        plugin_instance.get_health_status.return_value = {
-            "status": "error",
-            "record_count": None,
-            "last_fetch": None,
-            "data_path": "/gone.csv",
-        }
-        plugin_cls = MagicMock(return_value=plugin_instance)
-
-        markdown_calls: list[str] = []
-
         session: dict = {}
         with (
             patch("streamlit.session_state", session),
-            patch("components.plugin_config.settings") as mock_settings,
-            patch("components.sidebar.settings", mock_settings),
             patch("components.sidebar.REGISTRY", {"lastfm": plugin_cls}),
             patch("components.sidebar.load_builtin_plugins"),
             patch("components.sidebar.load_config_into_session_state"),
-            patch("streamlit.sidebar") as mock_sidebar,
+            patch("components.sidebar.get_plugin_config_from_session", return_value={}),
             patch("components.sidebar.os.path.exists", return_value=False),
         ):
-            mock_settings.get_fetch_history.return_value = []
-            mock_sidebar.button.return_value = False
-            mock_sidebar.markdown.side_effect = lambda s, **_kw: markdown_calls.append(s)
-
             from components.sidebar import render_sidebar
 
             render_sidebar()
 
-        badge_lines = [c for c in markdown_calls if "❌" in c]
-        self.assertTrue(len(badge_lines) > 0, "Expected ❌ badge in sidebar markdown")
+        self.assertIsNone(session.get("df"))
+
+    def test_render_sidebar_stores_cache_hit_status(self) -> None:
+        """render_sidebar sets _cache_status='hit' when cached data is found."""
+        import pandas as pd
+
+        cached_df = pd.DataFrame({"date_text": pd.to_datetime(["2024-01-01"])})
+
+        plugin_instance = MagicMock()
+        plugin_instance.get_config_fields.return_value = [
+            {"key": "data_path", "label": "CSV", "type": "file_path"}
+        ]
+        plugin_cls = MagicMock(return_value=plugin_instance)
+
+        session: dict = {"lastfm_data_path": "/some/file.csv"}
+        with (
+            patch("streamlit.session_state", session),
+            patch("components.sidebar.REGISTRY", {"lastfm": plugin_cls}),
+            patch("components.sidebar.load_builtin_plugins"),
+            patch("components.sidebar.load_config_into_session_state"),
+            patch(
+                "components.sidebar.get_plugin_config_from_session",
+                return_value={"data_path": "/some/file.csv"},
+            ),
+            patch("components.sidebar.os.path.exists", return_value=True),
+            patch("components.sidebar.load_assumptions", return_value={}),
+            patch("components.sidebar.get_cache_key", return_value="key"),
+            patch("components.sidebar.get_cached_data", return_value=cached_df),
+            patch("streamlit.sidebar") as mock_sidebar,
+        ):
+            mock_sidebar.date_input.return_value = [
+                cached_df["date_text"].min().date(),
+                cached_df["date_text"].max().date(),
+            ]
+            from components.sidebar import render_sidebar
+
+            render_sidebar()
+
+        self.assertEqual(session.get("_cache_status"), "hit")
 
 
 class TestConfigPersistence(unittest.TestCase):
@@ -376,7 +361,7 @@ class TestVisualize(unittest.TestCase):
         mock_pg = MagicMock()
         mock_nav.return_value = mock_pg
 
-        with patch("visualize.render_sidebar"):
+        with patch("visualize.render_sidebar"), patch("visualize.load_builtin_plugins"):
             main()
 
         mock_config.assert_called_once_with(page_title="Autobiographer", layout="wide")

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -9,10 +9,14 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pandas as pd
 
-from components.sidebar import (
-    _load_config_into_session_state,
-    _path_input,
-    _render_plugin_config,
+from components.plugin_config import (
+    load_config_into_session_state as _load_config_into_session_state,
+)
+from components.plugin_config import (
+    path_input as _path_input,
+)
+from components.plugin_config import (
+    render_plugin_config_fields as _render_plugin_config,
 )
 from core.local_settings import LocalSettings
 from pages.insights import render_insights_and_narrative
@@ -35,7 +39,7 @@ class TestPathInput(unittest.TestCase):
         col2.button.return_value = False
         return col1, col2
 
-    @patch("components.sidebar._TKINTER_AVAILABLE", True)
+    @patch("components.plugin_config._TKINTER_AVAILABLE", True)
     @patch("streamlit.columns")
     @patch("streamlit.button", return_value=False)
     @patch("streamlit.session_state", {})
@@ -48,7 +52,7 @@ class TestPathInput(unittest.TestCase):
         )
         self.assertEqual(result, "/some/default")
 
-    @patch("components.sidebar._TKINTER_AVAILABLE", True)
+    @patch("components.plugin_config._TKINTER_AVAILABLE", True)
     @patch("streamlit.columns")
     @patch("streamlit.button", return_value=False)
     def test_path_input_returns_existing_session_state(
@@ -61,7 +65,7 @@ class TestPathInput(unittest.TestCase):
             )
         self.assertEqual(result, "/existing/path")
 
-    @patch("components.sidebar._TKINTER_AVAILABLE", False)
+    @patch("components.plugin_config._TKINTER_AVAILABLE", False)
     @patch("streamlit.text_input")
     @patch("streamlit.session_state", {})
     def test_path_input_fallback_without_tkinter(self, mock_text_input: MagicMock) -> None:
@@ -71,7 +75,7 @@ class TestPathInput(unittest.TestCase):
         call_kwargs = mock_text_input.call_args
         self.assertEqual(call_kwargs[1]["key"], "nontk_key")
 
-    @patch("components.sidebar._TKINTER_AVAILABLE", True)
+    @patch("components.plugin_config._TKINTER_AVAILABLE", True)
     @patch("streamlit.columns")
     @patch("streamlit.button", return_value=False)
     @patch("streamlit.session_state", {})
@@ -85,117 +89,88 @@ class TestPathInput(unittest.TestCase):
         fields = [
             {"key": "data_path", "label": "CSV file", "type": "file_path"},
         ]
-        with patch("components.sidebar._settings") as mock_settings:
+        with patch("components.plugin_config.settings") as mock_settings:
             mock_settings.set_plugin_value = MagicMock()
             result = _render_plugin_config("myplugin", fields)
         self.assertIn("data_path", result)
 
 
-class TestSidebarExpansion(unittest.TestCase):
-    """Tests that plugin expanders auto-expand when a saved path no longer exists."""
+class TestSidebarHealthBadges(unittest.TestCase):
+    """Tests that the sidebar displays health badges reflecting plugin status."""
 
-    def _make_sidebar_mocks(
-        self, mock_columns: MagicMock, mock_button: MagicMock
-    ) -> tuple[MagicMock, MagicMock]:
-        col1, col2 = MagicMock(), MagicMock()
-        mock_columns.return_value = [col1, col2]
-        mock_button.return_value = False
-        col2.button.return_value = False
-        return col1, col2
+    def _make_plugin(self, data_path: str) -> MagicMock:
+        plugin_instance = MagicMock()
+        plugin_instance.DISPLAY_NAME = "Last.fm"
+        plugin_instance.get_config_fields.return_value = [
+            {"key": "data_path", "label": "CSV", "type": "file_path"}
+        ]
+        plugin_instance.get_health_status.return_value = {
+            "status": "error" if not data_path else "healthy",
+            "record_count": None,
+            "last_fetch": None,
+            "data_path": data_path or None,
+        }
+        return plugin_instance
 
-    @patch("components.sidebar._TKINTER_AVAILABLE", True)
-    @patch("streamlit.columns")
-    @patch("streamlit.button", return_value=False)
-    @patch("streamlit.warning")
-    def test_expander_opens_and_warns_when_path_missing(
-        self, mock_warning: MagicMock, mock_button: MagicMock, mock_columns: MagicMock
-    ) -> None:
-        """When session state holds a nonexistent path, the expander is expanded and a warning shown."""
-        self._make_sidebar_mocks(mock_columns, mock_button)
-        expander_ctx = MagicMock()
-        expander_ctx.__enter__ = MagicMock(return_value=expander_ctx)
-        expander_ctx.__exit__ = MagicMock(return_value=False)
-
-        session = {"lastfm_data_path": "/nonexistent/tracks.csv"}
-        with (
-            patch("streamlit.session_state", session),
-            patch("components.sidebar._settings") as mock_settings,
-            patch("components.sidebar.REGISTRY", {"lastfm": MagicMock()}),
-            patch("components.sidebar.load_builtin_plugins"),
-            patch("components.sidebar._load_config_into_session_state"),
-            patch("streamlit.sidebar") as mock_sidebar,
-            patch("os.path.exists", return_value=False),
-        ):
-            mock_settings.get_all_plugin_configs.return_value = {}
-            plugin_instance = MagicMock()
-            plugin_instance.ICON = ":material/headphones:"
-            plugin_instance.DISPLAY_NAME = "Last.fm"
-            plugin_instance.get_config_fields.return_value = [
-                {"key": "data_path", "label": "CSV", "type": "file_path"}
-            ]
-            mock_sidebar.expander.return_value = expander_ctx
-            import components.sidebar as sidebar_mod
-
-            sidebar_mod.REGISTRY["lastfm"].return_value = plugin_instance
-
-            from components.sidebar import render_sidebar
-
-            render_sidebar()
-
-        # Expander must be called with expanded=True when path is missing
-        mock_sidebar.expander.assert_called_once()
-        _, kwargs = mock_sidebar.expander.call_args
-        self.assertTrue(kwargs.get("expanded"), "Expander should be expanded when path is missing")
-        mock_warning.assert_called_once()
-
-    @patch("components.sidebar._TKINTER_AVAILABLE", True)
-    @patch("streamlit.columns")
-    @patch("streamlit.button", return_value=False)
-    @patch("streamlit.warning")
-    def test_expander_collapsed_and_no_warning_when_path_exists(
-        self, mock_warning: MagicMock, mock_button: MagicMock, mock_columns: MagicMock
-    ) -> None:
-        """When session state holds an existing path, the expander is collapsed and no warning shown."""
-        self._make_sidebar_mocks(mock_columns, mock_button)
-        expander_ctx = MagicMock()
-        expander_ctx.__enter__ = MagicMock(return_value=expander_ctx)
-        expander_ctx.__exit__ = MagicMock(return_value=False)
+    def test_render_sidebar_calls_get_health_status_per_plugin(self) -> None:
+        """render_sidebar calls get_health_status for each registered plugin."""
+        plugin_instance = self._make_plugin("/real/tracks.csv")
+        plugin_cls = MagicMock(return_value=plugin_instance)
 
         session = {"lastfm_data_path": "/real/tracks.csv"}
         with (
             patch("streamlit.session_state", session),
-            patch("components.sidebar._settings") as mock_settings,
-            patch("components.sidebar.REGISTRY", {"lastfm": MagicMock()}),
+            patch("components.plugin_config.settings") as mock_settings,
+            patch("components.sidebar.settings", mock_settings),
+            patch("components.sidebar.REGISTRY", {"lastfm": plugin_cls}),
             patch("components.sidebar.load_builtin_plugins"),
-            patch("components.sidebar._load_config_into_session_state"),
+            patch("components.sidebar.load_config_into_session_state"),
             patch("streamlit.sidebar") as mock_sidebar,
-            patch("components.sidebar.os.path.exists", return_value=True),
-            patch("components.sidebar.get_cache_key", return_value="key"),
-            patch("components.sidebar.get_cached_data", return_value=None),
-            patch("components.sidebar.load_assumptions", return_value={}),
-            patch("components.sidebar.load_listening_data", return_value=None),
+            patch("components.sidebar.os.path.exists", return_value=False),
         ):
-            mock_settings.get_all_plugin_configs.return_value = {}
+            mock_settings.get_fetch_history.return_value = []
             mock_sidebar.button.return_value = False
-            plugin_instance = MagicMock()
-            plugin_instance.ICON = ":material/headphones:"
-            plugin_instance.DISPLAY_NAME = "Last.fm"
-            plugin_instance.get_config_fields.return_value = [
-                {"key": "data_path", "label": "CSV", "type": "file_path"}
-            ]
-            mock_sidebar.expander.return_value = expander_ctx
-            import components.sidebar as sidebar_mod
-
-            sidebar_mod.REGISTRY["lastfm"].return_value = plugin_instance
 
             from components.sidebar import render_sidebar
 
             render_sidebar()
 
-        mock_sidebar.expander.assert_called_once()
-        _, kwargs = mock_sidebar.expander.call_args
-        self.assertFalse(kwargs.get("expanded"), "Expander should be collapsed when path exists")
-        mock_warning.assert_not_called()
+        plugin_instance.get_health_status.assert_called_once()
+
+    def test_render_sidebar_shows_error_badge_for_missing_path(self) -> None:
+        """When health status is 'error', sidebar markdown includes the ❌ badge."""
+        plugin_instance = self._make_plugin("")
+        plugin_instance.get_health_status.return_value = {
+            "status": "error",
+            "record_count": None,
+            "last_fetch": None,
+            "data_path": "/gone.csv",
+        }
+        plugin_cls = MagicMock(return_value=plugin_instance)
+
+        markdown_calls: list[str] = []
+
+        session: dict = {}
+        with (
+            patch("streamlit.session_state", session),
+            patch("components.plugin_config.settings") as mock_settings,
+            patch("components.sidebar.settings", mock_settings),
+            patch("components.sidebar.REGISTRY", {"lastfm": plugin_cls}),
+            patch("components.sidebar.load_builtin_plugins"),
+            patch("components.sidebar.load_config_into_session_state"),
+            patch("streamlit.sidebar") as mock_sidebar,
+            patch("components.sidebar.os.path.exists", return_value=False),
+        ):
+            mock_settings.get_fetch_history.return_value = []
+            mock_sidebar.button.return_value = False
+            mock_sidebar.markdown.side_effect = lambda s, **_kw: markdown_calls.append(s)
+
+            from components.sidebar import render_sidebar
+
+            render_sidebar()
+
+        badge_lines = [c for c in markdown_calls if "❌" in c]
+        self.assertTrue(len(badge_lines) > 0, "Expected ❌ badge in sidebar markdown")
 
 
 class TestConfigPersistence(unittest.TestCase):
@@ -210,7 +185,7 @@ class TestConfigPersistence(unittest.TestCase):
     def test_load_config_hydrates_session_state(self) -> None:
         mock_settings = self._make_settings({"lastfm": {"data_path": "/hydrated/path"}})
         session: dict[str, object] = {}
-        with patch("components.sidebar._settings", mock_settings):
+        with patch("components.plugin_config.settings", mock_settings):
             with patch("streamlit.session_state", session):
                 _load_config_into_session_state()
         self.assertEqual(session.get("lastfm_data_path"), "/hydrated/path")
@@ -218,7 +193,7 @@ class TestConfigPersistence(unittest.TestCase):
     def test_load_config_does_not_overwrite_existing_session_state(self) -> None:
         mock_settings = self._make_settings({"lastfm": {"data_path": "/from/disk"}})
         session: dict[str, object] = {"lastfm_data_path": "/already/set"}
-        with patch("components.sidebar._settings", mock_settings):
+        with patch("components.plugin_config.settings", mock_settings):
             with patch("streamlit.session_state", session):
                 _load_config_into_session_state()
         self.assertEqual(session["lastfm_data_path"], "/already/set")
@@ -226,7 +201,7 @@ class TestConfigPersistence(unittest.TestCase):
     def test_load_config_runs_only_once_per_session(self) -> None:
         mock_settings = self._make_settings({"lastfm": {"data_path": "/once"}})
         session: dict[str, object] = {"_autobio_config_loaded": True}
-        with patch("components.sidebar._settings", mock_settings):
+        with patch("components.plugin_config.settings", mock_settings):
             with patch("streamlit.session_state", session):
                 _load_config_into_session_state()
         # Key must NOT be loaded because config was already marked loaded.
@@ -240,7 +215,7 @@ class TestConfigPersistence(unittest.TestCase):
             }
         )
         session: dict[str, object] = {}
-        with patch("components.sidebar._settings", mock_settings):
+        with patch("components.plugin_config.settings", mock_settings):
             with patch("streamlit.session_state", session):
                 _load_config_into_session_state()
         self.assertEqual(session.get("lastfm_data_path"), "/tracks.csv")

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -198,14 +198,15 @@ class TestConfigPersistence(unittest.TestCase):
                 _load_config_into_session_state()
         self.assertEqual(session["lastfm_data_path"], "/already/set")
 
-    def test_load_config_runs_only_once_per_session(self) -> None:
-        mock_settings = self._make_settings({"lastfm": {"data_path": "/once"}})
-        session: dict[str, object] = {"_autobio_config_loaded": True}
+    def test_load_config_restores_cleared_widget_state(self) -> None:
+        # Simulates Streamlit clearing widget-bound keys during page navigation.
+        # On return to the page the key is absent, so load_config should restore it.
+        mock_settings = self._make_settings({"lastfm": {"data_path": "/saved/path"}})
+        session: dict[str, object] = {}  # key absent — as if Streamlit cleared it
         with patch("components.plugin_config.settings", mock_settings):
             with patch("streamlit.session_state", session):
                 _load_config_into_session_state()
-        # Key must NOT be loaded because config was already marked loaded.
-        self.assertNotIn("lastfm_data_path", session)
+        self.assertEqual(session.get("lastfm_data_path"), "/saved/path")
 
     def test_load_config_hydrates_multiple_plugins(self) -> None:
         mock_settings = self._make_settings(

--- a/visualize.py
+++ b/visualize.py
@@ -17,6 +17,7 @@ from dotenv import load_dotenv
 from components.sidebar import render_sidebar
 from pages.beer import render_beer
 from pages.culture import render_culture
+from pages.data_sources import render_data_sources
 from pages.fitness import render_fitness
 from pages.insights import render_insights, render_insights_and_narrative  # noqa: F401
 from pages.music import render_music, render_timeline_analysis  # noqa: F401
@@ -94,6 +95,9 @@ def main() -> None:
             "Culture": [
                 st.Page(render_culture, title="Films & Books", icon=":material/local_library:"),
                 st.Page(render_beer, title="Beer", icon=":material/sports_bar:"),
+            ],
+            "Sources": [
+                st.Page(render_data_sources, title="Data Sources", icon=":material/database:"),
             ],
         }
     )

--- a/visualize.py
+++ b/visualize.py
@@ -65,6 +65,7 @@ def main() -> None:
                 partial(render_plugin_page, plugin_id),
                 title=plugin.DISPLAY_NAME,
                 icon=plugin.ICON,
+                url_path=plugin_id,
             )
         )
 

--- a/visualize.py
+++ b/visualize.py
@@ -11,24 +11,27 @@ Run with::
 
 from __future__ import annotations
 
+from functools import partial
+
 import streamlit as st
 from dotenv import load_dotenv
 
 from components.sidebar import render_sidebar
 from pages.beer import render_beer
 from pages.culture import render_culture
-from pages.data_sources import render_data_sources
+from pages.data_sources import render_data_sources, render_plugin_page
 from pages.fitness import render_fitness
 from pages.insights import render_insights, render_insights_and_narrative  # noqa: F401
 from pages.music import render_music, render_timeline_analysis  # noqa: F401
 from pages.overview import render_overview, render_top_charts  # noqa: F401
 from pages.places import render_places, render_spatial_analysis  # noqa: F401
+from plugins.sources import REGISTRY, load_builtin_plugins
 
 load_dotenv()
 
 _SIDEBAR_CSS = """
 <style>
-/* ── Data Sources section header ──────────────────────────────────────────
+/* ── Section headers ──────────────────────────────────────────────────────
    Matches the st.navigation group-label style: small, uppercase, muted.    */
 .autobio-section-header {
     font-size: 0.75rem;
@@ -40,32 +43,6 @@ _SIDEBAR_CSS = """
     padding-left: 0.5rem;
     line-height: 1.5;
 }
-
-/* ── Plugin expanders ─────────────────────────────────────────────────────
-   Strip the bordered-box styling so each plugin reads as a flat list item
-   (matching the visual weight of "Listening" / "Check-ins" nav items).     */
-section[data-testid="stSidebar"] div[data-testid="stExpander"] > details {
-    border: none !important;
-    box-shadow: none !important;
-    background: transparent !important;
-}
-
-/* Summary row (collapsed toggle) — same size and padding as a nav item */
-section[data-testid="stSidebar"] div[data-testid="stExpander"] summary {
-    font-size: 0.875rem;
-    font-weight: 400;
-    padding: 0.35rem 0.6rem;
-    border-radius: 0.4rem;
-}
-
-section[data-testid="stSidebar"] div[data-testid="stExpander"] summary:hover {
-    background-color: rgba(255, 255, 255, 0.07);
-}
-
-/* Indent the expanded content slightly, like a nav sub-section */
-section[data-testid="stSidebar"] div[data-testid="stExpander"] details > div {
-    padding-left: 0.75rem;
-}
 </style>
 """
 
@@ -74,6 +51,22 @@ def main() -> None:
     """Configure and launch the Autobiographer multi-page dashboard."""
     st.set_page_config(page_title="Autobiographer", layout="wide")
     st.markdown(_SIDEBAR_CSS, unsafe_allow_html=True)
+
+    # Populate REGISTRY before building nav so plugin pages can be listed.
+    load_builtin_plugins()
+
+    sources_pages = [
+        st.Page(render_data_sources, title="Data Sources", icon=":material/database:"),
+    ]
+    for plugin_id, plugin_cls in REGISTRY.items():
+        plugin = plugin_cls()
+        sources_pages.append(
+            st.Page(
+                partial(render_plugin_page, plugin_id),
+                title=plugin.DISPLAY_NAME,
+                icon=plugin.ICON,
+            )
+        )
 
     pg = st.navigation(
         {
@@ -94,14 +87,11 @@ def main() -> None:
                 st.Page(render_culture, title="Films & Books", icon=":material/local_library:"),
                 st.Page(render_beer, title="Beer", icon=":material/sports_bar:"),
             ],
-            "Sources": [
-                st.Page(render_data_sources, title="Data Sources", icon=":material/database:"),
-            ],
+            "Sources": sources_pages,
         }
     )
 
-    # render_sidebar after st.navigation so health badges + cache controls
-    # appear below the navigation list in the sidebar, not above it.
+    # render_sidebar after st.navigation so it appears below the nav list.
     render_sidebar()
 
     pg.run()

--- a/visualize.py
+++ b/visualize.py
@@ -75,8 +75,6 @@ def main() -> None:
     st.set_page_config(page_title="Autobiographer", layout="wide")
     st.markdown(_SIDEBAR_CSS, unsafe_allow_html=True)
 
-    render_sidebar()
-
     pg = st.navigation(
         {
             "Overview": [
@@ -101,6 +99,11 @@ def main() -> None:
             ],
         }
     )
+
+    # render_sidebar after st.navigation so health badges + cache controls
+    # appear below the navigation list in the sidebar, not above it.
+    render_sidebar()
+
     pg.run()
 
 


### PR DESCRIPTION
Closes #41, closes #48

## Summary

- **New `pages/data_sources.py`** — dedicated "Data Sources" page in the nav with `st.tabs()` per plugin. Each tab has a Status card (health badge + record count + last fetch date), Configuration fields, a Fetch section with live progress console, and a versioned Fetch History table with "Use this version" rollback
- **Health status system** — `SourcePlugin.get_health_status()` returns `healthy / stale / error / unconfigured` based on fetch history or file mtime fallback; staleness threshold configurable via `AUTOBIO_STALE_THRESHOLD_HOURS` (default 24h)
- **Versioned fetch snapshots** — each fetch saves to a timestamped file (e.g. `lastfm_johndoe_tracks_2026-04-28T120000.csv`); history stored in `local_settings.json` (max 20 entries)
- **Simplified sidebar** — plugin expanders replaced with compact one-line health badges (`✅ / ⚠️ / ❌ / ◻️`); all config and fetch controls live on the Data Sources page
- **Shared `components/plugin_config.py`** — config rendering utilities extracted from sidebar so both the sidebar and Data Sources page reuse the same path-input widgets

## Test plan

- [ ] `streamlit run visualize.py` — confirm "Data Sources" nav entry appears under "Sources"
- [ ] Navigate to Data Sources — confirm tabs render for Last.fm, Swarm, Assumptions
- [ ] Health badges appear in sidebar for all plugins
- [ ] Configure a plugin path on Data Sources page → persists after page reload
- [ ] Fetch Last.fm (with env vars set) → versioned file created, history row appears, active path updates
- [ ] "→" button on a history row switches the active path
- [ ] Stale badge appears after `AUTOBIO_STALE_THRESHOLD_HOURS=0` with an old fetch
- [ ] `pytest tests/` — 183 tests pass, 73% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)