### PR TITLE
feat: Musical Map of America — listening per US state (#57)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,10 @@ This document serves as the foundational mandate for all development work perfor
 *   **Verify installs**: After installing a package, confirm it landed in the venv with `which python` and `pip list` before assuming a fix worked.
 *   **pyproject.toml is canonical**: Any package imported in source must be listed in `pyproject.toml [project.dependencies]`. `requirements.txt` is for local venv convenience only — CI installs from `pyproject.toml`.
 
+## Streamlit API deprecations
+
+*   **`use_container_width` is removed**: Use `width="stretch"` instead of `use_container_width=True`, and `width="content"` instead of `use_container_width=False`. Never write `use_container_width` — it was removed after 2025-12-31.
+
 ## Streamlit Conventions
 
 *   **Widget mock lists**: When adding or removing `st.columns()` calls, update the corresponding `side_effect` lists in any affected tests.

--- a/analysis_utils.py
+++ b/analysis_utils.py
@@ -30,7 +30,7 @@ def get_cache_key(
         key_parts.append(str(os.path.getmtime(assumptions_file)))
 
     # Include version to invalidate cache if logic changes
-    key_parts.append("v1.5")
+    key_parts.append("v1.6")
 
     return hashlib.md5("".join(key_parts).encode(), usedforsecurity=False).hexdigest()  # noqa: S324
 

--- a/components/share.py
+++ b/components/share.py
@@ -23,6 +23,6 @@ def render_share_button(html_bytes: bytes, filename: str) -> None:
             data=html_bytes,
             file_name=filename,
             mime="text/html",
-            use_container_width=True,
+            width="stretch",
             help="Download a self-contained HTML snapshot of this page",
         )

--- a/pages/music_map_america.py
+++ b/pages/music_map_america.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 import pandas as pd
 import plotly.express as px
 import streamlit as st
@@ -71,8 +73,92 @@ _US_STATE_ABBREVS: frozenset[str] = frozenset(
 )
 
 
+_CITY_STATE_RE = re.compile(r",\s*([A-Z]{2})$")
+
+# Full US state/territory names → abbreviations (covers reverse_geocoder admin1 output
+# and Foursquare GDPR exports that return the full state name).
+_STATE_NAME_TO_ABBREV: dict[str, str] = {
+    "alabama": "AL",
+    "alaska": "AK",
+    "arizona": "AZ",
+    "arkansas": "AR",
+    "california": "CA",
+    "colorado": "CO",
+    "connecticut": "CT",
+    "delaware": "DE",
+    "district of columbia": "DC",
+    "florida": "FL",
+    "georgia": "GA",
+    "hawaii": "HI",
+    "idaho": "ID",
+    "illinois": "IL",
+    "indiana": "IN",
+    "iowa": "IA",
+    "kansas": "KS",
+    "kentucky": "KY",
+    "louisiana": "LA",
+    "maine": "ME",
+    "maryland": "MD",
+    "massachusetts": "MA",
+    "michigan": "MI",
+    "minnesota": "MN",
+    "mississippi": "MS",
+    "missouri": "MO",
+    "montana": "MT",
+    "nebraska": "NE",
+    "nevada": "NV",
+    "new hampshire": "NH",
+    "new jersey": "NJ",
+    "new mexico": "NM",
+    "new york": "NY",
+    "north carolina": "NC",
+    "north dakota": "ND",
+    "ohio": "OH",
+    "oklahoma": "OK",
+    "oregon": "OR",
+    "pennsylvania": "PA",
+    "rhode island": "RI",
+    "south carolina": "SC",
+    "south dakota": "SD",
+    "tennessee": "TN",
+    "texas": "TX",
+    "utah": "UT",
+    "vermont": "VT",
+    "virginia": "VA",
+    "washington": "WA",
+    "west virginia": "WV",
+    "wisconsin": "WI",
+    "wyoming": "WY",
+}
+
+
+def _extract_state_abbrev(value: str) -> str:
+    """Return the US state abbreviation from *value*.
+
+    Handles three formats:
+    - Bare abbreviation: ``"IL"``
+    - Full state name (from ``reverse_geocoder`` admin1 or Foursquare GDPR export):
+      ``"Oklahoma"``, ``"New York"``
+    - City-state string (assumptions fallback when no explicit ``state`` key):
+      ``"Anchorage, AK"``
+    """
+    if value in _US_STATE_ABBREVS:
+        return value
+    lower = value.lower()
+    if lower in _STATE_NAME_TO_ABBREV:
+        return _STATE_NAME_TO_ABBREV[lower]
+    m = _CITY_STATE_RE.search(value)
+    if m and m.group(1) in _US_STATE_ABBREVS:
+        return m.group(1)
+    return value
+
+
 def _filter_us_states(df: pd.DataFrame) -> pd.DataFrame:
     """Return only rows whose ``state`` column matches a US state abbreviation.
+
+    Normalises ``"City, ST"`` values (common when assumptions entries lack an
+    explicit ``state`` key) before filtering, and rewrites the ``state`` column
+    so downstream code always sees bare abbreviations.
 
     Args:
         df: Listening history DataFrame, optionally containing a ``state`` column.
@@ -83,8 +169,11 @@ def _filter_us_states(df: pd.DataFrame) -> pd.DataFrame:
     """
     if df.empty or "state" not in df.columns:
         return pd.DataFrame()
-    mask = df["state"].isin(_US_STATE_ABBREVS)
-    return df[mask].copy()
+    normalised = df["state"].astype(str).map(_extract_state_abbrev)
+    mask = normalised.isin(_US_STATE_ABBREVS)
+    result = df[mask].copy()
+    result["state"] = normalised[mask]
+    return result
 
 
 def _build_state_stats(df: pd.DataFrame) -> pd.DataFrame:
@@ -95,7 +184,8 @@ def _build_state_stats(df: pd.DataFrame) -> pd.DataFrame:
     - ``plays`` — total scrobble count.
     - ``top_artist`` — most-played artist in the state.
     - ``top_artists_list`` — ordered list of up to 5 top artists (with play counts).
-    - ``top_track`` — most-played track in the state.
+    - ``top_track`` — most-played track name (for hover tooltip).
+    - ``top_tracks_list`` — ordered list of up to 5 "Artist — Track (N)" strings.
 
     Args:
         df: Listening history filtered to US rows (via :func:`_filter_us_states`).
@@ -119,8 +209,18 @@ def _build_state_stats(df: pd.DataFrame) -> pd.DataFrame:
             else []
         )
 
