### PR TITLE
feat: Dining Soundtrack — music around restaurant check-ins (#59)

### DIFF
--- a/analysis_utils.py
+++ b/analysis_utils.py
@@ -119,10 +119,19 @@ def load_listening_data(file_path: str) -> Optional[pd.DataFrame]:
 def load_swarm_data(swarm_dir: str) -> pd.DataFrame:
     """Load and parse Swarm checkin data from JSON files."""
     all_checkins = []
+    _EMPTY_COLS = [
+        "timestamp",
+        "offset",
+        "city",
+        "state",
+        "country",
+        "venue",
+        "venue_category",
+        "lat",
+        "lng",
+    ]
     if not swarm_dir or not os.path.exists(swarm_dir):
-        return pd.DataFrame(
-            columns=["timestamp", "offset", "city", "state", "country", "venue", "lat", "lng"]
-        )
+        return pd.DataFrame(columns=_EMPTY_COLS)
 
     json_files = glob.glob(os.path.join(swarm_dir, "checkins*.json"))
     for file_path in json_files:
@@ -166,6 +175,12 @@ def load_swarm_data(swarm_dir: str) -> pd.DataFrame:
                     lat = item.get("lat") or location.get("lat")
                     lng = item.get("lng") or location.get("lng")
 
+                    # Parse Foursquare venue category — take the first (primary) category.
+                    # Foursquare exports store categories as a list of objects with a
+                    # "name" field and an optional "pluralName" / "shortName" field.
+                    categories = venue.get("categories") or []
+                    venue_category = categories[0].get("name", "") if categories else ""
+
                     all_checkins.append(
                         {
                             "timestamp": ts,
@@ -174,6 +189,7 @@ def load_swarm_data(swarm_dir: str) -> pd.DataFrame:
                             "state": state,
                             "country": country,
                             "venue": venue.get("name", "Unknown"),
+                            "venue_category": venue_category,
                             "lat": lat,
                             "lng": lng,
                             "_needs_geocode": needs_geocode and lat is not None and lng is not None,
@@ -183,9 +199,7 @@ def load_swarm_data(swarm_dir: str) -> pd.DataFrame:
             print(f"Error loading {file_path}: {e}")
 
     if not all_checkins:
-        return pd.DataFrame(
-            columns=["timestamp", "offset", "city", "state", "country", "venue", "lat", "lng"]
-        )
+        return pd.DataFrame(columns=_EMPTY_COLS)
 
     df = pd.DataFrame(all_checkins)
 

--- a/pages/dining_soundtrack.py
+++ b/pages/dining_soundtrack.py
@@ -1,0 +1,331 @@
+"""Dining Soundtrack page — music listened to around food and drink check-ins.
+
+Matches Foursquare/Swarm check-ins at food and drink venues with Last.fm
+listens in a ±2 hour window, then groups the results by venue category to
+show top artists, average plays, and the most common listening hour.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+from analysis_utils import get_top_entities
+from components.theme import (
+    ACCENT_INDIGO,
+    AMBER,
+    COLORWAY,
+    TEAL,
+    apply_dark_theme,
+)
+
+# ---------------------------------------------------------------------------
+# Category taxonomy — maps partial Foursquare category name substrings to
+# the four display buckets shown in the venue grid.
+# ---------------------------------------------------------------------------
+
+#: The four venue buckets displayed on the page.
+FOOD_DRINK_CATEGORIES: list[str] = [
+    "Restaurants",
+    "Bars & Nightlife",
+    "Cafes",
+    "Fast Food",
+]
+
+# Ordered list of (substring, bucket) rules; first match wins.
+_CATEGORY_RULES: list[tuple[str, str]] = [
+    # Fast food — check before "restaurant" to avoid false positive
+    ("fast food", "Fast Food"),
+    ("burger", "Fast Food"),
+    ("pizza", "Fast Food"),
+    ("fried chicken", "Fast Food"),
+    ("hot dog", "Fast Food"),
+    ("sandwich", "Fast Food"),
+    # Bars & Nightlife
+    ("bar", "Bars & Nightlife"),
+    ("nightclub", "Bars & Nightlife"),
+    ("pub", "Bars & Nightlife"),
+    ("brewery", "Bars & Nightlife"),
+    ("wine", "Bars & Nightlife"),
+    ("cocktail", "Bars & Nightlife"),
+    ("lounge", "Bars & Nightlife"),
+    ("club", "Bars & Nightlife"),
+    # Cafes
+    ("cafe", "Cafes"),
+    ("café", "Cafes"),
+    ("coffee", "Cafes"),
+    ("tea room", "Cafes"),
+    ("bakery", "Cafes"),
+    ("dessert", "Cafes"),
+    ("ice cream", "Cafes"),
+    ("juice bar", "Cafes"),
+    # General restaurants — broadest bucket, checked last
+    ("restaurant", "Restaurants"),
+    ("diner", "Restaurants"),
+    ("food", "Restaurants"),
+    ("sushi", "Restaurants"),
+    ("ramen", "Restaurants"),
+    ("noodle", "Restaurants"),
+    ("steakhouse", "Restaurants"),
+    ("bbq", "Restaurants"),
+    ("seafood", "Restaurants"),
+    ("bistro", "Restaurants"),
+    ("brasserie", "Restaurants"),
+    ("tapas", "Restaurants"),
+    ("dim sum", "Restaurants"),
+    ("buffet", "Restaurants"),
+    ("grill", "Restaurants"),
+    ("kitchen", "Restaurants"),
+    ("eatery", "Restaurants"),
+]
+
+# Window size for listening matching (±hours)
+_WINDOW_HOURS: int = 2
+_WINDOW_SEC: int = _WINDOW_HOURS * 3600
+
+
+def _classify_venue_category(raw_category: str) -> str | None:
+    """Map a raw Foursquare category name to one of the four display buckets.
+
+    The match is case-insensitive substring search; the first rule that matches
+    wins.  Returns ``None`` for venue types that are not food or drink related.
+
+    Args:
+        raw_category: Raw category string from the Foursquare export (e.g.
+            ``"Italian Restaurant"``).
+
+    Returns:
+        One of the four :data:`FOOD_DRINK_CATEGORIES` strings, or ``None``.
+    """
+    lower = raw_category.lower()
+    for substring, bucket in _CATEGORY_RULES:
+        if substring in lower:
+            return bucket
+    return None
+
+
+def _get_listens_around_checkin(
+    lastfm_df: pd.DataFrame,
+    checkin_ts: int,
+    window_hours: int = _WINDOW_HOURS,
+) -> pd.DataFrame:
+    """Return Last.fm listens within ±``window_hours`` of a check-in timestamp.
+
+    Args:
+        lastfm_df: Full listening history DataFrame with a ``timestamp`` column.
+        checkin_ts: Unix timestamp of the Swarm check-in.
+        window_hours: Symmetric window size in hours (default 2).
+
+    Returns:
+        Subset of ``lastfm_df`` whose ``timestamp`` falls within
+        ``[checkin_ts - window_sec, checkin_ts + window_sec]``.
+    """
+    if lastfm_df.empty or "timestamp" not in lastfm_df.columns:
+        return pd.DataFrame()
+    window_sec = window_hours * 3600
+    mask = (lastfm_df["timestamp"] >= checkin_ts - window_sec) & (
+        lastfm_df["timestamp"] <= checkin_ts + window_sec
+    )
+    return lastfm_df[mask]
+
+
+def get_dining_soundtrack_data(
+    swarm_df: pd.DataFrame,
+    lastfm_df: pd.DataFrame,
+    top_n: int = 5,
+    window_hours: int = _WINDOW_HOURS,
+) -> dict[str, dict[str, Any]]:
+    """Aggregate Last.fm listens around food/drink check-ins by venue category.
+
+    For each Swarm check-in whose category maps to a food/drink bucket,
+    collects all Last.fm listens within ``±window_hours``.  Groups by bucket
+    and computes top artists, total listen count, check-in count, and peak
+    listening hour.
+
+    Args:
+        swarm_df: Swarm DataFrame with ``timestamp`` and ``venue_category``
+            columns (as returned by :func:`analysis_utils.load_swarm_data`).
+        lastfm_df: Listening history DataFrame with ``timestamp``, ``artist``,
+            and ``date_text`` columns.
+        top_n: Maximum number of top artists to return per category (default 5).
+        window_hours: Symmetric window around each check-in in hours (default 2).
+
+    Returns:
+        Dict keyed by venue category bucket.  Each value is a dict with:
+        ``top_artists`` (DataFrame), ``checkin_count`` (int),
+        ``listen_count`` (int), and ``peak_hour`` (int or None).
+    """
+    if swarm_df.empty or lastfm_df.empty:
+        return {}
+
+    required_swarm = {"timestamp", "venue_category"}
+    required_lastfm = {"timestamp", "artist"}
+    if not required_swarm.issubset(swarm_df.columns) or not required_lastfm.issubset(
+        lastfm_df.columns
+    ):
+        return {}
+
+    # Bucket all food/drink check-ins
+    bucket_listens: dict[str, list[pd.DataFrame]] = {cat: [] for cat in FOOD_DRINK_CATEGORIES}
+    bucket_checkin_count: dict[str, int] = {cat: 0 for cat in FOOD_DRINK_CATEGORIES}
+
+    for _, row in swarm_df.iterrows():
+        bucket = _classify_venue_category(str(row.get("venue_category", "")))
+        if bucket is None:
+            continue
+        nearby = _get_listens_around_checkin(lastfm_df, int(row["timestamp"]), window_hours)
+        if not nearby.empty:
+            bucket_listens[bucket].append(nearby)
+        bucket_checkin_count[bucket] += 1
+
+    results: dict[str, dict[str, Any]] = {}
+    for cat in FOOD_DRINK_CATEGORIES:
+        if bucket_checkin_count[cat] == 0:
+            continue  # no check-ins in this category
+        frames = bucket_listens[cat]
+        if not frames:
+            continue  # check-ins exist but no nearby listens
+        combined = pd.concat(frames, ignore_index=True).drop_duplicates()
+        top_artists = get_top_entities(combined, "artist", limit=top_n)
+
+        peak_hour: int | None = None
+        if "date_text" in combined.columns and not combined["date_text"].isna().all():
+            hour_counts = combined["date_text"].dt.hour.value_counts()
+            peak_hour = int(hour_counts.idxmax()) if not hour_counts.empty else None
+
+        results[cat] = {
+            "top_artists": top_artists,
+            "checkin_count": bucket_checkin_count[cat],
+            "listen_count": len(combined),
+            "peak_hour": peak_hour,
+        }
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Streamlit UI
+# ---------------------------------------------------------------------------
+
+_CATEGORY_COLORS: dict[str, str] = {
+    "Restaurants": ACCENT_INDIGO,
+    "Bars & Nightlife": AMBER,
+    "Cafes": TEAL,
+    "Fast Food": "#a855f7",  # purple accent
+}
+
+
+def render_dining_soundtrack() -> None:
+    """Render the Dining Soundtrack page.
+
+    Reads ``st.session_state['df']`` (Last.fm listens) and
+    ``st.session_state['swarm_df']`` (Swarm check-ins).  Shows an empty state
+    message when either dataset is missing or when no food/drink venues with
+    nearby listens are found.
+    """
+    df: pd.DataFrame | None = st.session_state.get("df")
+    swarm_df: pd.DataFrame | None = st.session_state.get("swarm_df")
+
+    st.header("Dining Soundtrack")
+
+    if df is None or df.empty or swarm_df is None or swarm_df.empty:
+        st.info(
+            "Both Last.fm and Foursquare/Swarm data are required. "
+            "Configure both sources in the sidebar."
+        )
+        return
+
+    with st.spinner("Matching listens to check-ins…"):
+        category_data = get_dining_soundtrack_data(swarm_df, df)
+
+    if not category_data:
+        st.info(
+            "No food or drink check-ins with nearby listens found. "
+            "Make sure your Swarm export includes venue categories."
+        )
+        return
+
+    st.markdown(
+        f"Showing Last.fm listens within **±{_WINDOW_HOURS} hours** "
+        "of Foursquare/Swarm food and drink check-ins."
+    )
+
+    # ── Summary metric row ─────────────────────────────────────────────────
+    cols = st.columns(len(FOOD_DRINK_CATEGORIES))
+    for col, cat in zip(cols, FOOD_DRINK_CATEGORIES):
+        with col:
+            if cat in category_data:
+                data = category_data[cat]
+                st.metric(
+                    cat,
+                    f"{data['listen_count']:,} listens",
+                    delta=f"{data['checkin_count']} check-ins",
+                )
+            else:
+                st.metric(cat, "—")
+
+    st.divider()
+
+    # ── Per-category grid ──────────────────────────────────────────────────
+    for cat in FOOD_DRINK_CATEGORIES:
+        if cat not in category_data:
+            continue
+        data = category_data[cat]
+        top_artists: pd.DataFrame = data["top_artists"]
+        color = _CATEGORY_COLORS.get(cat, ACCENT_INDIGO)
+
+        st.subheader(cat)
+        col_chart, col_stats = st.columns([2, 1])
+
+        with col_chart:
+            if not top_artists.empty:
+                fig = px.bar(
+                    top_artists,
+                    x="Plays",
+                    y="artist",
+                    orientation="h",
+                    title=f"Top Artists at {cat}",
+                    color_discrete_sequence=[color],
+                )
+                fig.update_layout(yaxis={"categoryorder": "total ascending"})
+                apply_dark_theme(fig)
+                st.plotly_chart(fig, width="stretch")
+            else:
+                st.caption("No artist data available.")
+
+        with col_stats:
+            st.metric("Check-ins", data["checkin_count"])
+            st.metric("Listens matched", data["listen_count"])
+            if data["peak_hour"] is not None:
+                st.metric("Peak hour", f"{data['peak_hour']:02d}:00")
+            if not top_artists.empty:
+                top_name = str(top_artists.iloc[0]["artist"])
+                st.caption(f"Top artist: **{top_name}**")
+
+        st.divider()
+
+    # ── Cross-category comparison chart ───────────────────────────────────
+    if len(category_data) > 1:
+        st.subheader("Category Comparison")
+        summary_rows = [
+            {
+                "Category": cat,
+                "Listens": data["listen_count"],
+                "Check-ins": data["checkin_count"],
+            }
+            for cat, data in category_data.items()
+        ]
+        summary_df = pd.DataFrame(summary_rows)
+        fig_cmp = px.bar(
+            summary_df,
+            x="Category",
+            y="Listens",
+            color="Category",
+            title="Total Listens per Venue Category",
+            color_discrete_sequence=COLORWAY,
+        )
+        apply_dark_theme(fig_cmp)
+        st.plotly_chart(fig_cmp, width="stretch")

--- a/tests/test_dining_soundtrack.py
+++ b/tests/test_dining_soundtrack.py
@@ -1,0 +1,408 @@
+"""Tests for pages.dining_soundtrack — music around restaurant check-ins."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from analysis_utils import load_swarm_data
+from pages.dining_soundtrack import (
+    FOOD_DRINK_CATEGORIES,
+    _classify_venue_category,
+    _get_listens_around_checkin,
+    get_dining_soundtrack_data,
+    render_dining_soundtrack,
+)
+
+
+class TestClassifyVenueCategory(unittest.TestCase):
+    """Tests for _classify_venue_category()."""
+
+    def test_restaurant_maps_correctly(self) -> None:
+        self.assertEqual(_classify_venue_category("Italian Restaurant"), "Restaurants")
+
+    def test_bar_maps_correctly(self) -> None:
+        self.assertEqual(_classify_venue_category("Dive Bar"), "Bars & Nightlife")
+
+    def test_nightclub_maps_to_bars(self) -> None:
+        self.assertEqual(_classify_venue_category("Nightclub"), "Bars & Nightlife")
+
+    def test_cafe_maps_correctly(self) -> None:
+        self.assertEqual(_classify_venue_category("Coffee Shop"), "Cafes")
+
+    def test_fast_food_maps_correctly(self) -> None:
+        self.assertEqual(_classify_venue_category("Fast Food Restaurant"), "Fast Food")
+
+    def test_burger_joint_maps_to_fast_food(self) -> None:
+        self.assertEqual(_classify_venue_category("Burger Joint"), "Fast Food")
+
+    def test_bakery_maps_to_cafes(self) -> None:
+        self.assertEqual(_classify_venue_category("Bakery"), "Cafes")
+
+    def test_non_food_returns_none(self) -> None:
+        self.assertIsNone(_classify_venue_category("Museum"))
+
+    def test_empty_string_returns_none(self) -> None:
+        self.assertIsNone(_classify_venue_category(""))
+
+    def test_case_insensitive(self) -> None:
+        self.assertEqual(_classify_venue_category("ITALIAN RESTAURANT"), "Restaurants")
+
+    def test_food_drink_categories_constant_is_nonempty(self) -> None:
+        self.assertIn("Restaurants", FOOD_DRINK_CATEGORIES)
+        self.assertIn("Bars & Nightlife", FOOD_DRINK_CATEGORIES)
+        self.assertIn("Cafes", FOOD_DRINK_CATEGORIES)
+        self.assertIn("Fast Food", FOOD_DRINK_CATEGORIES)
+
+
+class TestGetListensAroundCheckin(unittest.TestCase):
+    """Tests for _get_listens_around_checkin() — ±2 hour window logic."""
+
+    def _make_lastfm_df(self) -> pd.DataFrame:
+        """Return a small Last.fm DataFrame spanning several timestamps."""
+        base = 1_700_000_000  # arbitrary Unix epoch
+        return pd.DataFrame(
+            {
+                "artist": ["Artist A", "Artist B", "Artist C", "Artist D"],
+                "track": ["Track 1", "Track 2", "Track 3", "Track 4"],
+                "timestamp": [
+                    base - 7300,  # >2 hours before checkin — outside window
+                    base - 3600,  # 1 hour before — inside window
+                    base + 1800,  # 30 min after — inside window
+                    base + 7300,  # >2 hours after — outside window
+                ],
+                "date_text": pd.to_datetime(
+                    [
+                        base - 7300,
+                        base - 3600,
+                        base + 1800,
+                        base + 7300,
+                    ],
+                    unit="s",
+                ),
+            }
+        )
+
+    def test_returns_only_listens_within_window(self) -> None:
+        lastfm_df = self._make_lastfm_df()
+        base = 1_700_000_000
+        result = _get_listens_around_checkin(lastfm_df, base, window_hours=2)
+        self.assertEqual(len(result), 2)
+        self.assertIn("Artist B", result["artist"].values)
+        self.assertIn("Artist C", result["artist"].values)
+
+    def test_returns_empty_when_no_listens_in_window(self) -> None:
+        lastfm_df = self._make_lastfm_df()
+        result = _get_listens_around_checkin(lastfm_df, 0, window_hours=2)
+        self.assertTrue(result.empty)
+
+    def test_returns_empty_for_empty_lastfm(self) -> None:
+        result = _get_listens_around_checkin(pd.DataFrame(), 1_700_000_000, window_hours=2)
+        self.assertTrue(result.empty)
+
+
+class TestGetDiningSoundtrackData(unittest.TestCase):
+    """Tests for get_dining_soundtrack_data() — the main aggregation function."""
+
+    def _make_swarm_df(self) -> pd.DataFrame:
+        base = 1_700_000_000
+        return pd.DataFrame(
+            {
+                "timestamp": [base, base + 86400, base + 172800],
+                "venue": ["Pizzeria Roma", "The Dive", "McDonalds"],
+                "venue_category": ["Italian Restaurant", "Dive Bar", "Fast Food Restaurant"],
+                "city": ["London", "London", "London"],
+                "country": ["UK", "UK", "UK"],
+            }
+        )
+
+    def _make_lastfm_df(self) -> pd.DataFrame:
+        base = 1_700_000_000
+        return pd.DataFrame(
+            {
+                "artist": ["Beatles", "Beatles", "Rolling Stones", "Oasis"],
+                "track": ["Hey Jude", "Let It Be", "Paint It Black", "Wonderwall"],
+                "timestamp": [
+                    base - 1800,  # 30 min before restaurant checkin
+                    base + 1800,  # 30 min after restaurant checkin
+                    base + 86400 - 1800,  # 30 min before bar checkin
+                    base + 172800 + 1800,  # 30 min after fast food checkin
+                ],
+                "date_text": pd.to_datetime(
+                    [
+                        base - 1800,
+                        base + 1800,
+                        base + 86400 - 1800,
+                        base + 172800 + 1800,
+                    ],
+                    unit="s",
+                ),
+            }
+        )
+
+    def test_returns_dict_with_expected_categories(self) -> None:
+        swarm_df = self._make_swarm_df()
+        lastfm_df = self._make_lastfm_df()
+        result = get_dining_soundtrack_data(swarm_df, lastfm_df)
+        self.assertIsInstance(result, dict)
+        # At least the categories present in our test data should appear
+        self.assertIn("Restaurants", result)
+        self.assertIn("Bars & Nightlife", result)
+
+    def test_restaurants_category_has_correct_structure(self) -> None:
+        swarm_df = self._make_swarm_df()
+        lastfm_df = self._make_lastfm_df()
+        result = get_dining_soundtrack_data(swarm_df, lastfm_df)
+        cat_data = result.get("Restaurants")
+        self.assertIsNotNone(cat_data)
+        assert cat_data is not None
+        self.assertIn("top_artists", cat_data)
+        self.assertIn("checkin_count", cat_data)
+        self.assertIn("listen_count", cat_data)
+        self.assertIn("peak_hour", cat_data)
+
+    def test_top_artists_respects_limit(self) -> None:
+        swarm_df = self._make_swarm_df()
+        lastfm_df = self._make_lastfm_df()
+        result = get_dining_soundtrack_data(swarm_df, lastfm_df, top_n=5)
+        for cat_data in result.values():
+            self.assertLessEqual(len(cat_data["top_artists"]), 5)
+
+    def test_empty_swarm_returns_empty_dict(self) -> None:
+        result = get_dining_soundtrack_data(pd.DataFrame(), self._make_lastfm_df())
+        self.assertEqual(result, {})
+
+    def test_empty_lastfm_returns_empty_dict(self) -> None:
+        result = get_dining_soundtrack_data(self._make_swarm_df(), pd.DataFrame())
+        self.assertEqual(result, {})
+
+    def test_skips_non_food_venues(self) -> None:
+        swarm_df = pd.DataFrame(
+            {
+                "timestamp": [1_700_000_000],
+                "venue": ["Museum of Art"],
+                "venue_category": ["Museum"],
+                "city": ["London"],
+                "country": ["UK"],
+            }
+        )
+        lastfm_df = self._make_lastfm_df()
+        result = get_dining_soundtrack_data(swarm_df, lastfm_df)
+        self.assertEqual(result, {})
+
+    def test_missing_required_columns_returns_empty(self) -> None:
+        """Returns empty dict when swarm_df lacks required columns."""
+        swarm_df = pd.DataFrame({"venue": ["Pizzeria Roma"]})  # no timestamp or venue_category
+        lastfm_df = self._make_lastfm_df()
+        result = get_dining_soundtrack_data(swarm_df, lastfm_df)
+        self.assertEqual(result, {})
+
+    def test_checkins_with_no_nearby_listens_excluded(self) -> None:
+        """Category with check-ins but zero nearby listens is excluded from results."""
+        base = 1_700_000_000
+        swarm_df = pd.DataFrame(
+            {
+                "timestamp": [base],
+                "venue": ["Pizzeria Roma"],
+                "venue_category": ["Italian Restaurant"],
+                "city": ["London"],
+                "country": ["UK"],
+            }
+        )
+        # Put all listens far outside the ±2 hour window
+        lastfm_df = pd.DataFrame(
+            {
+                "artist": ["Beatles"],
+                "track": ["Hey Jude"],
+                "timestamp": [base + 86400],  # 24 hours away
+                "date_text": pd.to_datetime([base + 86400], unit="s"),
+            }
+        )
+        result = get_dining_soundtrack_data(swarm_df, lastfm_df)
+        # Restaurants had a checkin but no nearby listens — should be absent
+        self.assertNotIn("Restaurants", result)
+
+
+class TestLoadSwarmDataVenueCategory(unittest.TestCase):
+    """Test that load_swarm_data() correctly parses venue_category."""
+
+    def setUp(self) -> None:
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.test_dir)
+
+    def test_venue_category_parsed_when_present(self) -> None:
+        data = {
+            "items": [
+                {
+                    "createdAt": 1_700_000_000,
+                    "timeZoneOffset": 0,
+                    "venue": {
+                        "name": "Pizzeria Roma",
+                        "categories": [{"name": "Italian Restaurant"}],
+                        "location": {"city": "London", "country": "UK"},
+                    },
+                }
+            ]
+        }
+        with open(os.path.join(self.test_dir, "checkins1.json"), "w") as f:
+            json.dump(data, f)
+
+        df = load_swarm_data(self.test_dir)
+        self.assertIn("venue_category", df.columns)
+        self.assertEqual(df.iloc[0]["venue_category"], "Italian Restaurant")
+
+    def test_venue_category_empty_when_no_categories(self) -> None:
+        data = {
+            "items": [
+                {
+                    "createdAt": 1_700_000_001,
+                    "timeZoneOffset": 0,
+                    "venue": {
+                        "name": "Unnamed Place",
+                        "location": {"city": "London", "country": "UK"},
+                    },
+                }
+            ]
+        }
+        with open(os.path.join(self.test_dir, "checkins_nocat.json"), "w") as f:
+            json.dump(data, f)
+
+        df = load_swarm_data(self.test_dir)
+        self.assertIn("venue_category", df.columns)
+        self.assertEqual(df.iloc[0]["venue_category"], "")
+
+    def test_empty_dir_returns_venue_category_column(self) -> None:
+        empty_dir = tempfile.mkdtemp()
+        try:
+            df = load_swarm_data(empty_dir)
+            self.assertIn("venue_category", df.columns)
+        finally:
+            shutil.rmtree(empty_dir)
+
+
+class TestRenderDiningSoundtrack(unittest.TestCase):
+    """Integration-style tests for the render_dining_soundtrack() page function."""
+
+    def _make_swarm_df(self) -> pd.DataFrame:
+        base = 1_700_000_000
+        return pd.DataFrame(
+            {
+                "timestamp": [base],
+                "venue": ["Pizzeria Roma"],
+                "venue_category": ["Italian Restaurant"],
+                "city": ["London"],
+                "country": ["UK"],
+            }
+        )
+
+    def _make_lastfm_df(self) -> pd.DataFrame:
+        base = 1_700_000_000
+        return pd.DataFrame(
+            {
+                "artist": ["Beatles", "Beatles"],
+                "track": ["Hey Jude", "Let It Be"],
+                "timestamp": [base - 1800, base + 1800],
+                "date_text": pd.to_datetime([base - 1800, base + 1800], unit="s"),
+            }
+        )
+
+    @patch("streamlit.info")
+    def test_shows_info_when_no_swarm(self, mock_info: MagicMock) -> None:
+        with patch("streamlit.session_state", {"df": self._make_lastfm_df(), "swarm_df": None}):
+            render_dining_soundtrack()
+        mock_info.assert_called_once()
+
+    @patch("streamlit.info")
+    def test_shows_info_when_no_lastfm(self, mock_info: MagicMock) -> None:
+        with patch("streamlit.session_state", {"df": None, "swarm_df": self._make_swarm_df()}):
+            render_dining_soundtrack()
+        mock_info.assert_called_once()
+
+    @patch("streamlit.info")
+    def test_shows_info_when_no_matches(self, mock_info: MagicMock) -> None:
+        """Page shows an info message when no food/drink venues match."""
+        swarm_df = pd.DataFrame(
+            {
+                "timestamp": [1_700_000_000],
+                "venue": ["Art Museum"],
+                "venue_category": ["Museum"],
+                "city": ["London"],
+                "country": ["UK"],
+            }
+        )
+        lastfm_df = self._make_lastfm_df()
+        with patch("streamlit.session_state", {"df": lastfm_df, "swarm_df": swarm_df}):
+            render_dining_soundtrack()
+        mock_info.assert_called_once()
+
+    def _make_swarm_df(self) -> pd.DataFrame:
+        """Multi-category swarm data for render tests."""
+        base = 1_700_000_000
+        return pd.DataFrame(
+            {
+                "timestamp": [base, base + 86400],
+                "venue": ["Pizzeria Roma", "The Dive"],
+                "venue_category": ["Italian Restaurant", "Dive Bar"],
+                "city": ["London", "London"],
+                "country": ["UK", "UK"],
+            }
+        )
+
+    def _make_lastfm_df(self) -> pd.DataFrame:
+        """Last.fm data with listens near both check-ins above."""
+        base = 1_700_000_000
+        return pd.DataFrame(
+            {
+                "artist": ["Beatles", "Rolling Stones"],
+                "track": ["Hey Jude", "Paint It Black"],
+                "timestamp": [base - 1800, base + 86400 - 1800],
+                "date_text": pd.to_datetime([base - 1800, base + 86400 - 1800], unit="s"),
+            }
+        )
+
+    @patch("streamlit.header")
+    @patch("streamlit.subheader")
+    @patch("streamlit.columns")
+    @patch("streamlit.plotly_chart")
+    @patch("streamlit.metric")
+    @patch("streamlit.caption")
+    @patch("streamlit.markdown")
+    @patch("streamlit.divider")
+    def test_renders_with_valid_data(
+        self,
+        mock_divider: MagicMock,
+        mock_md: MagicMock,
+        mock_caption: MagicMock,
+        mock_metric: MagicMock,
+        mock_plotly: MagicMock,
+        mock_cols: MagicMock,
+        mock_subheader: MagicMock,
+        mock_header: MagicMock,
+    ) -> None:
+        swarm_df = self._make_swarm_df()
+        lastfm_df = self._make_lastfm_df()
+        # st.columns(len(FOOD_DRINK_CATEGORIES)) returns 4 cols;
+        # subsequent st.columns([2, 1]) calls return 2-element lists.
+        col_pair = [MagicMock(), MagicMock()]
+        col_quad = [MagicMock(), MagicMock(), MagicMock(), MagicMock()]
+        # First call = 4-column summary row; next calls = [2,1] per category + comparison chart
+        mock_cols.side_effect = [col_quad, col_pair, col_pair]
+
+        with patch("streamlit.session_state", {"df": lastfm_df, "swarm_df": swarm_df}):
+            render_dining_soundtrack()
+
+        mock_header.assert_called_with("Dining Soundtrack")
+        # Should render at least one plotly chart (per-category bar + comparison)
+        self.assertTrue(mock_plotly.called)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -19,6 +19,7 @@ from components.plugin_config import (
     render_plugin_config_fields as _render_plugin_config,
 )
 from core.local_settings import LocalSettings
+from pages.dining_soundtrack import render_dining_soundtrack
 from pages.insights import render_insights_and_narrative
 from pages.music import (
     _filter_by_date,
@@ -632,6 +633,13 @@ class TestMusicHelpers(unittest.TestCase):
 
         st.session_state["df"] = None
         render_music()
+        mock_info.assert_called_once()
+
+    @patch("streamlit.info")
+    def test_render_dining_soundtrack_no_data(self, mock_info: MagicMock) -> None:
+        """render_dining_soundtrack shows info when both datasets are missing."""
+        with patch("streamlit.session_state", {"df": None, "swarm_df": None}):
+            render_dining_soundtrack()
         mock_info.assert_called_once()
 
 

--- a/visualize.py
+++ b/visualize.py
@@ -21,6 +21,7 @@ from components.sidebar import render_sidebar
 from pages.beer import render_beer
 from pages.culture import render_culture
 from pages.data_sources import render_data_sources, render_plugin_page
+from pages.dining_soundtrack import render_dining_soundtrack
 from pages.fitness import render_fitness
 from pages.insights import render_insights, render_insights_and_narrative  # noqa: F401
 from pages.music import render_music, render_top_charts  # noqa: F401
@@ -125,6 +126,11 @@ def main() -> None:
             "Music": [
                 st.Page(render_music, title="Listening", icon=":material/headphones:"),
                 st.Page(render_insights, title="Insights", icon=":material/auto_stories:"),
+                st.Page(
+                    render_dining_soundtrack,
+                    title="Dining Soundtrack",
+                    icon=":material/restaurant:",
+                ),
             ],
             "Places": [
                 st.Page(render_places, title="Check-ins", icon=":material/location_on:"),


### PR DESCRIPTION
## Summary

- Parses Foursquare venue categories from Swarm JSON exports via a new `venue_category` field added to `load_swarm_data()` in `analysis_utils.py`
- Implements `pages/dining_soundtrack.py` with a four-bucket venue grid (Restaurants, Bars & Nightlife, Cafes, Fast Food), each showing top-5 artists, total listens matched, check-in count, and peak listening hour
- Collects Last.fm listens in a ±2 hour window around each food/drink check-in using vectorised timestamp comparisons
- Adds a cross-category comparison bar chart when two or more categories have data
- Registers the page under the Music section in `visualize.py` with icon `:material/restaurant:`

## Test plan

- [x] `tests/test_dining_soundtrack.py` — 29 new unit tests covering `_classify_venue_category`, `_get_listens_around_checkin`, `get_dining_soundtrack_data`, `load_swarm_data` category parsing, and `render_dining_soundtrack` UI paths
- [x] `tests/test_visualize.py` — smoke test for empty-state render
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy` — no issues in 12 source files
- [x] `pytest` — 285 passed, 0 failed (coverage 73.42%; pre-existing gap, up from 72.18% on main)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)