### PR TITLE
feat: plugin-centric fetch workflow with list subcommand (closes #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 <img src="assets/example%20screenshot%20map.png" style="width: 500">
 
-Autobiographer is a Python-based toolkit that allows you to fetch, store, and explore your personal music listening history (Last.fm) and location history (Foursquare/Swarm). It transforms your data into an interactive autobiographical experience, highlighting your top artists, listening patterns, milestones, and travel history.
+Autobiographer is a Python-based toolkit that lets you fetch, store, and explore your personal life data through a plugin system. Each plugin owns one data source — music listening (Last.fm), location check-ins (Foursquare/Swarm), and more — and exposes a unified fetch-and-display workflow. It transforms your data into an interactive autobiographical experience, highlighting your top artists, listening patterns, milestones, and travel history.
 
 
 <img src="assets/example%20screenshot%20stats.png" style="width: 500">
 
 ## Features
 
-- **Data Fetching**: Securely fetch your entire listening history using the Last.fm API.
+- **Plugin-Based Data Fetching**: Each source plugin handles its own fetch workflow. Plugins that support automatic retrieval (e.g. Last.fm) download data with one command; plugins that require a manual export (e.g. Foursquare/Swarm) print step-by-step instructions. Run `python autobiographer.py list` to see every plugin's status and required configuration.
 - **Interactive Dashboard**: A multi-tab Streamlit dashboard with:
     - **Overview**: Top Artists, Albums, and Tracks.
     - **Timeline**: Daily, Weekly, and Monthly listening activity with cumulative growth.
@@ -104,6 +104,15 @@ Get a Last.fm API key at: https://www.last.fm/api/account/create
 
 #### Fetch Your Data
 
+Start by listing available plugins to see what each one needs:
+
+```bash
+python autobiographer.py list
+```
+
+This prints every plugin with its fetch mode (auto or manual), required environment
+variables with a ✓/✗ status for each, and the exact command to run.
+
 The `fetch` command targets a specific plugin. Plugins that support automatic download
 will retrieve your data; plugins that require a manual export will print step-by-step
 instructions instead.
@@ -123,10 +132,10 @@ python autobiographer.py fetch lastfm --from-date 2024-01-01 --to-date 2024-12-3
 python autobiographer.py fetch lastfm --output data/my_tracks.csv
 ```
 
-If a plugin is not yet configured the command will list exactly which environment
+If a plugin is not yet configured the `fetch` command lists exactly which environment
 variables are missing and what each one is for.
 
-The app sidebar also exposes this directly: a **Fetch Latest Data** button appears for
+The app also exposes fetch directly: a **Fetch Latest Data** button appears for
 plugins that support automatic retrieval, and step-by-step manual instructions are
 shown for plugins that require a data export from the provider.
 
@@ -241,7 +250,7 @@ Additional utility scripts are available in the `tools/` directory:
 ## Project Structure
 
 ```
-autobiographer.py       # Data-fetching CLI (`fetch <plugin>`) + Last.fm API client
+autobiographer.py       # Data-fetching CLI (`list`, `fetch <plugin>`) + Last.fm API client
 visualize.py            # Streamlit dashboard (assembles views from plugins)
 export_html.py          # Static HTML export — single self-contained report file
 analysis_utils.py       # Shared data processing and caching logic

--- a/autobiographer.py
+++ b/autobiographer.py
@@ -131,6 +131,38 @@ def _parse_date(date_str: str, label: str) -> Optional[int]:
         raise SystemExit(1) from exc
 
 
+def _run_list() -> None:
+    """Execute the ``list`` subcommand.
+
+    Prints every registered plugin with its display name, type, fetchability,
+    and the configuration it requires so users can discover what is available
+    and what they need to set up before running ``fetch``.
+    """
+    from plugins.sources import REGISTRY, load_builtin_plugins
+
+    load_builtin_plugins()
+
+    if not REGISTRY:
+        print("No plugins registered.")
+        return
+
+    for plugin_id in sorted(REGISTRY):
+        plugin = REGISTRY[plugin_id]()
+        fetch_label = "auto-fetch" if plugin.FETCHABLE else "manual export"
+        print(f"\n{plugin.DISPLAY_NAME} ({plugin_id})  [{plugin.PLUGIN_TYPE} · {fetch_label}]")
+
+        if plugin.FETCHABLE:
+            env_vars = plugin.get_fetch_env_vars()
+            if env_vars:
+                print("  Required environment variables:")
+                for v in env_vars:
+                    status = "✓" if os.getenv(v["var"]) else "✗ missing"
+                    print(f"    {v['var']}  —  {v['description']}  [{status}]")
+            print(f"  Fetch command:  python autobiographer.py fetch {plugin_id}")
+        else:
+            print("  " + plugin.get_manual_download_instructions().replace("\n", "\n  "))
+
+
 def _run_fetch(args: argparse.Namespace) -> None:
     """Execute the ``fetch`` subcommand.
 
@@ -190,6 +222,9 @@ def main() -> None:
 
     Subcommands
     -----------
+    list
+        Print all registered plugins with their fetchability, required
+        environment variables, and configuration instructions.
     fetch <plugin>
         Fetch data for the named plugin. For plugins that support programmatic
         retrieval (e.g. ``lastfm``) this downloads and saves data locally.
@@ -200,6 +235,7 @@ def main() -> None:
     --------
     ::
 
+        python autobiographer.py list
         python autobiographer.py fetch lastfm
         python autobiographer.py fetch lastfm --pages 5
         python autobiographer.py fetch lastfm --from-date 2024-01-01
@@ -210,6 +246,15 @@ def main() -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
+
+    subparsers.add_parser(
+        "list",
+        help="List all registered plugins with their configuration requirements.",
+        description=(
+            "Print every registered source plugin with its display name, type, "
+            "fetchability, and required environment variables or manual export instructions."
+        ),
+    )
 
     fetch_parser = subparsers.add_parser(
         "fetch",
@@ -253,6 +298,8 @@ def main() -> None:
 
     if args.command == "fetch":
         _run_fetch(args)
+    elif args.command == "list":
+        _run_list()
     else:
         parser.print_help()
 

--- a/tests/test_autobiographer.py
+++ b/tests/test_autobiographer.py
@@ -216,5 +216,98 @@ class TestRunFetch(unittest.TestCase):
         self.assertEqual(to_ts, expected_base + 86399)
 
 
+class TestRunList(unittest.TestCase):
+    """Tests for the _run_list CLI subcommand."""
+
+    def _make_fetchable_plugin(self) -> MagicMock:
+        plugin = MagicMock()
+        plugin.FETCHABLE = True
+        plugin.DISPLAY_NAME = "Auto Plugin"
+        plugin.PLUGIN_TYPE = "what-when"
+        plugin.get_fetch_env_vars.return_value = [
+            {"var": "AUTOBIO_AUTO_KEY", "description": "An API key"}
+        ]
+        plugin.get_manual_download_instructions.return_value = "Auto plugin instructions."
+        return plugin
+
+    def _make_manual_plugin(self) -> MagicMock:
+        plugin = MagicMock()
+        plugin.FETCHABLE = False
+        plugin.DISPLAY_NAME = "Manual Plugin"
+        plugin.PLUGIN_TYPE = "where-when"
+        plugin.get_fetch_env_vars.return_value = []
+        plugin.get_manual_download_instructions.return_value = "Export from the website."
+        return plugin
+
+    def test_empty_registry_prints_message(self):
+        from autobiographer import _run_list
+
+        with (
+            patch("plugins.sources.load_builtin_plugins"),
+            patch("plugins.sources.REGISTRY", {}),
+            patch("builtins.print") as mock_print,
+        ):
+            _run_list()
+
+        printed = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("No plugins", printed)
+
+    def test_fetchable_plugin_shows_env_vars(self):
+        from autobiographer import _run_list
+
+        plugin = self._make_fetchable_plugin()
+        fake_cls = MagicMock(return_value=plugin)
+
+        with (
+            patch("plugins.sources.load_builtin_plugins"),
+            patch("plugins.sources.REGISTRY", {"autoplugin": fake_cls}),
+            patch("os.getenv", return_value=None),
+            patch("builtins.print") as mock_print,
+        ):
+            _run_list()
+
+        printed = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("AUTOBIO_AUTO_KEY", printed)
+        self.assertIn("fetch autoplugin", printed)
+
+    def test_manual_plugin_shows_instructions(self):
+        from autobiographer import _run_list
+
+        plugin = self._make_manual_plugin()
+        fake_cls = MagicMock(return_value=plugin)
+
+        with (
+            patch("plugins.sources.load_builtin_plugins"),
+            patch("plugins.sources.REGISTRY", {"manualplugin": fake_cls}),
+            patch("builtins.print") as mock_print,
+        ):
+            _run_list()
+
+        printed = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("Export from the website.", printed)
+
+    def test_configured_env_var_shows_check(self):
+        from autobiographer import _run_list
+
+        plugin = self._make_fetchable_plugin()
+        fake_cls = MagicMock(return_value=plugin)
+
+        def fake_getenv(var: str, default: str = "") -> str:
+            if var == "AUTOBIO_AUTO_KEY":
+                return "secret"
+            return default
+
+        with (
+            patch("plugins.sources.load_builtin_plugins"),
+            patch("plugins.sources.REGISTRY", {"autoplugin": fake_cls}),
+            patch("os.getenv", side_effect=fake_getenv),
+            patch("builtins.print") as mock_print,
+        ):
+            _run_list()
+
+        printed = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("✓", printed)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds `python autobiographer.py list` subcommand that prints every registered plugin with its display name, type (what-when/where-when), fetch mode (auto/manual), required env vars with live ✓/✗ configured status, and the exact `fetch` command or manual export instructions
- Updates README intro paragraph and Features section to describe the plugin-based fetch system rather than implying Last.fm-only data fetching
- Adds 4 unit tests for `_run_list` covering empty registry, fetchable plugins, manual plugins, and env-var configured/missing states

Most of the underlying CLI and App UI functionality (fetch subcommand, env-var validation, manual-export instructions, Fetch button in Data Sources page) was already implemented in PRs #47 and #50. This PR completes #45 by adding the discovery/listing command and bringing the README in line with the plugin architecture.

## Test plan

- [ ] `python autobiographer.py list` — prints all three plugins with their status
- [ ] `python autobiographer.py list` with env vars unset — shows ✗ missing for Last.fm vars
- [ ] `python autobiographer.py list` with env vars set — shows ✓ for configured vars
- [ ] All 189 tests pass: `pytest`
- [ ] Quality gate: `ruff check . && ruff format --check . && mypy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)