### PR TITLE
feat: Holiday Soundtrack — recurring annual listening patterns (#65)

### DIFF
--- a/default_assumptions.json.example
+++ b/default_assumptions.json.example
@@ -23,6 +23,60 @@
       "lat": 61.2181,
       "lng": -149.9003,
       "timezone": "US/Alaska"
+    },
+    {
+      "name": "Halloween",
+      "month": 10,
+      "day_range": [31, 31],
+      "city": "Your City",
+      "lat": 0.0,
+      "lng": 0.0,
+      "timezone": "America/Chicago"
+    },
+    {
+      "name": "Christmas",
+      "month": 12,
+      "day_range": [24, 26],
+      "city": "Your City",
+      "lat": 0.0,
+      "lng": 0.0,
+      "timezone": "America/Chicago"
+    },
+    {
+      "name": "Thanksgiving",
+      "month": 11,
+      "day_range": [22, 28],
+      "city": "Your City",
+      "lat": 0.0,
+      "lng": 0.0,
+      "timezone": "America/Chicago"
+    },
+    {
+      "name": "New Years",
+      "month": 1,
+      "day_range": [1, 2],
+      "city": "Your City",
+      "lat": 0.0,
+      "lng": 0.0,
+      "timezone": "America/Chicago"
+    },
+    {
+      "name": "Fourth of July",
+      "month": 7,
+      "day_range": [4, 4],
+      "city": "Your City",
+      "lat": 0.0,
+      "lng": 0.0,
+      "timezone": "America/Chicago"
+    },
+    {
+      "name": "Easter",
+      "month": 4,
+      "day_range": [14, 20],
+      "city": "Your City",
+      "lat": 0.0,
+      "lng": 0.0,
+      "timezone": "America/Chicago"
     }
   ],
   "trips": [

--- a/pages/holiday_soundtrack.py
+++ b/pages/holiday_soundtrack.py
@@ -1,0 +1,347 @@
+"""Holiday Soundtrack page — recurring annual listening patterns (issue #65).
+
+For each holiday defined in the user's assumptions file, this page shows:
+- Year-over-year total play counts (line chart)
+- Artist consistency heatmap (years × top artists, coloured by play count)
+- Jaccard-similarity scores between consecutive years' top-10 artist sets
+- Signature song (most-played track across all years of that holiday)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+import streamlit as st
+
+from components.theme import (
+    ACCENT_INDIGO,
+    SEQUENTIAL_SCALE,
+    TEAL,
+    apply_dark_theme,
+)
+
+# ---------------------------------------------------------------------------
+# Pure computation helpers (tested independently)
+# ---------------------------------------------------------------------------
+
+
+def _build_holiday_windows(df: pd.DataFrame, holiday: dict[str, Any]) -> list[dict[str, Any]]:
+    """Build per-year date windows for a recurring holiday.
+
+    Args:
+        df: Full listening-history DataFrame with a ``date_text`` column.
+        holiday: Holiday definition dict with ``month`` and ``day_range`` keys.
+
+    Returns:
+        List of dicts, one per calendar year that appears in ``df``, each
+        containing ``year``, ``start`` (Timestamp), and ``end`` (Timestamp).
+    """
+    if df.empty or "date_text" not in df.columns:
+        return []
+
+    month: int = holiday.get("month", 1)
+    day_range: list[int] = holiday.get("day_range", [1, 1])
+    day_start, day_end = day_range[0], day_range[1]
+
+    years = sorted(df["date_text"].dt.year.unique())
+    windows: list[dict[str, Any]] = []
+    for year in years:
+        try:
+            start = pd.Timestamp(year=year, month=month, day=day_start)
+            end = pd.Timestamp(year=year, month=month, day=day_end, hour=23, minute=59, second=59)
+        except ValueError:
+            # Invalid date (e.g. day 31 in a month with fewer days) — skip silently.
+            continue
+        windows.append({"year": int(year), "start": start, "end": end})
+    return windows
+
+
+def _filter_holiday(df: pd.DataFrame, window: dict[str, Any]) -> pd.DataFrame:
+    """Return rows whose ``date_text`` falls within a holiday window.
+
+    Args:
+        df: Listening history with a ``date_text`` column.
+        window: Dict with ``start`` and ``end`` Timestamp keys.
+
+    Returns:
+        Filtered sub-DataFrame (may be empty).
+    """
+    mask = (df["date_text"] >= window["start"]) & (df["date_text"] <= window["end"])
+    return df[mask]
+
+
+def _year_over_year_plays(df: pd.DataFrame, windows: list[dict[str, Any]]) -> pd.DataFrame:
+    """Compute total play counts per year for a list of holiday windows.
+
+    Args:
+        df: Full listening history.
+        windows: Output of :func:`_build_holiday_windows`.
+
+    Returns:
+        DataFrame with columns ``year`` (int) and ``plays`` (int).
+    """
+    rows = []
+    for w in windows:
+        subset = _filter_holiday(df, w)
+        rows.append({"year": w["year"], "plays": len(subset)})
+    return pd.DataFrame(rows)
+
+
+def _top_artists_for_year(df: pd.DataFrame, window: dict[str, Any], n: int = 10) -> set[str]:
+    """Return the top-N artist names by play count within a holiday window.
+
+    Args:
+        df: Full listening history.
+        window: A single year's holiday window dict.
+        n: How many top artists to include.
+
+    Returns:
+        Set of artist name strings (may be smaller than ``n`` if data is sparse).
+    """
+    subset = _filter_holiday(df, window)
+    if subset.empty or "artist" not in subset.columns:
+        return set()
+    return set(subset["artist"].value_counts().head(n).index.tolist())
+
+
+def _jaccard_similarity(set_a: set[str], set_b: set[str]) -> float:
+    """Compute Jaccard similarity between two sets.
+
+    Args:
+        set_a: First set of strings.
+        set_b: Second set of strings.
+
+    Returns:
+        Float in [0, 1].  Returns 0.0 when both sets are empty.
+    """
+    union = set_a | set_b
+    if not union:
+        return 0.0
+    return len(set_a & set_b) / len(union)
+
+
+def _signature_song(df: pd.DataFrame, windows: list[dict[str, Any]]) -> str | None:
+    """Find the most-played track across all holiday windows.
+
+    Args:
+        df: Full listening history.
+        windows: All per-year windows for a holiday.
+
+    Returns:
+        ``"Artist — Track"`` string, or ``None`` when no data exists.
+    """
+    if not windows or df.empty:
+        return None
+
+    subsets = [_filter_holiday(df, w) for w in windows]
+    combined = pd.concat(subsets, ignore_index=True)
+    if combined.empty or "track" not in combined.columns or "artist" not in combined.columns:
+        return None
+
+    combined["_song_key"] = combined["artist"] + " — " + combined["track"]
+    top = combined["_song_key"].value_counts()
+    if top.empty:
+        return None
+    return str(top.index[0])
+
+
+# ---------------------------------------------------------------------------
+# Chart renderers
+# ---------------------------------------------------------------------------
+
+
+def _render_yoy_chart(yoy: pd.DataFrame, holiday_name: str) -> None:
+    """Render the year-over-year total plays line chart.
+
+    Args:
+        yoy: DataFrame with ``year`` and ``plays`` columns.
+        holiday_name: Display name of the holiday (used in the chart title).
+    """
+    if yoy.empty or yoy["plays"].sum() == 0:
+        st.caption("No plays found for this holiday.")
+        return
+
+    fig = px.line(
+        yoy,
+        x="year",
+        y="plays",
+        markers=True,
+        title=f"{holiday_name} — Total Plays by Year",
+        labels={"year": "Year", "plays": "Plays"},
+    )
+    fig.update_traces(line_color=TEAL, marker_color=ACCENT_INDIGO, marker_size=8)
+    fig.update_xaxes(dtick=1, tickformat="d")
+    apply_dark_theme(fig)
+    st.plotly_chart(fig, width="stretch")
+
+
+def _render_artist_heatmap(
+    df: pd.DataFrame, windows: list[dict[str, Any]], holiday_name: str, top_n: int = 10
+) -> None:
+    """Render a years × top-artists heatmap coloured by play count.
+
+    Args:
+        df: Full listening history.
+        windows: Per-year holiday windows.
+        holiday_name: Display name of the holiday (used in the chart title).
+        top_n: Number of top artists to track across all years.
+    """
+    if not windows:
+        return
+
+    # Collect all holiday plays to find the globally top-N artists.
+    combined = pd.concat([_filter_holiday(df, w) for w in windows], ignore_index=True)
+    if combined.empty or "artist" not in combined.columns:
+        st.caption("Not enough data to build artist heatmap.")
+        return
+
+    global_top = combined["artist"].value_counts().head(top_n).index.tolist()
+    if not global_top:
+        return
+
+    # Build a year × artist pivot.
+    records = []
+    for w in windows:
+        subset = _filter_holiday(df, w)
+        if subset.empty:
+            continue
+        counts = subset[subset["artist"].isin(global_top)]["artist"].value_counts()
+        for artist in global_top:
+            records.append(
+                {"year": w["year"], "artist": artist, "plays": int(counts.get(artist, 0))}
+            )
+
+    pivot_df = pd.DataFrame(records)
+    if pivot_df.empty:
+        return
+
+    pivot = pivot_df.pivot(index="artist", columns="year", values="plays").fillna(0)
+
+    fig = go.Figure(
+        go.Heatmap(
+            z=pivot.values.tolist(),
+            x=[str(c) for c in pivot.columns],
+            y=pivot.index.tolist(),
+            colorscale=SEQUENTIAL_SCALE,
+            hoverongaps=False,
+            hovertemplate="Year: %{x}<br>Artist: %{y}<br>Plays: %{z}<extra></extra>",
+        )
+    )
+    fig.update_layout(
+        title=f"{holiday_name} — Artist Consistency (plays per year)",
+        xaxis_title="Year",
+        yaxis_title="Artist",
+        yaxis={"autorange": "reversed"},
+    )
+    apply_dark_theme(fig)
+    st.plotly_chart(fig, width="stretch")
+
+
+def _render_jaccard_chart(
+    df: pd.DataFrame, windows: list[dict[str, Any]], holiday_name: str
+) -> None:
+    """Render a bar chart of year-over-year Jaccard similarities for the top-10 artists.
+
+    Args:
+        df: Full listening history.
+        windows: Per-year holiday windows (must have at least 2 to show anything).
+        holiday_name: Display name of the holiday.
+    """
+    if len(windows) < 2:
+        return
+
+    top_sets = {w["year"]: _top_artists_for_year(df, w, n=10) for w in windows}
+    years_sorted = sorted(top_sets.keys())
+
+    records = []
+    for i in range(1, len(years_sorted)):
+        y_prev = years_sorted[i - 1]
+        y_curr = years_sorted[i]
+        sim = _jaccard_similarity(top_sets[y_prev], top_sets[y_curr])
+        records.append({"pair": f"{y_prev}→{y_curr}", "jaccard": round(sim, 3)})
+
+    if not records:
+        return
+
+    sim_df = pd.DataFrame(records)
+    fig = px.bar(
+        sim_df,
+        x="pair",
+        y="jaccard",
+        title=f"{holiday_name} — Artist Consistency (Jaccard Similarity, top-10)",
+        labels={"pair": "Year Pair", "jaccard": "Jaccard Similarity"},
+        range_y=[0, 1],
+    )
+    fig.update_traces(marker_color=ACCENT_INDIGO)
+    apply_dark_theme(fig)
+    st.plotly_chart(fig, width="stretch")
+
+
+# ---------------------------------------------------------------------------
+# Page entry-point
+# ---------------------------------------------------------------------------
+
+
+def render_holiday_soundtrack() -> None:
+    """Render the Holiday Soundtrack page.
+
+    Reads ``st.session_state['df']`` and ``st.session_state['assumptions']``.
+    Shows an empty-state info message when data or holidays are missing.
+    """
+    df: pd.DataFrame | None = st.session_state.get("df")
+    assumptions: dict[str, Any] = st.session_state.get("assumptions") or {}
+    holidays: list[dict[str, Any]] = assumptions.get("holidays", [])
+
+    if df is None or df.empty:
+        st.info(
+            "No music data loaded yet. "
+            "Configure a Last.fm source in the sidebar and select a data file."
+        )
+        return
+
+    if not holidays:
+        st.info(
+            "No holidays are defined in your assumptions file. "
+            "Add entries to the ``holidays`` array in your assumptions JSON to use this page."
+        )
+        return
+
+    st.header("Holiday Soundtrack")
+
+    holiday_names = [h.get("name", f"Holiday {i}") for i, h in enumerate(holidays)]
+    selected_name = st.selectbox("Select Holiday", holiday_names)
+    holiday_def = next((h for h in holidays if h.get("name") == selected_name), holidays[0])
+
+    windows = _build_holiday_windows(df, holiday_def)
+    yoy = _year_over_year_plays(df, windows)
+
+    # ── Summary metrics ──────────────────────────────────────────────────────
+    total_plays = int(yoy["plays"].sum()) if not yoy.empty else 0
+    active_years = int((yoy["plays"] > 0).sum()) if not yoy.empty else 0
+    sig_song = _signature_song(df, windows)
+
+    c1, c2, c3 = st.columns(3)
+    with c1:
+        st.metric("Total Holiday Plays", f"{total_plays:,}")
+    with c2:
+        st.metric("Years with Data", str(active_years))
+    with c3:
+        st.metric("Signature Song", sig_song or "—")
+
+    st.divider()
+
+    # ── Year-over-year line chart ─────────────────────────────────────────────
+    st.subheader("Year-over-Year Plays")
+    _render_yoy_chart(yoy, selected_name)
+
+    st.divider()
+
+    # ── Artist consistency heatmap ────────────────────────────────────────────
+    st.subheader("Artist Consistency")
+    _render_artist_heatmap(df, windows, selected_name, top_n=10)
+
+    # ── Jaccard similarity chart ──────────────────────────────────────────────
+    _render_jaccard_chart(df, windows, selected_name)

--- a/tests/test_holiday_soundtrack.py
+++ b/tests/test_holiday_soundtrack.py
@@ -1,0 +1,246 @@
+"""Unit tests for the Holiday Soundtrack page (issue #65)."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from pages.holiday_soundtrack import (
+    _build_holiday_windows,
+    _filter_holiday,
+    _jaccard_similarity,
+    _signature_song,
+    _top_artists_for_year,
+    _year_over_year_plays,
+    render_holiday_soundtrack,
+)
+
+
+def _make_df() -> pd.DataFrame:
+    """Return a minimal listening-history DataFrame spanning two Christmases."""
+    rows = [
+        # Christmas 2021
+        {
+            "artist": "Mariah Carey",
+            "track": "All I Want for Christmas Is You",
+            "date_text": "2021-12-25 10:00:00",
+        },
+        {
+            "artist": "Mariah Carey",
+            "track": "All I Want for Christmas Is You",
+            "date_text": "2021-12-25 11:00:00",
+        },
+        {"artist": "Wham!", "track": "Last Christmas", "date_text": "2021-12-25 12:00:00"},
+        # Christmas 2022
+        {
+            "artist": "Mariah Carey",
+            "track": "All I Want for Christmas Is You",
+            "date_text": "2022-12-25 09:00:00",
+        },
+        {
+            "artist": "Brenda Lee",
+            "track": "Rockin Around the Christmas Tree",
+            "date_text": "2022-12-25 10:00:00",
+        },
+        # Halloween 2021
+        {"artist": "Michael Jackson", "track": "Thriller", "date_text": "2021-10-31 20:00:00"},
+        # Off-holiday track
+        {"artist": "Other Artist", "track": "Summer Song", "date_text": "2021-06-15 14:00:00"},
+    ]
+    df = pd.DataFrame(rows)
+    df["date_text"] = pd.to_datetime(df["date_text"])
+    return df
+
+
+_CHRISTMAS_DEF = {"name": "Christmas", "month": 12, "day_range": [24, 26]}
+_HALLOWEEN_DEF = {"name": "Halloween", "month": 10, "day_range": [31, 31]}
+
+
+class TestBuildHolidayWindows(unittest.TestCase):
+    """Tests for _build_holiday_windows."""
+
+    def test_returns_rows_for_every_year_in_range(self) -> None:
+        df = _make_df()
+        windows = _build_holiday_windows(df, _CHRISTMAS_DEF)
+        years = [w["year"] for w in windows]
+        self.assertIn(2021, years)
+        self.assertIn(2022, years)
+
+    def test_window_bounds_match_day_range(self) -> None:
+        df = _make_df()
+        windows = _build_holiday_windows(df, _CHRISTMAS_DEF)
+        for w in windows:
+            self.assertEqual(w["start"].month, 12)
+            self.assertEqual(w["start"].day, 24)
+            self.assertEqual(w["end"].month, 12)
+            self.assertEqual(w["end"].day, 26)
+
+    def test_empty_df_returns_empty_list(self) -> None:
+        windows = _build_holiday_windows(pd.DataFrame(), _CHRISTMAS_DEF)
+        self.assertEqual(windows, [])
+
+
+class TestFilterHoliday(unittest.TestCase):
+    """Tests for _filter_holiday."""
+
+    def test_keeps_rows_inside_window(self) -> None:
+        df = _make_df()
+        windows = _build_holiday_windows(df, _CHRISTMAS_DEF)
+        # 2021 Christmas window
+        w = next(w for w in windows if w["year"] == 2021)
+        filtered = _filter_holiday(df, w)
+        self.assertEqual(len(filtered), 3)  # 2 Mariah + 1 Wham! on 2021-12-25
+
+    def test_excludes_off_holiday_rows(self) -> None:
+        df = _make_df()
+        windows = _build_holiday_windows(df, _CHRISTMAS_DEF)
+        all_christmas = pd.concat([_filter_holiday(df, w) for w in windows], ignore_index=True)
+        self.assertNotIn("Other Artist", all_christmas["artist"].values)
+        self.assertNotIn("Michael Jackson", all_christmas["artist"].values)
+
+
+class TestYearOverYearPlays(unittest.TestCase):
+    """Tests for _year_over_year_plays."""
+
+    def test_returns_dataframe_with_year_and_plays_columns(self) -> None:
+        df = _make_df()
+        windows = _build_holiday_windows(df, _CHRISTMAS_DEF)
+        result = _year_over_year_plays(df, windows)
+        self.assertIn("year", result.columns)
+        self.assertIn("plays", result.columns)
+
+    def test_play_counts_are_correct(self) -> None:
+        df = _make_df()
+        windows = _build_holiday_windows(df, _CHRISTMAS_DEF)
+        result = _year_over_year_plays(df, windows)
+        plays_2021 = result.loc[result["year"] == 2021, "plays"].iloc[0]
+        plays_2022 = result.loc[result["year"] == 2022, "plays"].iloc[0]
+        self.assertEqual(plays_2021, 3)
+        self.assertEqual(plays_2022, 2)
+
+
+class TestTopArtistsForYear(unittest.TestCase):
+    """Tests for _top_artists_for_year."""
+
+    def test_returns_top_n_artists(self) -> None:
+        df = _make_df()
+        windows = _build_holiday_windows(df, _CHRISTMAS_DEF)
+        w_2021 = next(w for w in windows if w["year"] == 2021)
+        top = _top_artists_for_year(df, w_2021, n=10)
+        self.assertIn("Mariah Carey", top)
+
+    def test_respects_n_limit(self) -> None:
+        df = _make_df()
+        windows = _build_holiday_windows(df, _CHRISTMAS_DEF)
+        w_2021 = next(w for w in windows if w["year"] == 2021)
+        top = _top_artists_for_year(df, w_2021, n=1)
+        self.assertEqual(len(top), 1)
+
+    def test_empty_window_returns_empty_set(self) -> None:
+        # A window in a year with no data
+        window = {
+            "year": 1900,
+            "start": pd.Timestamp("1900-12-24"),
+            "end": pd.Timestamp("1900-12-26"),
+        }
+        top = _top_artists_for_year(_make_df(), window, n=10)
+        self.assertEqual(len(top), 0)
+
+
+class TestJaccardSimilarity(unittest.TestCase):
+    """Tests for _jaccard_similarity."""
+
+    def test_identical_sets_return_one(self) -> None:
+        self.assertAlmostEqual(_jaccard_similarity({"a", "b"}, {"a", "b"}), 1.0)
+
+    def test_disjoint_sets_return_zero(self) -> None:
+        self.assertAlmostEqual(_jaccard_similarity({"a"}, {"b"}), 0.0)
+
+    def test_partial_overlap(self) -> None:
+        # {"a","b"} ∩ {"b","c"} = {"b"}, union = {"a","b","c"} → 1/3
+        result = _jaccard_similarity({"a", "b"}, {"b", "c"})
+        self.assertAlmostEqual(result, 1 / 3)
+
+    def test_empty_sets_return_zero(self) -> None:
+        self.assertAlmostEqual(_jaccard_similarity(set(), set()), 0.0)
+
+
+class TestSignatureSong(unittest.TestCase):
+    """Tests for _signature_song."""
+
+    def test_returns_most_played_track(self) -> None:
+        df = _make_df()
+        windows = _build_holiday_windows(df, _CHRISTMAS_DEF)
+        song = _signature_song(df, windows)
+        # Mariah Carey's track appears 3 times across both Christmases
+        self.assertIsNotNone(song)
+        assert song is not None  # narrow type for mypy
+        self.assertIn("Mariah Carey", song)
+
+    def test_no_data_returns_none(self) -> None:
+        # No Christmas rows → empty windows or zero-count holiday
+        song = _signature_song(pd.DataFrame(), [])
+        self.assertIsNone(song)
+
+
+class TestRenderHolidaySoundtrack(unittest.TestCase):
+    """Integration smoke-tests for render_holiday_soundtrack."""
+
+    def _session_with_data(self) -> dict:
+        return {"df": _make_df(), "assumptions": {"holidays": [_CHRISTMAS_DEF, _HALLOWEEN_DEF]}}
+
+    @patch("streamlit.info")
+    def test_empty_state_shows_info(self, mock_info: MagicMock) -> None:
+        with patch("streamlit.session_state", {"df": None, "assumptions": {}}):
+            render_holiday_soundtrack()
+        mock_info.assert_called_once()
+
+    @patch("streamlit.info")
+    def test_no_holidays_shows_info(self, mock_info: MagicMock) -> None:
+        df = _make_df()
+        session = {"df": df, "assumptions": {"holidays": []}}
+        with patch("streamlit.session_state", session):
+            render_holiday_soundtrack()
+        mock_info.assert_called_once()
+
+    @patch("streamlit.plotly_chart")
+    @patch("streamlit.subheader")
+    @patch("streamlit.header")
+    @patch("streamlit.selectbox")
+    @patch("streamlit.metric")
+    @patch("streamlit.columns")
+    @patch("streamlit.caption")
+    @patch("streamlit.markdown")
+    @patch("streamlit.divider")
+    def test_render_with_data(
+        self,
+        mock_divider: MagicMock,
+        mock_md: MagicMock,
+        mock_caption: MagicMock,
+        mock_cols: MagicMock,
+        mock_metric: MagicMock,
+        mock_select: MagicMock,
+        mock_header: MagicMock,
+        mock_subheader: MagicMock,
+        mock_plotly: MagicMock,
+    ) -> None:
+        """render_holiday_soundtrack renders at least one chart with valid data."""
+        mock_select.return_value = "Christmas"
+        # Provide enough column mock lists for every st.columns() call in the page.
+        mock_cols.side_effect = [
+            [MagicMock(), MagicMock(), MagicMock()],  # metric row
+        ] * 20  # generous upper bound
+
+        session = self._session_with_data()
+        with patch("streamlit.session_state", session):
+            render_holiday_soundtrack()
+
+        mock_header.assert_called_once_with("Holiday Soundtrack")
+        # At least the year-over-year line chart must be drawn.
+        self.assertGreater(mock_plotly.call_count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_location_fallbacks.py
+++ b/tests/test_location_fallbacks.py
@@ -83,8 +83,8 @@ class TestLocationFallbacks(unittest.TestCase):
             {"dt": datetime(2016, 1, 3, 12, 0, tzinfo=timezone.utc), "expected": "Nairobi, KE"},
             # 5. Residency Home 2: Jan 5, 2020 (Sunday) (Mombasa)
             {"dt": datetime(2020, 1, 5, 12, 0, tzinfo=timezone.utc), "expected": "Mombasa, KE"},
-            # 6. Default: 2026 (After residency ends)
-            {"dt": datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc), "expected": "Reykjavik, IS"},
+            # 6. Default: 2026 (After residency ends, mid-February avoids all holidays)
+            {"dt": datetime(2026, 2, 15, 12, 0, tzinfo=timezone.utc), "expected": "Reykjavik, IS"},
         ]
 
         df = pd.DataFrame(

--- a/visualize.py
+++ b/visualize.py
@@ -22,6 +22,7 @@ from pages.beer import render_beer
 from pages.culture import render_culture
 from pages.data_sources import render_data_sources, render_plugin_page
 from pages.fitness import render_fitness
+from pages.holiday_soundtrack import render_holiday_soundtrack
 from pages.insights import render_insights, render_insights_and_narrative  # noqa: F401
 from pages.music import render_music, render_top_charts  # noqa: F401
 from pages.overview import render_overview  # noqa: F401
@@ -125,6 +126,11 @@ def main() -> None:
             "Music": [
                 st.Page(render_music, title="Listening", icon=":material/headphones:"),
                 st.Page(render_insights, title="Insights", icon=":material/auto_stories:"),
+                st.Page(
+                    render_holiday_soundtrack,
+                    title="Holiday Soundtrack",
+                    icon=":material/celebration:",
+                ),
             ],
             "Places": [
                 st.Page(render_places, title="Check-ins", icon=":material/location_on:"),


### PR DESCRIPTION
## Summary

- Adds a new **Holiday Soundtrack** page under the Music nav group (`:material/celebration:` icon) that shows year-over-year listening patterns for each holiday defined in the user's assumptions file.
- Extends `default_assumptions.json.example` with 6 US holidays: Halloween (Oct 31), Christmas (Dec 24–26), Thanksgiving (Nov 22–28), New Years (Jan 1–2), Fourth of July (Jul 4), and Easter (Apr 14–20).
- Implements `pages/holiday_soundtrack.py` with pure, tested helper functions (`_build_holiday_windows`, `_filter_holiday`, `_year_over_year_plays`, `_top_artists_for_year`, `_jaccard_similarity`, `_signature_song`) and chart renderers (year-over-year line chart, artist consistency heatmap, Jaccard similarity bar chart).
- Registers the page in `visualize.py` and adds 19 new tests in `tests/test_holiday_soundtrack.py` covering all helpers and integration smoke-tests.
- Fixes `tests/test_location_fallbacks.py`: the default-fallback probe was 2026-01-01, which now correctly matches the new New Years holiday entry; changed to 2026-02-15.

## Test plan

- [x] All 19 new tests in `tests/test_holiday_soundtrack.py` pass
- [x] All 274 tests pass with `pytest` (pre-push hook ran and succeeded)
- [x] `ruff check`, `ruff format --check`, and `mypy` all pass (pre-commit and pre-push hooks)
- [x] Holiday selector shows all holidays from assumptions file
- [x] Year-over-year line chart renders when holiday data exists
- [x] Artist consistency heatmap renders with global top-10 artists
- [x] Jaccard similarity bar chart renders for consecutive year pairs
- [x] Summary metrics (total plays, years with data, signature song) display correctly
- [x] Empty state shows info message when no data or no holidays configured

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)