-        top_tracks_df = get_top_entities(group, "track", limit=1)
-        top_track = top_tracks_df.iloc[0]["track"] if not top_tracks_df.empty else "—"
+        # Top tracks grouped by (artist, track) so each entry carries its artist.
+        if "artist" in group.columns and "track" in group.columns:
+            track_counts = group.groupby(["artist", "track"]).size().reset_index(name="plays_t")
+            track_counts = track_counts.sort_values("plays_t", ascending=False).head(5)
+            top_track = track_counts.iloc[0]["track"] if not track_counts.empty else "—"
+            top_tracks_list = [
+                f"{r['artist']} — {r['track']} ({int(r['plays_t'])})"
+                for _, r in track_counts.iterrows()
+            ]
+        else:
+            top_track = "—"
+            top_tracks_list = []
 
         rows.append(
             {
@@ -129,6 +229,7 @@ def _build_state_stats(df: pd.DataFrame) -> pd.DataFrame:
                 "top_artist": top_artist,
                 "top_artists_list": top_artists_list,
                 "top_track": top_track,
+                "top_tracks_list": top_tracks_list,
             }
         )
 
@@ -150,7 +251,8 @@ def _build_share_html(stats: pd.DataFrame, total_plays: int) -> str:
     """
     rows_html = "".join(
         f"<tr><td>{r['state']}</td><td>{r['plays']:,}</td>"
-        f"<td>{r['top_artist']}</td><td>{r['top_track']}</td></tr>"
+        f"<td>{r['top_artist']}</td>"
+        f"<td>{r['top_tracks_list'][0] if r['top_tracks_list'] else '—'}</td></tr>"
         for _, r in stats.iterrows()
     )
     return f"""<!DOCTYPE html>
@@ -276,8 +378,9 @@ def render_music_map_america() -> None:
             for entry in row["top_artists_list"]:
                 st.markdown(f"- {entry}")
         with col_right:
-            st.markdown("**Top Track**")
-            st.markdown(f"> {row['top_track']}")
+            st.markdown("**Top 5 Tracks**")
+            for entry in row["top_tracks_list"]:
+                st.markdown(f"- {entry}")
 
     # ── Sortable state table ──────────────────────────────────────────────────
     st.subheader("All Visited States")
@@ -289,4 +392,4 @@ def render_music_map_america() -> None:
             "top_track": "Top Track",
         }
     )
-    st.dataframe(display_df, hide_index=True, use_container_width=True)
+    st.dataframe(display_df, hide_index=True, width="stretch")

