### PR TITLE
feat: music visualization overhaul — streamgraph, bump chart, sunburst

### DIFF
--- a/analysis_utils.py
+++ b/analysis_utils.py
@@ -709,3 +709,56 @@ def get_hourly_distribution(df: pd.DataFrame) -> pd.DataFrame:
     df_copy["hour"] = df_copy["date_text"].dt.hour
     hourly = df_copy.groupby("hour").size().reset_index(name="Plays")
     return hourly
+
+
+def get_genre_weekly(df: pd.DataFrame, n: int = 8) -> pd.DataFrame:
+    """Return weekly scrobble counts for the top N artists.
+
+    Because Last.fm exports do not include genre tags, artist name is used as
+    the grouping dimension.  The column is named ``genre`` for compatibility
+    with generic streamgraph rendering code.
+
+    Args:
+        df: Listening history with ``artist`` and ``date_text`` columns.
+        n: Number of top artists (by total plays) to include.
+
+    Returns:
+        DataFrame with columns ``date`` (ISO-week Monday as Timestamp),
+        ``genre`` (artist name), and ``scrobbles`` (int).
+    """
+    if df.empty or "artist" not in df.columns or "date_text" not in df.columns:
+        return pd.DataFrame(columns=["date", "genre", "scrobbles"])
+
+    top_artists = df["artist"].value_counts().head(n).index.tolist()
+    subset = df[df["artist"].isin(top_artists)].copy()
+    subset["date"] = subset["date_text"].dt.to_period("W").dt.start_time
+    weekly = subset.groupby(["date", "artist"]).size().reset_index(name="scrobbles")
+    return weekly.rename(columns={"artist": "genre"})
+
+
+def get_artist_monthly_ranks(df: pd.DataFrame, n: int = 10) -> pd.DataFrame:
+    """Return monthly rank positions for the top N artists overall.
+
+    Ranks are computed per-month: rank 1 = most scrobbles in that month.
+    Only the top ``n`` artists by all-time play count are tracked.
+
+    Args:
+        df: Listening history with ``artist`` and ``date_text`` columns.
+        n: Number of top artists to track.
+
+    Returns:
+        DataFrame with columns ``month`` (first-day Timestamp), ``artist``
+        (str), and ``rank`` (int, 1 = most played).
+    """
+    if df.empty or "artist" not in df.columns or "date_text" not in df.columns:
+        return pd.DataFrame(columns=["month", "artist", "rank"])
+
+    top_artists = df["artist"].value_counts().head(n).index.tolist()
+    subset = df[df["artist"].isin(top_artists)].copy()
+    subset["month"] = subset["date_text"].dt.to_period("M").dt.to_timestamp()
+
+    monthly = subset.groupby(["month", "artist"]).size().reset_index(name="plays")
+    monthly["rank"] = (
+        monthly.groupby("month")["plays"].rank(method="min", ascending=False).astype(int)
+    )
+    return monthly[["month", "artist", "rank"]]

--- a/pages/insights.py
+++ b/pages/insights.py
@@ -14,7 +14,7 @@ from analysis_utils import (
     get_top_entities,
     get_unique_entities,
 )
-from components.theme import SEQUENTIAL_SCALE, apply_dark_theme
+from components.theme import COLORWAY, SEQUENTIAL_SCALE, apply_dark_theme
 
 
 def render_insights_and_narrative(df: DataFrame) -> None:
@@ -55,6 +55,22 @@ def render_insights_and_narrative(df: DataFrame) -> None:
     if filtered_df.empty:
         st.warning("No data found for the selected granular filters.")
     else:
+        if "album" in filtered_df.columns:
+            top_artists = get_top_entities(filtered_df, "artist", limit=12)["artist"].tolist()
+            subset = filtered_df[filtered_df["artist"].isin(top_artists)].copy()
+            grouped = subset.groupby(["artist", "album"]).size().reset_index(name="scrobbles")
+            fig_sun = px.sunburst(
+                grouped,
+                path=["artist", "album"],
+                values="scrobbles",
+                title="Music Listening Hierarchy",
+                color_discrete_sequence=COLORWAY,
+            )
+            fig_sun.update_traces(textinfo="label+percent parent")
+            apply_dark_theme(fig_sun)
+            st.plotly_chart(fig_sun, width="stretch")
+
+        st.markdown("---")
         col_top1, col_top2 = st.columns(2)
 
         with col_top1:
