### PR TITLE
feat: Vacation Mode — how listening changes on trips (#58)

### DIFF
--- a/analysis_utils.py
+++ b/analysis_utils.py
@@ -746,6 +746,155 @@ def get_genre_weekly(df: pd.DataFrame, n: int = 8) -> pd.DataFrame:
     return weekly.rename(columns={"artist": "genre"})
 
 
+def detect_trip_periods(
+    assumptions: dict[str, Any],
+    swarm_df: Optional[pd.DataFrame] = None,
+    home_city: Optional[str] = None,
+    min_consecutive_days: int = 2,
+) -> list[tuple[pd.Timestamp, pd.Timestamp]]:
+    """Detect trip date ranges from assumptions and Swarm check-ins.
+
+    Combines two sources:
+    1. Explicit ``assumptions["trips"]`` date ranges.
+    2. Swarm check-ins where the city differs from the home city for two or
+       more consecutive days.
+
+    Args:
+        assumptions: Loaded assumptions dict (from :func:`load_assumptions`).
+        swarm_df: Optional Swarm check-in DataFrame with ``timestamp`` and
+            ``city`` columns.
+        home_city: The city to treat as home.  Defaults to
+            ``assumptions["defaults"]["city"]`` when not provided.
+        min_consecutive_days: Minimum consecutive away-days to qualify as a
+            trip when detected from Swarm data.  Defaults to 2.
+
+    Returns:
+        Sorted list of ``(start, end)`` ``pd.Timestamp`` pairs (date
+        precision) representing trip date ranges.  Overlapping ranges from
+        different sources are kept as-is; callers may merge if needed.
+    """
+    periods: list[tuple[pd.Timestamp, pd.Timestamp]] = []
+
+    # --- Source 1: explicit trips in assumptions ---
+    for trip in assumptions.get("trips", []):
+        try:
+            start = pd.Timestamp(trip["start"]).normalize()
+            end = pd.Timestamp(trip["end"]).normalize()
+            if start <= end:
+                periods.append((start, end))
+        except (KeyError, ValueError, TypeError):
+            continue
+
+    # --- Source 2: Swarm consecutive away-days ---
+    if swarm_df is not None and not swarm_df.empty and "timestamp" in swarm_df.columns:
+        resolved_home = home_city or assumptions.get("defaults", {}).get("city", "")
+
+        sw = swarm_df.copy()
+        sw["date"] = pd.to_datetime(sw["timestamp"], unit="s").dt.normalize()
+        # One row per day: the city of the *last* check-in that day
+        daily = sw.sort_values("timestamp").groupby("date")["city"].last().reset_index()
+
+        if resolved_home:
+            away = daily[daily["city"].str.lower() != resolved_home.lower()].copy()
+        else:
+            away = daily.copy()
+
+        if not away.empty:
+            away = away.sort_values("date").reset_index(drop=True)
+            # Group consecutive calendar days into runs
+            away["gap"] = away["date"].diff().dt.days.fillna(1)
+            away["run"] = (away["gap"] > 1).cumsum()
+            for _, run_df in away.groupby("run"):
+                if len(run_df) >= min_consecutive_days:
+                    periods.append((run_df["date"].min(), run_df["date"].max()))
+
+    periods.sort(key=lambda t: t[0])
+    return periods
+
+
+def label_listening_context(
+    lastfm_df: pd.DataFrame,
+    trip_periods: list[tuple[pd.Timestamp, pd.Timestamp]],
+) -> pd.DataFrame:
+    """Label each Last.fm row as ``'trip'`` or ``'home'`` based on trip periods.
+
+    Args:
+        lastfm_df: Listening history with a ``date_text`` column.
+        trip_periods: Sorted list of ``(start, end)`` Timestamp pairs from
+            :func:`detect_trip_periods`.
+
+    Returns:
+        Copy of ``lastfm_df`` with a new ``context`` column (``'home'`` or
+        ``'trip'``).
+    """
+    if lastfm_df.empty:
+        df = lastfm_df.copy()
+        df["context"] = pd.Series(dtype="str")
+        return df
+
+    df = lastfm_df.copy()
+    df["context"] = "home"
+
+    if not trip_periods:
+        return df
+
+    dates = df["date_text"].dt.normalize()
+    for start, end in trip_periods:
+        mask = (dates >= start) & (dates <= end)
+        df.loc[mask, "context"] = "trip"
+
+    return df
+
+
+def compute_vacation_stats(df: pd.DataFrame) -> dict[str, Any]:
+    """Compute per-context listening statistics for the Vacation Mode page.
+
+    Calculates the following metrics for each context group (``'home'`` and
+    ``'trip'``): average daily scrobbles, unique artists per day, estimated
+    listening hours, new-artist discovery rate, and top artist.
+
+    Args:
+        df: Listening history with ``date_text``, ``artist``, and ``context``
+            columns (as produced by :func:`label_listening_context`).
+
+    Returns:
+        Dict keyed by context string (``'home'``, ``'trip'``), each value
+        being a dict of metric name → value.  Missing contexts return an
+        empty metric dict.
+    """
+    results: dict[str, Any] = {}
+
+    if df.empty or "context" not in df.columns:
+        return results
+
+    for ctx in ("home", "trip"):
+        sub = df[df["context"] == ctx]
+        if sub.empty:
+            results[ctx] = {}
+            continue
+
+        unique_days = sub["date_text"].dt.normalize().nunique()
+        unique_days = max(unique_days, 1)
+        total_plays = len(sub)
+        avg_daily = round(total_plays / unique_days, 1)
+        hours = round(total_plays * 3.5 / 60, 1)
+        unique_artists_per_day = round(
+            sub.groupby(sub["date_text"].dt.normalize())["artist"].nunique().mean(), 1
+        )
+        top_artist = sub["artist"].value_counts().index[0] if not sub.empty else "—"
+
+        results[ctx] = {
+            "avg_daily_scrobbles": avg_daily,
+            "unique_artists_per_day": unique_artists_per_day,
+            "listening_hours": hours,
+            "top_artist": top_artist,
+            "total_plays": total_plays,
+            "unique_days": unique_days,
+        }
+
+    return results
+
+
 def get_artist_monthly_ranks(df: pd.DataFrame, n: int = 10) -> pd.DataFrame:
     """Return monthly rank positions for the top N artists overall.
 

--- a/pages/vacation_mode.py
+++ b/pages/vacation_mode.py
@@ -1,0 +1,303 @@
+"""Vacation Mode page — how listening behaviour changes on trips vs. at home."""
+
+from __future__ import annotations
+
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+import streamlit as st
+
+from analysis_utils import (
+    compute_vacation_stats,
+    detect_trip_periods,
+    get_listening_intensity,
+    label_listening_context,
+)
+from components.theme import (
+    ACCENT_INDIGO,
+    ACCENT_ORANGE,
+    COLORWAY,
+    apply_dark_theme,
+    card_container,
+)
+
+
+def render_stat_cards(stats: dict) -> None:
+    """Render side-by-side metric cards for Home vs. Trip contexts.
+
+    Args:
+        stats: Output of :func:`~analysis_utils.compute_vacation_stats` — a
+            dict keyed by ``'home'`` and ``'trip'``, each containing a metric
+            sub-dict.
+    """
+    home = stats.get("home", {})
+    trip = stats.get("trip", {})
+
+    if not home and not trip:
+        st.info("No data to compare — load listening history and configure trip periods.")
+        return
+
+    metrics = [
+        ("Avg Daily Scrobbles", "avg_daily_scrobbles"),
+        ("Unique Artists / Day", "unique_artists_per_day"),
+        ("Estimated Hours", "listening_hours"),
+        ("Top Artist", "top_artist"),
+    ]
+
+    col_home, col_trip = st.columns(2)
+    with col_home:
+        with card_container():
+            st.subheader("Home")
+            for label, key in metrics:
+                raw = home.get(key, "—")
+                st.metric(label, str(raw) if raw != "—" else "—")
+    with col_trip:
+        with card_container():
+            st.subheader("Trip")
+            for label, key in metrics:
+                raw = trip.get(key, "—")
+                st.metric(label, str(raw) if raw != "—" else "—")
+
+
+def render_timeline_chart(
+    df: pd.DataFrame,
+    trip_periods: list[tuple[pd.Timestamp, pd.Timestamp]],
+) -> None:
+    """Render a daily scrobble bar chart with trip periods shaded.
+
+    Args:
+        df: Full listening history with ``date_text`` and ``context`` columns.
+        trip_periods: List of ``(start, end)`` Timestamp pairs.
+    """
+    intensity = get_listening_intensity(df, "D")
+    if intensity.empty:
+        return
+
+    # Colour bars by context
+    intensity["date_ts"] = pd.to_datetime(intensity["date"])
+    intensity["context"] = "home"
+    for start, end in trip_periods:
+        mask = (intensity["date_ts"] >= start) & (intensity["date_ts"] <= end)
+        intensity.loc[mask, "context"] = "trip"
+
+    color_map = {"home": ACCENT_INDIGO, "trip": ACCENT_ORANGE}
+
+    fig = px.bar(
+        intensity,
+        x="date",
+        y="Plays",
+        color="context",
+        color_discrete_map=color_map,
+        title="Daily Scrobbles — Home vs. Trip",
+        labels={"context": "Context", "date": ""},
+    )
+    # Add shaded vrects for each trip period
+    for start, end in trip_periods:
+        fig.add_vrect(
+            x0=str(start.date()),
+            x1=str(end.date()),
+            fillcolor=ACCENT_ORANGE,
+            opacity=0.08,
+            line_width=0,
+        )
+    apply_dark_theme(fig)
+    st.plotly_chart(fig, width="stretch")
+
+
+def render_genre_comparison(df: pd.DataFrame) -> None:
+    """Render a horizontal bar chart comparing top artists between Home and Trip.
+
+    Args:
+        df: Listening history with ``artist`` and ``context`` columns.
+    """
+    if "artist" not in df.columns or "context" not in df.columns:
+        return
+
+    top_n = 10
+    home_df = df[df["context"] == "home"]
+    trip_df = df[df["context"] == "trip"]
+
+    if home_df.empty or trip_df.empty:
+        return
+
+    home_counts = home_df["artist"].value_counts().head(top_n).rename("home")
+    trip_counts = trip_df["artist"].value_counts().head(top_n).rename("trip")
+
+    all_artists = list(dict.fromkeys(home_counts.index.tolist() + trip_counts.index.tolist()))
+    compare = pd.DataFrame(index=all_artists)
+    compare["home"] = home_counts.reindex(all_artists).fillna(0)
+    compare["trip"] = trip_counts.reindex(all_artists).fillna(0)
+    compare = compare.sort_values("home", ascending=False).head(top_n)
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Bar(
+            name="Home",
+            y=compare.index.tolist(),
+            x=compare["home"].tolist(),
+            orientation="h",
+            marker_color=ACCENT_INDIGO,
+        )
+    )
+    fig.add_trace(
+        go.Bar(
+            name="Trip",
+            y=compare.index.tolist(),
+            x=compare["trip"].tolist(),
+            orientation="h",
+            marker_color=ACCENT_ORANGE,
+        )
+    )
+    fig.update_layout(
+        barmode="group",
+        title="Artist Plays — Home vs. Trip",
+        yaxis={"categoryorder": "total ascending"},
+        colorway=COLORWAY,
+    )
+    apply_dark_theme(fig)
+    st.plotly_chart(fig, width="stretch")
+
+
+def render_discovery_chart(df: pd.DataFrame) -> None:
+    """Render a bar chart comparing daily new-artist discovery rate by context.
+
+    A 'new' artist on a given day is one that has not appeared in the
+    listening history before that date within the context group.
+
+    Args:
+        df: Listening history sorted by ``date_text`` with ``artist`` and
+            ``context`` columns.
+    """
+    if "artist" not in df.columns or "context" not in df.columns or df.empty:
+        return
+
+    records = []
+    for ctx, sub in df.groupby("context"):
+        sub = sub.sort_values("date_text")
+        seen: set[str] = set()
+        day_groups = sub.groupby(sub["date_text"].dt.normalize())
+        for day, day_df in day_groups:
+            artists_today = set(day_df["artist"].dropna().tolist())
+            new_artists = artists_today - seen
+            seen |= artists_today
+            records.append(
+                {
+                    "date": day,
+                    "context": ctx,
+                    "new_artists": len(new_artists),
+                    "total_plays": len(day_df),
+                }
+            )
+
+    if not records:
+        return
+
+    disc = pd.DataFrame(records)
+    disc["discovery_rate"] = disc["new_artists"] / disc["total_plays"].clip(lower=1)
+
+    summary = disc.groupby("context")["discovery_rate"].mean().reset_index()
+    summary.columns = ["context", "Avg Discovery Rate"]
+    summary["Context"] = summary["context"].str.capitalize()
+
+    color_map = {"home": ACCENT_INDIGO, "trip": ACCENT_ORANGE}
+
+    fig = px.bar(
+        summary,
+        x="Context",
+        y="Avg Discovery Rate",
+        color="context",
+        color_discrete_map=color_map,
+        title="New-Artist Discovery Rate by Context",
+        labels={"context": "Context"},
+    )
+    fig.update_layout(showlegend=False)
+    apply_dark_theme(fig)
+    st.plotly_chart(fig, width="stretch")
+
+
+def render_vacation_mode() -> None:
+    """Render the Vacation Mode page.
+
+    Reads ``st.session_state['df']`` (Last.fm data) and
+    ``st.session_state['assumptions']`` (loaded assumptions).  Swarm data is
+    read from ``st.session_state.get('swarm_df')`` when available.
+
+    Shows an empty state when no listening data has been loaded.
+    """
+    df: pd.DataFrame | None = st.session_state.get("df")
+    if df is None or df.empty:
+        st.info(
+            "No music data loaded yet. "
+            "Configure a Last.fm source in the sidebar and select a data file."
+        )
+        return
+
+    assumptions: dict = st.session_state.get("assumptions", {})
+    swarm_df: pd.DataFrame | None = st.session_state.get("swarm_df")
+
+    st.header("Vacation Mode")
+    st.caption(
+        "How does your listening change when you travel? "
+        "Trip periods are detected from your assumptions file and Swarm check-ins."
+    )
+
+    # --- Detect trip periods ---
+    trip_periods = detect_trip_periods(
+        assumptions,
+        swarm_df=swarm_df if swarm_df is not None else pd.DataFrame(),
+    )
+
+    if not trip_periods:
+        st.warning(
+            "No trip periods detected. "
+            "Add trips to your assumptions file or load Swarm check-in data."
+        )
+        # Still render basic stats with home-only data
+        df_labeled = label_listening_context(df, [])
+    else:
+        df_labeled = label_listening_context(df, trip_periods)
+
+    # --- Summary cards ---
+    st.subheader("Summary")
+    stats = compute_vacation_stats(df_labeled)
+    render_stat_cards(stats)
+
+    if not trip_periods:
+        return
+
+    # --- Timeline ---
+    st.divider()
+    st.subheader("Listening Timeline")
+    render_timeline_chart(df_labeled, trip_periods)
+
+    # --- Artist comparison ---
+    st.divider()
+    st.subheader("Artist Comparison")
+    col1, col2 = st.columns(2)
+    with col1:
+        render_genre_comparison(df_labeled)
+    with col2:
+        render_discovery_chart(df_labeled)
+
+    # --- Trip list ---
+    st.divider()
+    st.subheader("Detected Trip Periods")
+    trip_rows = [
+        {
+            "Start": str(s.date()),
+            "End": str(e.date()),
+            "Days": (e - s).days + 1,
+        }
+        for s, e in trip_periods
+    ]
+    st.dataframe(pd.DataFrame(trip_rows), use_container_width=True, hide_index=True)
+
+    trip_count = len(df_labeled[df_labeled["context"] == "trip"])
+    home_count = len(df_labeled[df_labeled["context"] == "home"])
+    total = trip_count + home_count
+    if total:
+        pct = round(trip_count / total * 100, 1)
+        st.caption(
+            f"{trip_count:,} scrobbles on trips ({pct}%) · "
+            f"{home_count:,} at home across {len(trip_periods)} trip period(s)."
+        )

--- a/tests/test_analysis_utils.py
+++ b/tests/test_analysis_utils.py
@@ -4,6 +4,8 @@ import unittest
 import pandas as pd
 
 from analysis_utils import (
+    compute_vacation_stats,
+    detect_trip_periods,
     get_artist_monthly_ranks,
     get_cumulative_plays,
     get_day_hour_heatmap,
@@ -14,6 +16,7 @@ from analysis_utils import (
     get_listening_streaks,
     get_milestones,
     get_top_entities,
+    label_listening_context,
     load_listening_data,
 )
 
@@ -185,6 +188,202 @@ class TestAnalysisUtils(unittest.TestCase):
         empty = pd.DataFrame(columns=["artist", "date_text"])
         result = get_artist_monthly_ranks(empty)
         self.assertTrue(result.empty)
+
+
+class TestDetectTripPeriods(unittest.TestCase):
+    """Tests for detect_trip_periods."""
+
+    def _assumptions_with_trips(self) -> dict:
+        return {
+            "trips": [
+                {"start": "2021-03-01", "end": "2021-03-07", "city": "Paris"},
+                {"start": "2021-06-10", "end": "2021-06-15", "city": "Tokyo"},
+            ],
+            "defaults": {"city": "Reykjavik, IS"},
+        }
+
+    def test_returns_assumption_trips(self) -> None:
+        assumptions = self._assumptions_with_trips()
+        periods = detect_trip_periods(assumptions)
+        self.assertEqual(len(periods), 2)
+        self.assertEqual(periods[0][0], pd.Timestamp("2021-03-01"))
+        self.assertEqual(periods[0][1], pd.Timestamp("2021-03-07"))
+
+    def test_empty_trips_returns_empty(self) -> None:
+        periods = detect_trip_periods({"trips": [], "defaults": {"city": "Home City"}})
+        self.assertEqual(periods, [])
+
+    def test_detects_swarm_away_days(self) -> None:
+        # 3 consecutive away days should produce one trip period
+        swarm_df = pd.DataFrame(
+            {
+                "timestamp": [
+                    int(pd.Timestamp("2021-04-01").timestamp()),
+                    int(pd.Timestamp("2021-04-02").timestamp()),
+                    int(pd.Timestamp("2021-04-03").timestamp()),
+                ],
+                "city": ["Amsterdam", "Amsterdam", "Amsterdam"],
+            }
+        )
+        assumptions = {"trips": [], "defaults": {"city": "Reykjavik, IS"}}
+        periods = detect_trip_periods(assumptions, swarm_df=swarm_df, home_city="Reykjavik, IS")
+        self.assertEqual(len(periods), 1)
+        self.assertEqual(periods[0][0], pd.Timestamp("2021-04-01"))
+        self.assertEqual(periods[0][1], pd.Timestamp("2021-04-03"))
+
+    def test_single_away_day_below_threshold_excluded(self) -> None:
+        swarm_df = pd.DataFrame(
+            {
+                "timestamp": [int(pd.Timestamp("2021-04-01").timestamp())],
+                "city": ["Amsterdam"],
+            }
+        )
+        assumptions = {"trips": [], "defaults": {"city": "Reykjavik, IS"}}
+        periods = detect_trip_periods(
+            assumptions, swarm_df=swarm_df, home_city="Reykjavik, IS", min_consecutive_days=2
+        )
+        self.assertEqual(periods, [])
+
+    def test_swarm_home_checkins_excluded(self) -> None:
+        # All swarm check-ins are in home city — no trips detected
+        swarm_df = pd.DataFrame(
+            {
+                "timestamp": [
+                    int(pd.Timestamp("2021-04-01").timestamp()),
+                    int(pd.Timestamp("2021-04-02").timestamp()),
+                    int(pd.Timestamp("2021-04-03").timestamp()),
+                ],
+                "city": ["Reykjavik, IS", "Reykjavik, IS", "Reykjavik, IS"],
+            }
+        )
+        assumptions = {"trips": [], "defaults": {"city": "Reykjavik, IS"}}
+        periods = detect_trip_periods(assumptions, swarm_df=swarm_df, home_city="Reykjavik, IS")
+        self.assertEqual(periods, [])
+
+    def test_sorted_output(self) -> None:
+        assumptions = {
+            "trips": [
+                {"start": "2021-06-10", "end": "2021-06-15", "city": "Tokyo"},
+                {"start": "2021-03-01", "end": "2021-03-07", "city": "Paris"},
+            ],
+            "defaults": {"city": "Reykjavik, IS"},
+        }
+        periods = detect_trip_periods(assumptions)
+        self.assertLessEqual(periods[0][0], periods[1][0])
+
+    def test_malformed_trip_skipped(self) -> None:
+        assumptions = {
+            "trips": [
+                {"start": "not-a-date", "end": "2021-03-07"},
+                {"start": "2021-05-01", "end": "2021-05-05", "city": "London"},
+            ],
+            "defaults": {"city": "Reykjavik, IS"},
+        }
+        periods = detect_trip_periods(assumptions)
+        # Only the valid trip should be returned
+        self.assertEqual(len(periods), 1)
+        self.assertEqual(periods[0][0], pd.Timestamp("2021-05-01"))
+
+
+class TestLabelListeningContext(unittest.TestCase):
+    """Tests for label_listening_context."""
+
+    def _make_df(self) -> pd.DataFrame:
+        df = pd.DataFrame(
+            {
+                "artist": ["A", "B", "C", "D"],
+                "date_text": pd.to_datetime(
+                    ["2021-03-01", "2021-03-05", "2021-03-10", "2021-03-15"]
+                ),
+            }
+        )
+        return df
+
+    def test_labels_trip_rows_correctly(self) -> None:
+        df = self._make_df()
+        periods = [(pd.Timestamp("2021-03-03"), pd.Timestamp("2021-03-07"))]
+        result = label_listening_context(df, periods)
+        self.assertIn("context", result.columns)
+        self.assertEqual(result.iloc[0]["context"], "home")
+        self.assertEqual(result.iloc[1]["context"], "trip")
+        self.assertEqual(result.iloc[2]["context"], "home")
+
+    def test_no_periods_all_home(self) -> None:
+        df = self._make_df()
+        result = label_listening_context(df, [])
+        self.assertTrue((result["context"] == "home").all())
+
+    def test_empty_df_returns_with_context_column(self) -> None:
+        result = label_listening_context(pd.DataFrame(), [])
+        self.assertIn("context", result.columns)
+        self.assertTrue(result.empty)
+
+    def test_multiple_periods(self) -> None:
+        df = self._make_df()
+        periods = [
+            (pd.Timestamp("2021-03-01"), pd.Timestamp("2021-03-01")),
+            (pd.Timestamp("2021-03-15"), pd.Timestamp("2021-03-15")),
+        ]
+        result = label_listening_context(df, periods)
+        self.assertEqual(result.iloc[0]["context"], "trip")
+        self.assertEqual(result.iloc[1]["context"], "home")
+        self.assertEqual(result.iloc[3]["context"], "trip")
+
+
+class TestComputeVacationStats(unittest.TestCase):
+    """Tests for compute_vacation_stats."""
+
+    def _make_labeled_df(self) -> pd.DataFrame:
+        df = pd.DataFrame(
+            {
+                "artist": ["A", "B", "A", "C", "D"],
+                "date_text": pd.to_datetime(
+                    ["2021-01-01", "2021-01-02", "2021-01-03", "2021-01-04", "2021-01-05"]
+                ),
+                "context": ["home", "home", "trip", "trip", "home"],
+            }
+        )
+        return df
+
+    def test_returns_both_contexts(self) -> None:
+        df = self._make_labeled_df()
+        stats = compute_vacation_stats(df)
+        self.assertIn("home", stats)
+        self.assertIn("trip", stats)
+
+    def test_avg_daily_scrobbles_correct(self) -> None:
+        df = self._make_labeled_df()
+        stats = compute_vacation_stats(df)
+        # Home: rows 0 (2021-01-01), 1 (2021-01-02), 4 (2021-01-05) → 3 plays over 3 days → 1.0
+        self.assertEqual(stats["home"]["avg_daily_scrobbles"], 1.0)
+        # Trip: rows 2 (2021-01-03), 3 (2021-01-04) → 2 plays over 2 days → 1.0
+        self.assertEqual(stats["trip"]["avg_daily_scrobbles"], 1.0)
+
+    def test_top_artist_identified(self) -> None:
+        df = self._make_labeled_df()
+        stats = compute_vacation_stats(df)
+        self.assertEqual(stats["home"]["top_artist"], "A")
+
+    def test_empty_df_returns_empty_dict(self) -> None:
+        stats = compute_vacation_stats(pd.DataFrame())
+        self.assertEqual(stats, {})
+
+    def test_missing_context_column_returns_empty(self) -> None:
+        df = pd.DataFrame({"artist": ["A"], "date_text": pd.to_datetime(["2021-01-01"])})
+        stats = compute_vacation_stats(df)
+        self.assertEqual(stats, {})
+
+    def test_single_context_returns_empty_for_missing(self) -> None:
+        df = pd.DataFrame(
+            {
+                "artist": ["A", "B"],
+                "date_text": pd.to_datetime(["2021-01-01", "2021-01-02"]),
+                "context": ["home", "home"],
+            }
+        )
+        stats = compute_vacation_stats(df)
+        self.assertIn("home", stats)
+        self.assertEqual(stats.get("trip"), {})
 
 
 if __name__ == "__main__":

--- a/tests/test_vacation_mode.py
+++ b/tests/test_vacation_mode.py
@@ -1,0 +1,252 @@
+"""Tests for pages/vacation_mode.py render functions."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import ANY, MagicMock, patch
+
+import pandas as pd
+
+from pages.vacation_mode import (
+    render_discovery_chart,
+    render_genre_comparison,
+    render_stat_cards,
+    render_timeline_chart,
+    render_vacation_mode,
+)
+
+
+def _make_labeled_df() -> pd.DataFrame:
+    """Return a small labeled DataFrame with both home and trip rows."""
+    df = pd.DataFrame(
+        {
+            "artist": ["A", "B", "C", "D", "A", "E"],
+            "album": ["X", "X", "Y", "Y", "X", "Z"],
+            "track": ["t1", "t2", "t3", "t4", "t1", "t5"],
+            "timestamp": [
+                1610000000,
+                1610086400,
+                1610172800,
+                1610259200,
+                1610345600,
+                1610432000,
+            ],
+            "date_text": pd.to_datetime(
+                [
+                    "2021-01-07",
+                    "2021-01-08",
+                    "2021-01-09",
+                    "2021-01-10",
+                    "2021-01-11",
+                    "2021-01-12",
+                ]
+            ),
+            "context": ["home", "home", "trip", "trip", "home", "home"],
+        }
+    )
+    return df
+
+
+class TestRenderStatCards(unittest.TestCase):
+    """Tests for render_stat_cards."""
+
+    @patch("streamlit.metric")
+    @patch("streamlit.subheader")
+    @patch("streamlit.columns")
+    @patch("streamlit.container")
+    def test_renders_home_and_trip_sections(
+        self,
+        mock_container: MagicMock,
+        mock_cols: MagicMock,
+        mock_subheader: MagicMock,
+        mock_metric: MagicMock,
+    ) -> None:
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=ctx)
+        ctx.__exit__ = MagicMock(return_value=False)
+        mock_container.return_value = ctx
+        mock_cols.return_value = [ctx, ctx]
+
+        stats = {
+            "home": {
+                "avg_daily_scrobbles": 10.0,
+                "unique_artists_per_day": 3.0,
+                "listening_hours": 2.5,
+                "top_artist": "Artist A",
+            },
+            "trip": {
+                "avg_daily_scrobbles": 5.0,
+                "unique_artists_per_day": 2.0,
+                "listening_hours": 1.0,
+                "top_artist": "Artist B",
+            },
+        }
+        render_stat_cards(stats)
+        # At least Home and Trip subheaders
+        calls = [str(c) for c in mock_subheader.call_args_list]
+        self.assertTrue(any("Home" in c for c in calls))
+        self.assertTrue(any("Trip" in c for c in calls))
+        self.assertTrue(mock_metric.called)
+
+    @patch("streamlit.info")
+    def test_empty_stats_shows_info(self, mock_info: MagicMock) -> None:
+        render_stat_cards({})
+        mock_info.assert_called_once()
+
+
+class TestRenderTimelineChart(unittest.TestCase):
+    """Tests for render_timeline_chart."""
+
+    @patch("streamlit.plotly_chart")
+    def test_renders_chart_with_periods(self, mock_plotly: MagicMock) -> None:
+        df = _make_labeled_df()
+        trip_periods = [
+            (pd.Timestamp("2021-01-09"), pd.Timestamp("2021-01-10")),
+        ]
+        render_timeline_chart(df, trip_periods)
+        mock_plotly.assert_called_once_with(ANY, width="stretch")
+
+    @patch("streamlit.plotly_chart")
+    def test_empty_df_does_not_render(self, mock_plotly: MagicMock) -> None:
+        render_timeline_chart(pd.DataFrame(), [])
+        mock_plotly.assert_not_called()
+
+
+class TestRenderGenreComparison(unittest.TestCase):
+    """Tests for render_genre_comparison."""
+
+    @patch("streamlit.plotly_chart")
+    def test_renders_with_both_contexts(self, mock_plotly: MagicMock) -> None:
+        df = _make_labeled_df()
+        render_genre_comparison(df)
+        mock_plotly.assert_called_once()
+
+    @patch("streamlit.plotly_chart")
+    def test_no_render_when_one_context_empty(self, mock_plotly: MagicMock) -> None:
+        df = _make_labeled_df()
+        df_home_only = df[df["context"] == "home"].copy()
+        render_genre_comparison(df_home_only)
+        mock_plotly.assert_not_called()
+
+
+class TestRenderDiscoveryChart(unittest.TestCase):
+    """Tests for render_discovery_chart."""
+
+    @patch("streamlit.plotly_chart")
+    def test_renders_with_valid_data(self, mock_plotly: MagicMock) -> None:
+        df = _make_labeled_df()
+        render_discovery_chart(df)
+        mock_plotly.assert_called_once()
+
+    @patch("streamlit.plotly_chart")
+    def test_no_render_on_empty_df(self, mock_plotly: MagicMock) -> None:
+        render_discovery_chart(pd.DataFrame())
+        mock_plotly.assert_not_called()
+
+
+class TestRenderVacationMode(unittest.TestCase):
+    """Integration-style tests for render_vacation_mode."""
+
+    def _base_df(self) -> pd.DataFrame:
+        df = pd.DataFrame(
+            {
+                "artist": ["A", "B", "C", "D"],
+                "album": ["X", "X", "Y", "Y"],
+                "track": ["t1", "t2", "t3", "t4"],
+                "timestamp": [1610000000, 1610086400, 1610172800, 1610259200],
+                "date_text": pd.to_datetime(
+                    ["2021-01-07", "2021-01-08", "2021-01-09", "2021-01-10"]
+                ),
+            }
+        )
+        return df
+
+    @patch("streamlit.info")
+    def test_empty_state_shown_when_no_df(self, mock_info: MagicMock) -> None:
+        with patch("streamlit.session_state", {"df": None}):
+            render_vacation_mode()
+        mock_info.assert_called_once()
+
+    @patch("streamlit.warning")
+    @patch("streamlit.caption")
+    @patch("streamlit.subheader")
+    @patch("streamlit.header")
+    @patch("streamlit.info")
+    @patch("streamlit.columns")
+    @patch("streamlit.metric")
+    @patch("streamlit.container")
+    def test_renders_with_no_trips(
+        self,
+        mock_container: MagicMock,
+        mock_metric: MagicMock,
+        mock_cols: MagicMock,
+        mock_info: MagicMock,
+        mock_header: MagicMock,
+        mock_subheader: MagicMock,
+        mock_caption: MagicMock,
+        mock_warning: MagicMock,
+    ) -> None:
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=ctx)
+        ctx.__exit__ = MagicMock(return_value=False)
+        mock_container.return_value = ctx
+        mock_cols.return_value = [ctx, ctx]
+
+        session = {
+            "df": self._base_df(),
+            "assumptions": {"trips": [], "defaults": {"city": "Reykjavik, IS"}},
+            "swarm_df": None,
+        }
+        with patch("streamlit.session_state", session):
+            render_vacation_mode()
+
+        mock_header.assert_called_with("Vacation Mode")
+        mock_warning.assert_called_once()
+
+    @patch("streamlit.dataframe")
+    @patch("streamlit.caption")
+    @patch("streamlit.divider")
+    @patch("streamlit.subheader")
+    @patch("streamlit.header")
+    @patch("streamlit.columns")
+    @patch("streamlit.metric")
+    @patch("streamlit.container")
+    @patch("streamlit.plotly_chart")
+    def test_renders_with_trip_periods(
+        self,
+        mock_plotly: MagicMock,
+        mock_container: MagicMock,
+        mock_metric: MagicMock,
+        mock_cols: MagicMock,
+        mock_header: MagicMock,
+        mock_subheader: MagicMock,
+        mock_divider: MagicMock,
+        mock_caption: MagicMock,
+        mock_df_widget: MagicMock,
+    ) -> None:
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=ctx)
+        ctx.__exit__ = MagicMock(return_value=False)
+        mock_container.return_value = ctx
+        mock_cols.return_value = [ctx, ctx]
+
+        assumptions = {
+            "trips": [{"start": "2021-01-09", "end": "2021-01-10", "city": "Paris"}],
+            "defaults": {"city": "Reykjavik, IS"},
+        }
+        session = {
+            "df": self._base_df(),
+            "assumptions": assumptions,
+            "swarm_df": None,
+        }
+        with patch("streamlit.session_state", session):
+            render_vacation_mode()
+
+        mock_header.assert_called_with("Vacation Mode")
+        # Timeline + comparison + discovery charts should be rendered
+        self.assertTrue(mock_plotly.called)
+        mock_df_widget.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -35,6 +35,7 @@ from pages.music import (
 )
 from pages.overview import render_overview
 from pages.places import render_spatial_analysis