--- a/pages/music_map_america.py
+++ b/pages/music_map_america.py
@@ -1,0 +1,292 @@
+"""Music Map of America — choropleth scrobble density per US state (issue #57)."""
+
+from __future__ import annotations
+
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+from analysis_utils import get_top_entities
+from components.share import render_share_button
+from components.theme import SEQUENTIAL_SCALE, apply_dark_theme
+
+# ---------------------------------------------------------------------------
+# All valid US state abbreviations (50 states + DC)
+# ---------------------------------------------------------------------------
+
+_US_STATE_ABBREVS: frozenset[str] = frozenset(
+    {
+        "AL",
+        "AK",
+        "AZ",
+        "AR",
+        "CA",
+        "CO",
+        "CT",
+        "DE",
+        "FL",
+        "GA",
+        "HI",
+        "ID",
+        "IL",
+        "IN",
+        "IA",
+        "KS",
+        "KY",
+        "LA",
+        "ME",
+        "MD",
+        "MA",
+        "MI",
+        "MN",
+        "MS",
+        "MO",
+        "MT",
+        "NE",
+        "NV",
+        "NH",
+        "NJ",
+        "NM",
+        "NY",
+        "NC",
+        "ND",
+        "OH",
+        "OK",
+        "OR",
+        "PA",
+        "RI",
+        "SC",
+        "SD",
+        "TN",
+        "TX",
+        "UT",
+        "VT",
+        "VA",
+        "WA",
+        "WV",
+        "WI",
+        "WY",
+        "DC",
+    }
+)
+
+
+def _filter_us_states(df: pd.DataFrame) -> pd.DataFrame:
+    """Return only rows whose ``state`` column matches a US state abbreviation.
+
+    Args:
+        df: Listening history DataFrame, optionally containing a ``state`` column.
+
+    Returns:
+        Filtered DataFrame with only US-state rows, or an empty DataFrame if
+        the ``state`` column is absent or no US rows are found.
+    """
+    if df.empty or "state" not in df.columns:
+        return pd.DataFrame()
+    mask = df["state"].isin(_US_STATE_ABBREVS)
+    return df[mask].copy()
+
+
+def _build_state_stats(df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate per-state listening statistics.
+
+    For each US state present in *df*, computes:
+
+    - ``plays`` — total scrobble count.
+    - ``top_artist`` — most-played artist in the state.
+    - ``top_artists_list`` — ordered list of up to 5 top artists (with play counts).
+    - ``top_track`` — most-played track in the state.
+
+    Args:
+        df: Listening history filtered to US rows (via :func:`_filter_us_states`).
+
+    Returns:
+        DataFrame with one row per state, sorted by ``plays`` descending.
+        Empty DataFrame when input is empty.
+    """
+    if df.empty or "state" not in df.columns:
+        return pd.DataFrame()
+
+    rows: list[dict] = []
+    for state, group in df.groupby("state"):
+        plays = len(group)
+
+        top_artists_df = get_top_entities(group, "artist", limit=5)
+        top_artist = top_artists_df.iloc[0]["artist"] if not top_artists_df.empty else "—"
+        top_artists_list = (
+            top_artists_df.apply(lambda r: f"{r['artist']} ({int(r['Plays'])})", axis=1).tolist()
+            if not top_artists_df.empty
+            else []
+        )
+
+        top_tracks_df = get_top_entities(group, "track", limit=1)
+        top_track = top_tracks_df.iloc[0]["track"] if not top_tracks_df.empty else "—"
+
+        rows.append(
+            {
+                "state": str(state),
+                "plays": plays,
+                "top_artist": top_artist,
+                "top_artists_list": top_artists_list,
+                "top_track": top_track,
+            }
+        )
+
+    if not rows:
+        return pd.DataFrame()
+
+    return pd.DataFrame(rows).sort_values("plays", ascending=False).reset_index(drop=True)
+
+
+def _build_share_html(stats: pd.DataFrame, total_plays: int) -> str:
+    """Build a minimal HTML snapshot for the share button.
+
+    Args:
+        stats: Per-state stats produced by :func:`_build_state_stats`.
+        total_plays: Total US scrobble count shown in the snapshot header.
+
+    Returns:
+        UTF-8–safe HTML string.
+    """
+    rows_html = "".join(
+        f"<tr><td>{r['state']}</td><td>{r['plays']:,}</td>"
+        f"<td>{r['top_artist']}</td><td>{r['top_track']}</td></tr>"
+        for _, r in stats.iterrows()
+    )
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8">
+<title>Music Map of America</title>
+<style>
+body{{font-family:system-ui,sans-serif;background:#0c1120;color:#f0f4ff;padding:2rem}}
+h1{{color:#6366f1}}
+table{{border-collapse:collapse;width:100%}}
+th,td{{text-align:left;padding:.4rem .8rem;border-bottom:1px solid #2d3a52}}
+th{{color:#22d3ee}}
+</style>
+</head>
+<body>
+<h1>Music Map of America</h1>
+<p>{total_plays:,} US scrobbles across {len(stats)} states</p>
+<table>
+<tr><th>State</th><th>Plays</th><th>Top Artist</th><th>Top Track</th></tr>
+{rows_html}
+</table>
+</body></html>"""
+
+
+def render_music_map_america() -> None:
+    """Render the Musical Map of America page.
+
+    Reads the active DataFrame from ``st.session_state['df']``.  Filters to
+    rows whose ``state`` column matches a US state abbreviation, then renders:
+
+    1. A Plotly choropleth coloured by scrobble density.
+    2. Clicking (selecting) a state shows its top-5 artists and top track.
+    3. A sortable table of all visited states with play counts.
+
+    Shows an informational empty state when no data or no US plays are found.
+    """
+    df: pd.DataFrame | None = st.session_state.get("df")
+
+    if df is None or df.empty:
+        st.info(
+            "No music data loaded yet. "
+            "Configure a Last.fm source in the sidebar and select a data file."
+        )
+        return
+
+    if "state" not in df.columns:
+        st.info(
+            "No location data found. "
+            "Link a Foursquare/Swarm export so that tracks can be assigned to states."
+        )
+        return
+
+    us_df = _filter_us_states(df)
+
+    if us_df.empty:
+        st.info(
+            "No US listening data found. "
+            "This map only shows plays assigned to US states via Swarm check-ins "
+            "or location assumptions."
+        )
+        return
+
+    stats = _build_state_stats(us_df)
+    total_us_plays = int(stats["plays"].sum())
+
+    st.header("Musical Map of America")
+
+    # Share button
+    html_bytes = _build_share_html(stats, total_us_plays).encode("utf-8")
+    render_share_button(html_bytes, "autobiographer-music-map-america.html")
+
+    st.markdown(f"**{total_us_plays:,}** US scrobbles tracked across **{len(stats)}** states.")
+
+    # ── Choropleth ────────────────────────────────────────────────────────────
+    st.subheader("Scrobble Density by State")
+
+    # Build colour scale list that px.choropleth accepts: [[0.0, "#hex"], ...]
+    colorscale = [[v, c] for v, c in SEQUENTIAL_SCALE]
+
+    fig = px.choropleth(
+        stats,
+        locations="state",
+        locationmode="USA-states",
+        color="plays",
+        scope="usa",
+        color_continuous_scale=colorscale,
+        labels={"plays": "Scrobbles", "state": "State"},
+        hover_data={
+            "state": True,
+            "plays": True,
+            "top_artist": True,
+            "top_track": True,
+        },
+        custom_data=["state", "plays", "top_artist", "top_track"],
+    )
+    fig.update_traces(
+        hovertemplate=(
+            "<b>%{customdata[0]}</b><br>"
+            "Plays: %{customdata[1]:,}<br>"
+            "Top artist: %{customdata[2]}<br>"
+            "Top track: %{customdata[3]}<extra></extra>"
+        )
+    )
+    fig.update_layout(
+        geo=dict(bgcolor="rgba(0,0,0,0)", lakecolor="rgba(0,0,0,0)"),
+        coloraxis_colorbar=dict(title="Plays"),
+        margin=dict(l=0, r=0, t=0, b=0),
+    )
+    apply_dark_theme(fig)
+    st.plotly_chart(fig, width="stretch")
+
+    # ── State detail panel ────────────────────────────────────────────────────
+    st.subheader("State Detail")
+    state_options = ["— select a state —"] + sorted(stats["state"].tolist())
+    selected_state = st.selectbox("Select a state", state_options, label_visibility="collapsed")
+
+    if selected_state and selected_state != "— select a state —":
+        row = stats.loc[stats["state"] == selected_state].iloc[0]
+        col_left, col_right = st.columns(2)
+        with col_left:
+            st.metric("Total Plays", f"{int(row['plays']):,}")
+            st.markdown("**Top 5 Artists**")
+            for entry in row["top_artists_list"]:
+                st.markdown(f"- {entry}")
+        with col_right:
+            st.markdown("**Top Track**")
+            st.markdown(f"> {row['top_track']}")
+
+    # ── Sortable state table ──────────────────────────────────────────────────
+    st.subheader("All Visited States")
+    display_df = stats[["state", "plays", "top_artist", "top_track"]].rename(
+        columns={
+            "state": "State",
+            "plays": "Plays",
+            "top_artist": "Top Artist",
+            "top_track": "Top Track",
+        }
+    )
+    st.dataframe(display_df, hide_index=True, use_container_width=True)

--- a/tests/test_music_map_america.py
+++ b/tests/test_music_map_america.py
@@ -150,6 +150,47 @@ class TestFilterUsStates:
         result = _filter_us_states(pd.DataFrame())
         assert result.empty
 
+    def test_normalises_city_state_strings(self) -> None:
+        """'City, ST' values produced by the city fallback should be recognised."""
+        df = pd.DataFrame(
+            {
+                "artist": ["A", "B"],
+                "album": ["X", "Y"],
+                "track": ["t1", "t2"],
+                "timestamp": [1610000000, 1610000100],
+                "date_text": pd.to_datetime(["2021-01-01", "2021-01-01"]),
+                "state": ["Anchorage, AK", "Chicago, IL"],
+                "country": ["US", "US"],
+                "lat": [61.2, 41.8],
+                "lng": [-149.9, -87.6],
+                "city": ["Anchorage, AK", "Chicago, IL"],
+            }
+        )
+        result = _filter_us_states(df)
+        assert len(result) == 2
+        assert set(result["state"].tolist()) == {"AK", "IL"}
+
+    def test_normalises_full_state_names(self) -> None:
+        """Full state names from reverse_geocoder admin1 should be normalised."""
+        df = pd.DataFrame(
+            {
+                "artist": ["A", "B", "C"],
+                "album": ["X", "Y", "Z"],
+                "track": ["t1", "t2", "t3"],
+                "timestamp": [1610000000, 1610000100, 1610000200],
+                "date_text": pd.to_datetime(["2021-01-01"] * 3),
+                "state": ["Oklahoma", "New York", "Ontario"],
+                "country": ["US", "US", "Canada"],
+                "lat": [35.5, 40.7, 43.7],
+                "lng": [-97.5, -74.0, -79.4],
+                "city": ["Oklahoma City", "New York", "Toronto"],
+            }
+        )
+        result = _filter_us_states(df)
+        assert len(result) == 2
+        assert set(result["state"].tolist()) == {"OK", "NY"}
+        assert "Ontario" not in result["state"].values
+
 
 # ---------------------------------------------------------------------------
 # Unit tests for _build_state_stats
@@ -203,6 +244,25 @@ class TestBuildStateStats:
         il_row = stats.loc[stats["state"] == "IL"].iloc[0]
         # IL has 3 plays all by Artist A — list should have at most 5 entries
         assert len(il_row["top_artists_list"]) <= 5
+
+    def test_top_tracks_list_column_present(self) -> None:
+        df = _make_df()
+        stats = _build_state_stats(df)
+        assert "top_tracks_list" in stats.columns
+
+    def test_top_tracks_list_contains_artist_and_track(self) -> None:
+        df = _make_df()
+        stats = _build_state_stats(df)
+        il_row = stats.loc[stats["state"] == "IL"].iloc[0]
+        assert len(il_row["top_tracks_list"]) >= 1
+        # Each entry should contain " — " separating artist from track
+        assert " — " in il_row["top_tracks_list"][0]
+
+    def test_top_tracks_list_at_most_five(self) -> None:
+        df = _make_df()
+        stats = _build_state_stats(df)
+        for _, row in stats.iterrows():
+            assert len(row["top_tracks_list"]) <= 5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_music_map_america.py
+++ b/tests/test_music_map_america.py
@@ -1,0 +1,354 @@
+"""Tests for the Music Map of America page (issue #57)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from pages.music_map_america import (
+    _build_state_stats,
+    _filter_us_states,
+    render_music_map_america,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+US_STATES = [
+    "AL",
+    "AK",
+    "AZ",
+    "AR",
+    "CA",
+    "CO",
+    "CT",
+    "DE",
+    "FL",
+    "GA",
+    "HI",
+    "ID",
+    "IL",
+    "IN",
+    "IA",
+    "KS",
+    "KY",
+    "LA",
+    "ME",
+    "MD",
+    "MA",
+    "MI",
+    "MN",
+    "MS",
+    "MO",
+    "MT",
+    "NE",
+    "NV",
+    "NH",
+    "NJ",
+    "NM",
+    "NY",
+    "NC",
+    "ND",
+    "OH",
+    "OK",
+    "OR",
+    "PA",
+    "RI",
+    "SC",
+    "SD",
+    "TN",
+    "TX",
+    "UT",
+    "VT",
+    "VA",
+    "WA",
+    "WV",
+    "WI",
+    "WY",
+    "DC",
+]
+
+
+def _make_df() -> pd.DataFrame:
+    """Return a minimal DataFrame with the columns produced by apply_swarm_offsets."""
+    return pd.DataFrame(
+        {
+            "artist": ["Artist A", "Artist A", "Artist B", "Artist C", "Artist A"],
+            "album": ["Album 1", "Album 1", "Album 2", "Album 3", "Album 1"],
+            "track": ["Track 1", "Track 2", "Track 3", "Track 4", "Track 1"],
+            "timestamp": [1610000000, 1610000100, 1610000200, 1610000300, 1610000400],
+            "date_text": pd.to_datetime(
+                ["2021-01-07", "2021-01-07", "2021-01-07", "2021-01-07", "2021-01-07"]
+            ),
+            "state": ["IL", "IL", "NY", "CA", "IL"],
+            "country": ["US", "US", "US", "US", "US"],
+            "lat": [41.8, 41.8, 40.7, 34.0, 41.8],
+            "lng": [-87.6, -87.6, -74.0, -118.2, -87.6],
+            "city": ["Chicago", "Chicago", "New York", "Los Angeles", "Chicago"],
+        }
+    )
+
+
+def _make_df_with_non_us() -> pd.DataFrame:
+    """Return a DataFrame that mixes US states with non-US state codes."""
+    df = _make_df()
+    extra = pd.DataFrame(
+        {
+            "artist": ["Artist D", "Artist E"],
+            "album": ["Album X", "Album Y"],
+            "track": ["Track X", "Track Y"],
+            "timestamp": [1610001000, 1610002000],
+            "date_text": pd.to_datetime(["2021-01-08", "2021-01-08"]),
+            "state": ["ON", "IS"],  # Ontario (Canada) and Iceland — not US states
+            "country": ["Canada", "Iceland"],
+            "lat": [43.7, 64.1],
+            "lng": [-79.4, -21.8],
+            "city": ["Toronto", "Reykjavik"],
+        }
+    )
+    return pd.concat([df, extra], ignore_index=True)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _filter_us_states
+# ---------------------------------------------------------------------------
+
+
+class TestFilterUsStates:
+    def test_keeps_known_us_abbreviations(self) -> None:
+        df = _make_df()
+        result = _filter_us_states(df)
+        assert set(result["state"].unique()).issubset(set(US_STATES))
+
+    def test_removes_non_us_codes(self) -> None:
+        df = _make_df_with_non_us()
+        result = _filter_us_states(df)
+        assert "ON" not in result["state"].values
+        assert "IS" not in result["state"].values
+
+    def test_returns_empty_for_no_us_rows(self) -> None:
+        df = pd.DataFrame(
+            {
+                "state": ["ON", "IS"],
+                "artist": ["A", "B"],
+                "track": ["t1", "t2"],
+                "album": ["x", "y"],
+                "timestamp": [1, 2],
+                "date_text": pd.to_datetime(["2021-01-01", "2021-01-01"]),
+                "country": ["Canada", "Iceland"],
+                "lat": [43.7, 64.1],
+                "lng": [-79.4, -21.8],
+                "city": ["Toronto", "Reykjavik"],
+            }
+        )
+        result = _filter_us_states(df)
+        assert result.empty
+
+    def test_handles_empty_dataframe(self) -> None:
+        result = _filter_us_states(pd.DataFrame())
+        assert result.empty
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _build_state_stats
+# ---------------------------------------------------------------------------
+
+
+class TestBuildStateStats:
+    def test_returns_all_us_states_present(self) -> None:
+        df = _make_df()
+        stats = _build_state_stats(df)
+        assert "IL" in stats["state"].values
+        assert "NY" in stats["state"].values
+        assert "CA" in stats["state"].values
+
+    def test_play_counts_are_correct(self) -> None:
+        df = _make_df()
+        stats = _build_state_stats(df)
+        il_plays = stats.loc[stats["state"] == "IL", "plays"].iloc[0]
+        ny_plays = stats.loc[stats["state"] == "NY", "plays"].iloc[0]
+        assert il_plays == 3
+        assert ny_plays == 1
+
+    def test_top_artist_column_present(self) -> None:
+        df = _make_df()
+        stats = _build_state_stats(df)
+        assert "top_artist" in stats.columns
+
+    def test_top_artist_is_most_played(self) -> None:
+        df = _make_df()
+        stats = _build_state_stats(df)
+        il_top = stats.loc[stats["state"] == "IL", "top_artist"].iloc[0]
+        assert il_top == "Artist A"
+
+    def test_top_track_column_present(self) -> None:
+        df = _make_df()
+        stats = _build_state_stats(df)
+        assert "top_track" in stats.columns
+
+    def test_returns_empty_for_empty_input(self) -> None:
+        result = _build_state_stats(pd.DataFrame())
+        assert result.empty
+
+    def test_top_artists_list_column_present(self) -> None:
+        df = _make_df()
+        stats = _build_state_stats(df)
+        assert "top_artists_list" in stats.columns
+
+    def test_top_artists_list_contains_top_5_or_fewer(self) -> None:
+        df = _make_df()
+        stats = _build_state_stats(df)
+        il_row = stats.loc[stats["state"] == "IL"].iloc[0]
+        # IL has 3 plays all by Artist A — list should have at most 5 entries
+        assert len(il_row["top_artists_list"]) <= 5
+
+
+# ---------------------------------------------------------------------------
+# Integration test for render_music_map_america
+# ---------------------------------------------------------------------------
+
+
+class TestRenderMusicMapAmerica:
+    @patch("streamlit.plotly_chart")
+    @patch("streamlit.dataframe")
+    @patch("streamlit.subheader")
+    @patch("streamlit.header")
+    @patch("streamlit.info")
+    def test_empty_state_shown_when_no_df(
+        self,
+        mock_info: MagicMock,
+        mock_header: MagicMock,
+        mock_subheader: MagicMock,
+        mock_dataframe: MagicMock,
+        mock_plotly: MagicMock,
+    ) -> None:
+        with patch("streamlit.session_state", {"df": None}):
+            render_music_map_america()
+        mock_info.assert_called_once()
+        mock_plotly.assert_not_called()
+
+    @patch("streamlit.plotly_chart")
+    @patch("streamlit.dataframe")
+    @patch("streamlit.subheader")
+    @patch("streamlit.header")
+    @patch("streamlit.info")
+    def test_no_us_data_shows_warning(
+        self,
+        mock_info: MagicMock,
+        mock_header: MagicMock,
+        mock_subheader: MagicMock,
+        mock_dataframe: MagicMock,
+        mock_plotly: MagicMock,
+    ) -> None:
+        df = pd.DataFrame(
+            {
+                "artist": ["A"],
+                "album": ["X"],
+                "track": ["t1"],
+                "timestamp": [1610000000],
+                "date_text": pd.to_datetime(["2021-01-01"]),
+                "state": ["ON"],  # non-US
+                "country": ["Canada"],
+                "lat": [43.7],
+                "lng": [-79.4],
+                "city": ["Toronto"],
+            }
+        )
+        with patch("streamlit.session_state", {"df": df}):
+            render_music_map_america()
+        mock_info.assert_called_once()
+
+    @patch("streamlit.selectbox")
+    @patch("streamlit.columns")
+    @patch("streamlit.plotly_chart")
+    @patch("streamlit.dataframe")
+    @patch("streamlit.subheader")
+    @patch("streamlit.header")
+    @patch("streamlit.markdown")
+    def test_renders_choropleth_and_table_for_us_data(
+        self,
+        mock_md: MagicMock,
+        mock_header: MagicMock,
+        mock_subheader: MagicMock,
+        mock_dataframe: MagicMock,
+        mock_plotly: MagicMock,
+        mock_cols: MagicMock,
+        mock_select: MagicMock,
+    ) -> None:
+        df = _make_df()
+        col_mock = MagicMock(
+            __enter__=MagicMock(return_value=MagicMock()),
+            __exit__=MagicMock(return_value=False),
+        )
+        mock_cols.return_value = [col_mock, col_mock]
+        # Return the sentinel "no selection" value so state detail panel is skipped
+        mock_select.return_value = "— select a state —"
+
+        with patch("streamlit.session_state", {"df": df}):
+            render_music_map_america()
+
+        # Choropleth chart should be rendered
+        mock_plotly.assert_called()
+        # State breakdown table should be rendered
+        mock_dataframe.assert_called()
+
+    @patch("streamlit.selectbox")
+    @patch("streamlit.columns")
+    @patch("streamlit.plotly_chart")
+    @patch("streamlit.dataframe")
+    @patch("streamlit.subheader")
+    @patch("streamlit.header")
+    @patch("streamlit.markdown")
+    def test_renders_share_button(
+        self,
+        mock_md: MagicMock,
+        mock_header: MagicMock,
+        mock_subheader: MagicMock,
+        mock_dataframe: MagicMock,
+        mock_plotly: MagicMock,
+        mock_cols: MagicMock,
+        mock_select: MagicMock,
+    ) -> None:
+        df = _make_df()
+        col_mock = MagicMock(
+            __enter__=MagicMock(return_value=MagicMock()),
+            __exit__=MagicMock(return_value=False),
+        )
+        mock_cols.return_value = [col_mock, col_mock]
+        mock_select.return_value = "— select a state —"
+
+        with patch("streamlit.session_state", {"df": df}):
+            with patch("pages.music_map_america.render_share_button") as mock_share:
+                render_music_map_america()
+
+        mock_share.assert_called_once()
+
+    @patch("streamlit.plotly_chart")
+    @patch("streamlit.dataframe")
+    @patch("streamlit.subheader")
+    @patch("streamlit.header")
+    @patch("streamlit.markdown")
+    def test_df_missing_state_column_shows_info(
+        self,
+        mock_md: MagicMock,
+        mock_header: MagicMock,
+        mock_subheader: MagicMock,
+        mock_dataframe: MagicMock,
+        mock_plotly: MagicMock,
+    ) -> None:
+        """A DataFrame without a state column should show the empty/info state."""
+        df = pd.DataFrame(
+            {
+                "artist": ["A"],
+                "album": ["X"],
+                "track": ["t"],
+                "timestamp": [1610000000],
+                "date_text": pd.to_datetime(["2021-01-01"]),
+            }
+        )
+        with patch("streamlit.session_state", {"df": df}):
+            with patch("streamlit.info") as mock_info:
+                render_music_map_america()
+        mock_info.assert_called_once()

--- a/visualize.py
+++ b/visualize.py
@@ -24,6 +24,7 @@ from pages.data_sources import render_data_sources, render_plugin_page
 from pages.fitness import render_fitness
 from pages.insights import render_insights, render_insights_and_narrative  # noqa: F401
 from pages.music import render_music, render_top_charts  # noqa: F401
+from pages.music_map_america import render_music_map_america
 from pages.overview import render_overview  # noqa: F401
 from pages.places import (  # noqa: F401
     render_checkin_insights,
@@ -125,6 +126,7 @@ def main() -> None:
             "Music": [
                 st.Page(render_music, title="Listening", icon=":material/headphones:"),
                 st.Page(render_insights, title="Insights", icon=":material/auto_stories:"),
+                st.Page(render_music_map_america, title="Music Map", icon=":material/map:"),
             ],
             "Places": [
                 st.Page(render_places, title="Check-ins", icon=":material/location_on:"),


### PR DESCRIPTION
## Summary

- Adds a new **Music Map** page (`pages/music_map_america.py`) under the Music section of the Autobiographer dashboard.
- Filters the loaded Last.fm listening history to rows whose `state` column matches a US state abbreviation (50 states + DC) — relies on state data already propagated by `apply_swarm_offsets()`.
- Groups by state and computes: total plays, top artist, top-5 artist list, top track (via `get_top_entities()`).
- Renders a `px.choropleth` with `locationmode="USA-states"` coloured by scrobble density using the project's `SEQUENTIAL_SCALE`.
- State detail panel (selectbox) shows top-5 artists and top track for a chosen state.
- Sortable `st.dataframe` of all visited states below the map.
- Share button generates a self-contained HTML snapshot.
- Registered as `Music > Music Map` with `:material/map:` icon in `visualize.py`.
- Comprehensive test suite in `tests/test_music_map_america.py` covering all helper functions and render paths.

## Test plan

- [x] `_filter_us_states()` — keeps valid state codes, removes non-US codes (e.g. ON, IS), handles empty input
- [x] `_build_state_stats()` — correct play counts, top artist identification, top-5 list, empty input
- [x] `render_music_map_america()` — empty state (no df), no-US-data info, state-column-missing info, choropleth rendered, table rendered, share button called
- [x] ruff check + ruff format — passed (auto-fixed by pre-commit hook)
- [x] mypy — passed

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)