@@ -156,6 +172,7 @@ def render_insights_and_narrative(df: DataFrame) -> None:
         st.dataframe(forgotten, hide_index=True)
     else:
         st.info("No forgotten favorites identified.")
+
 
 
 def render_insights() -> None:

--- a/pages/insights.py
+++ b/pages/insights.py
@@ -174,7 +174,6 @@ def render_insights_and_narrative(df: DataFrame) -> None:
         st.info("No forgotten favorites identified.")
 
 
-
 def render_insights() -> None:
     """Render the Insights page.
 

--- a/pages/music.py
+++ b/pages/music.py
@@ -6,15 +6,26 @@ import datetime
 
 import pandas as pd
 import plotly.express as px
+import plotly.graph_objects as go
 import streamlit as st
 
 from analysis_utils import (
+    get_artist_monthly_ranks,
     get_cumulative_plays,
+    get_genre_weekly,
     get_hourly_distribution,
     get_listening_intensity,
     get_top_entities,
 )
-from components.theme import AMBER, TEAL, apply_dark_theme, card_container
+from components.theme import (
+    ACCENT_INDIGO,
+    AMBER,
+    COLORWAY,
+    LIFTED_BG,
+    TEAL,
+    apply_dark_theme,
+    card_container,
+)
 
 
 def _filter_by_date(df: pd.DataFrame, start: datetime.date, end: datetime.date) -> pd.DataFrame:
@@ -224,7 +235,11 @@ def render_plays_growth(filtered: pd.DataFrame) -> None:
 
 
 def render_top_charts(df: pd.DataFrame) -> None:
-    """Render top entity charts with a type toggle.
+    """Render top entity charts with rank badges and a type toggle.
+
+    The #1 entry is highlighted in indigo; remaining bars use the lifted
+    background colour.  A scrobble count label appears outside each bar and
+    a rank badge is embedded in the y-axis label.
 
     Args:
         df: Loaded listening history DataFrame.
@@ -235,14 +250,26 @@ def render_top_charts(df: pd.DataFrame) -> None:
     top_data = get_top_entities(df, entity_type, limit=limit)
     col1, col2 = st.columns([2, 1])
     with col1:
-        fig_bar = px.bar(
-            top_data,
-            x="Plays",
-            y=entity_type,
-            orientation="h",
-            title=f"Top {limit} {entity_type.capitalize()}s",
+        plays = top_data["Plays"].tolist()
+        ranked_labels = [f"#{r}  {n}" for r, n in enumerate(top_data[entity_type], 1)]
+        colors = [ACCENT_INDIGO] + [LIFTED_BG] * (len(top_data) - 1)
+
+        fig_bar = go.Figure(
+            go.Bar(
+                x=plays,
+                y=ranked_labels,
+                orientation="h",
+                marker_color=colors,
+                text=[f"{p:,}" for p in plays],
+                textposition="outside",
+                cliponaxis=False,
+            )
         )
-        fig_bar.update_layout(yaxis={"categoryorder": "total ascending"})
+        fig_bar.update_layout(
+            title=f"Top {limit} {entity_type.capitalize()}s",
+            yaxis={"categoryorder": "total ascending"},
+            margin={"r": 80},
+        )
         apply_dark_theme(fig_bar)
         st.plotly_chart(fig_bar, width="stretch")
     with col2:
@@ -253,13 +280,65 @@ def render_top_charts(df: pd.DataFrame) -> None:
         st.plotly_chart(fig_pie, width="stretch")
 
 
-def render_activity_over_time(df: pd.DataFrame) -> None:
-    """Render all-time listening intensity and cumulative growth charts.
+def render_streamgraph(df: pd.DataFrame) -> None:
+    """Render a stacked-area streamgraph of top-artist scrobble volume by week.
+
+    Uses artist as the category dimension because Last.fm exports do not
+    include genre tags.
 
     Args:
-        df: Full listening history DataFrame.
+        df: Listening history DataFrame (already filtered to the selected date range).
     """
