### PR TITLE
ci: add pre-push hooks to enforce full quality gate before push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,30 @@ repos:
       - id: mypy
         additional_dependencies:
           - types-requests
+
+  - repo: local
+    hooks:
+      - id: ruff-check-push
+        name: ruff check (pre-push)
+        entry: ruff check .
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+      - id: ruff-format-check-push
+        name: ruff format --check (pre-push)
+        entry: ruff format --check .
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+      - id: mypy-push
+        name: mypy (pre-push)
+        entry: mypy
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+      - id: pytest-push
+        name: pytest (pre-push)
+        entry: pytest
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,3 +85,16 @@ All four commands must exit with code 0. If any fail, fix the reported errors an
 ```bash
 pip install ruff mypy types-requests
 ```
+
+### Installing git hooks (one-time, per clone)
+
+The project uses `pre-commit` to enforce the quality gate automatically. After cloning, run:
+
+```bash
+pre-commit install
+pre-commit install --hook-type pre-push
+```
+
+This installs two hook stages:
+- **pre-commit**: ruff (auto-fix + format) and mypy — fast checks on every commit.
+- **pre-push**: full CI gate (ruff check, ruff format --check, mypy, pytest) — mirrors CI exactly, blocking any push that would fail.


### PR DESCRIPTION
## Summary

- Adds four `pre-push` stage hooks to `.pre-commit-config.yaml` that mirror CI exactly: `ruff check`, `ruff format --check`, `mypy`, and `pytest`
- Keeps the existing `pre-commit` stage hooks (ruff auto-fix + mypy) for fast feedback on every commit
- Documents the one-time `pre-commit install --hook-type pre-push` setup step in `CLAUDE.md`

## Test plan

- [ ] `pre-commit install && pre-commit install --hook-type pre-push` installs both hook stages cleanly
- [ ] A push with a failing lint/type/test check is blocked by the pre-push hook
- [ ] A clean push completes without interruption

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)