+from pages.vacation_mode import render_vacation_mode
 from visualize import main
 
 
@@ -633,6 +634,48 @@ class TestMusicHelpers(unittest.TestCase):
         st.session_state["df"] = None
         render_music()
         mock_info.assert_called_once()
+
+    @patch("streamlit.info")
+    def test_render_vacation_mode_empty_state(self, mock_info: MagicMock) -> None:
+        with patch("streamlit.session_state", {"df": None}):
+            render_vacation_mode()
+        mock_info.assert_called_once()
+
+    @patch("streamlit.warning")
+    @patch("streamlit.caption")
+    @patch("streamlit.subheader")
+    @patch("streamlit.header")
+    @patch("streamlit.info")
+    @patch("streamlit.columns")
+    @patch("streamlit.metric")
+    @patch("streamlit.container")
+    def test_render_vacation_mode_no_trips(
+        self,
+        mock_container: MagicMock,
+        mock_metric: MagicMock,
+        mock_cols: MagicMock,
+        mock_info: MagicMock,
+        mock_header: MagicMock,
+        mock_subheader: MagicMock,
+        mock_caption: MagicMock,
+        mock_warning: MagicMock,
+    ) -> None:
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=ctx)
+        ctx.__exit__ = MagicMock(return_value=False)
+        mock_container.return_value = ctx
+        mock_cols.return_value = [ctx, ctx]
+
+        session = {
+            "df": self._make_df(),
+            "assumptions": {"trips": [], "defaults": {"city": "Reykjavik, IS"}},
+            "swarm_df": None,
+        }
+        with patch("streamlit.session_state", session):
+            render_vacation_mode()
+
+        mock_header.assert_called_with("Vacation Mode")
+        mock_warning.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/visualize.py
+++ b/visualize.py
@@ -30,6 +30,7 @@ from pages.places import (  # noqa: F401
     render_places,
     render_spatial_analysis,
 )