-    st.subheader("All-Time Activity")
+    weekly = get_genre_weekly(df)
+    if weekly.empty:
+        return
+    fig = px.area(
+        weekly,
+        x="date",
+        y="scrobbles",
+        color="genre",
+        title="Artist Listening Timeline",
+        color_discrete_sequence=COLORWAY,
+        labels={"genre": "Artist", "scrobbles": "Scrobbles", "date": ""},
+    )
+    fig.update_layout(legend_title_text="Artist")
+    apply_dark_theme(fig)
+    st.plotly_chart(fig, width="stretch")
+
+
+def render_bump_chart(df: pd.DataFrame) -> None:
+    """Render a monthly artist rank bump chart for the top 10 artists.
+
+    Hidden when fewer than two months of data are available.
+
+    Args:
+        df: Listening history DataFrame (already filtered to the selected date range).
+    """
+    ranks = get_artist_monthly_ranks(df)
+    if ranks.empty or ranks["month"].nunique() < 2:
+        return
+    fig = px.line(
+        ranks,
+        x="month",
+        y="rank",
+        color="artist",
+        title="Artist Rank Over Time",
+        color_discrete_sequence=COLORWAY,
+        labels={"month": "", "rank": "Rank", "artist": "Artist"},
+        markers=True,
+    )
+    fig.update_yaxes(autorange="reversed", dtick=1, title="Rank")
+    apply_dark_theme(fig)
+    st.plotly_chart(fig, width="stretch")
+
+
+def render_activity_over_time(df: pd.DataFrame) -> None:
+    """Render listening intensity and cumulative growth charts for the given period.
+
+    Args:
+        df: Listening history DataFrame (already filtered to the selected date range).
+    """
+    st.subheader("Activity Over Time")
     freq_map = {"Daily": "D", "Weekly": "W", "Monthly": "ME"}
     freq_label = st.selectbox("Grouping", list(freq_map.keys()))
     intensity = get_listening_intensity(df, freq_map[freq_label])
@@ -268,7 +347,7 @@ def render_activity_over_time(df: pd.DataFrame) -> None:
     st.plotly_chart(fig, width="stretch")
 
     cumulative = get_cumulative_plays(df)
-    fig2 = px.area(cumulative, x="date", y="CumulativePlays", title="All-Time Total Plays")
+    fig2 = px.area(cumulative, x="date", y="CumulativePlays", title="Total Plays")
     fig2.update_traces(line_color=TEAL, fillcolor="rgba(0,200,200,0.15)")
     apply_dark_theme(fig2)
     st.plotly_chart(fig2, width="stretch")
@@ -317,7 +396,9 @@ def render_music() -> None:
 
     st.divider()
     with card_container():
-        render_top_charts(df)
+        render_top_charts(filtered)
 
     st.divider()
-    render_activity_over_time(df)
+    render_streamgraph(filtered)
+    render_bump_chart(filtered)
+    render_activity_over_time(filtered)