+from pages.vacation_mode import render_vacation_mode
 from plugins.sources import REGISTRY, load_builtin_plugins
 
 load_dotenv()
@@ -125,6 +126,11 @@ def main() -> None:
             "Music": [
                 st.Page(render_music, title="Listening", icon=":material/headphones:"),
                 st.Page(render_insights, title="Insights", icon=":material/auto_stories:"),
+                st.Page(
+                    render_vacation_mode,
+                    title="Vacation Mode",
+                    icon=":material/flight_takeoff:",
+                ),
             ],
             "Places": [
                 st.Page(render_places, title="Check-ins", icon=":material/location_on:"),


### PR DESCRIPTION
## Summary

- Add `detect_trip_periods(assumptions, swarm_df)` to `analysis_utils.py`: unions explicit trips from the assumptions file with Swarm check-ins where city ≠ home city for 2+ consecutive days
- Add `label_listening_context()` to label each Last.fm row as `'home'` or `'trip'`
- Add `compute_vacation_stats()` to compute per-context metrics (avg daily scrobbles, unique artists/day, listening hours, top artist)
- New page `pages/vacation_mode.py` with `render_vacation_mode()`: side-by-side metric cards (Home vs. Trip), daily scrobble timeline with trip periods shaded, artist comparison bar chart, and new-artist discovery rate chart
- Registered in `visualize.py` under the Music section with `:material/flight_takeoff:` icon

## Test plan

- [ ] `pytest` passes (285 tests, all green)
- [ ] `ruff check .` — no issues
- [ ] `ruff format --check .` — all files formatted correctly
- [ ] `mypy` — no issues
- [ ] Empty state shown when no Last.fm data loaded
- [ ] Warning shown when no trip periods detected; only home stats rendered
- [ ] Timeline chart shows orange bars and shaded vrects during trip periods
- [ ] Artist comparison and discovery rate charts render with real data

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)