--- a/tests/test_analysis_utils.py
+++ b/tests/test_analysis_utils.py
@@ -4,8 +4,10 @@ import unittest
 import pandas as pd
 
 from analysis_utils import (
+    get_artist_monthly_ranks,
     get_cumulative_plays,
     get_forgotten_favorites,
+    get_genre_weekly,
     get_hourly_distribution,
     get_listening_intensity,
     get_listening_streaks,
@@ -111,6 +113,56 @@ class TestAnalysisUtils(unittest.TestCase):
         self.assertEqual(len(hourly), 2)  # Hour 10 and 11
         self.assertEqual(hourly[hourly["hour"] == 10].iloc[0]["Plays"], 2)
         self.assertEqual(hourly[hourly["hour"] == 11].iloc[0]["Plays"], 1)
+
+    def test_get_genre_weekly_returns_expected_columns(self):
+        dates = pd.to_datetime(["2021-01-04", "2021-01-04", "2021-01-11", "2021-01-11"])
+        df = pd.DataFrame(
+            {
+                "artist": ["Artist A", "Artist B", "Artist A", "Artist A"],
+                "date_text": dates,
+            }
+        )
+        result = get_genre_weekly(df, n=5)
+        self.assertListEqual(list(result.columns), ["date", "genre", "scrobbles"])
+
+    def test_get_genre_weekly_aggregates_correctly(self):
+        dates = pd.to_datetime(["2021-01-04", "2021-01-04", "2021-01-11"])
+        df = pd.DataFrame({"artist": ["Artist A", "Artist A", "Artist A"], "date_text": dates})
+        result = get_genre_weekly(df, n=2)
+        self.assertEqual(result["scrobbles"].sum(), 3)
+        self.assertEqual(len(result), 2)  # two distinct weeks
+
+    def test_get_genre_weekly_empty(self):
+        empty = pd.DataFrame(columns=["artist", "date_text"])
+        result = get_genre_weekly(empty)
+        self.assertTrue(result.empty)
+
+    def test_get_genre_weekly_limits_to_top_n(self):
+        dates = pd.to_datetime(["2021-01-04"] * 5)
+        df = pd.DataFrame({"artist": ["A", "B", "C", "D", "E"], "date_text": dates})
+        result = get_genre_weekly(df, n=3)
+        self.assertLessEqual(result["genre"].nunique(), 3)
+
+    def test_get_artist_monthly_ranks_columns(self):
+        dates = pd.to_datetime(["2021-01-15", "2021-01-20", "2021-02-10"])
+        df = pd.DataFrame({"artist": ["Artist A", "Artist B", "Artist A"], "date_text": dates})
+        result = get_artist_monthly_ranks(df, n=5)
+        self.assertListEqual(list(result.columns), ["month", "artist", "rank"])
+
+    def test_get_artist_monthly_ranks_rank_1_is_highest_plays(self):
+        dates = pd.to_datetime(["2021-01-01"] * 3 + ["2021-01-02"])
+        df = pd.DataFrame(
+            {"artist": ["Artist A", "Artist A", "Artist A", "Artist B"], "date_text": dates}
+        )
+        result = get_artist_monthly_ranks(df, n=2)
+        jan = result[result["month"].dt.month == 1]
+        rank1_artist = jan.loc[jan["rank"] == 1, "artist"].values[0]
+        self.assertEqual(rank1_artist, "Artist A")
+
+    def test_get_artist_monthly_ranks_empty(self):
+        empty = pd.DataFrame(columns=["artist", "date_text"])
+        result = get_artist_monthly_ranks(empty)
+        self.assertTrue(result.empty)
 
 
 if __name__ == "__main__":

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -324,7 +324,7 @@ class TestVisualize(unittest.TestCase):
 
         render_activity_over_time(self.df)
 
-        mock_subheader.assert_called_with("All-Time Activity")
+        mock_subheader.assert_called_with("Activity Over Time")
         self.assertEqual(mock_plotly.call_count, 2)
         mock_plotly.assert_any_call(ANY, width="stretch")
 


### PR DESCRIPTION
## Summary

- Adds `get_genre_weekly()` and `get_artist_monthly_ranks()` to `analysis_utils.py` with full type annotations, docstrings, and unit tests
- Replaces the top-artists vertical bar with a styled horizontal bar: indigo for #1, `LIFTED_BG` for the rest, rank badge in each label, scrobble count outside each bar
- Adds a stacked-area streamgraph (top artists by week) and a monthly rank bump chart (rank 1 at top, hidden if < 2 months of data) to the Music page
- Adds an artist → album sunburst to the Insights page, above "Top Artists & Tracks", respecting all active filters
- All charts on the Music page are now constrained by the date-range picker at the top

Closes #25

## Test plan

- [x] `ruff check .`, `mypy`, and `pytest` all pass (215 tests)
- [x] Streamgraph renders and stacks correctly with ≥ 4 weeks of data
- [x] Bump chart appears with multi-month data; hidden for short ranges
- [x] Top-artists bar shows indigo #1 bar and rank badges
- [x] Sunburst on Insights page drills down on click and updates with filters
- [x] Changing the date range on Music page updates every chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)