### PR TITLE
feat: In Transit — airport and travel hub listening patterns (#61)

### DIFF
--- a/analysis_utils.py
+++ b/analysis_utils.py
@@ -117,11 +117,31 @@ def load_listening_data(file_path: str) -> Optional[pd.DataFrame]:
 
 
 def load_swarm_data(swarm_dir: str) -> pd.DataFrame:
-    """Load and parse Swarm checkin data from JSON files."""
+    """Load and parse Swarm checkin data from JSON files.
+
+    Args:
+        swarm_dir: Path to the directory containing ``checkins*.json`` export files.
+
+    Returns:
+        DataFrame with columns: timestamp, offset, city, state, country, venue,
+        venue_category, lat, lng.  ``venue_category`` contains the first
+        Foursquare category name (e.g. ``"Airport"``, ``"Train Station"``) or an
+        empty string when categories are absent from the export.
+    """
     all_checkins = []
     if not swarm_dir or not os.path.exists(swarm_dir):
         return pd.DataFrame(
-            columns=["timestamp", "offset", "city", "state", "country", "venue", "lat", "lng"]
+            columns=[
+                "timestamp",
+                "offset",
+                "city",
+                "state",
+                "country",
+                "venue",
+                "venue_category",
+                "lat",
+                "lng",
+            ]
         )
 
     json_files = glob.glob(os.path.join(swarm_dir, "checkins*.json"))
@@ -166,6 +186,10 @@ def load_swarm_data(swarm_dir: str) -> pd.DataFrame:
                     lat = item.get("lat") or location.get("lat")
                     lng = item.get("lng") or location.get("lng")
 
+                    # Extract the primary Foursquare category name (first element only).
+                    categories = venue.get("categories") or []
+                    venue_category = categories[0].get("name", "") if categories else ""
+
                     all_checkins.append(
                         {
                             "timestamp": ts,
@@ -174,6 +198,7 @@ def load_swarm_data(swarm_dir: str) -> pd.DataFrame:
                             "state": state,
                             "country": country,
                             "venue": venue.get("name", "Unknown"),
+                            "venue_category": venue_category,
                             "lat": lat,
                             "lng": lng,
                             "_needs_geocode": needs_geocode and lat is not None and lng is not None,
@@ -184,7 +209,17 @@ def load_swarm_data(swarm_dir: str) -> pd.DataFrame:
 
     if not all_checkins:
         return pd.DataFrame(
-            columns=["timestamp", "offset", "city", "state", "country", "venue", "lat", "lng"]
+            columns=[
+                "timestamp",
+                "offset",
+                "city",
+                "state",
+                "country",
+                "venue",
+                "venue_category",
+                "lat",
+                "lng",
+            ]
         )
 
     df = pd.DataFrame(all_checkins)
@@ -772,3 +807,175 @@ def get_artist_monthly_ranks(df: pd.DataFrame, n: int = 10) -> pd.DataFrame:
         monthly.groupby("month")["plays"].rank(method="min", ascending=False).astype(int)
     )
     return monthly[["month", "artist", "rank"]]
+
+
+# ---------------------------------------------------------------------------
+# Transit / airport analysis (Issue #61)
+# ---------------------------------------------------------------------------
+
+# Foursquare category names that indicate transit hubs.  This list captures
+# the most common category strings found in GDPR exports; partial matching via
+# ``str.contains`` is used so minor label variations still match.
+TRANSIT_CATEGORY_KEYWORDS: list[str] = [
+    "Airport",
+    "Train Station",
+    "Transit",
+    "Bus Station",
+    "Metro",
+    "Subway",
+    "Ferry",
+    "Port",
+    "Rail",
+]
+
+
+def get_transit_days(swarm_df: pd.DataFrame) -> set[str]:
+    """Return the set of calendar date strings (YYYY-MM-DD) that contain a transit check-in.
+
+    A day is classified as a *transit day* when at least one Swarm check-in on
+    that calendar day falls into an airport or transit hub Foursquare category.
+
+    Args:
+        swarm_df: Output of :func:`load_swarm_data`, which must include a
+            ``venue_category`` column and a ``timestamp`` column (Unix seconds).
+
+    Returns:
+        Set of ISO date strings (e.g. ``{"2023-06-12", "2023-06-15"}``).
+    """
+    if swarm_df.empty or "venue_category" not in swarm_df.columns:
+        return set()
+
+    # Build a regex pattern from the keyword list (case-insensitive).
+    pattern = "|".join(TRANSIT_CATEGORY_KEYWORDS)
+    transit_mask = swarm_df["venue_category"].str.contains(pattern, case=False, na=False)
+    transit_rows = swarm_df[transit_mask].copy()
+
+    if transit_rows.empty:
+        return set()
+
+    transit_rows["date"] = pd.to_datetime(transit_rows["timestamp"], unit="s").dt.strftime(
+        "%Y-%m-%d"
+    )
+    return set(transit_rows["date"].unique())
+
+
+def split_transit_listens(
+    listens_df: pd.DataFrame, transit_days: set[str]
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Partition a listening DataFrame into transit-day and non-transit-day rows.
+
+    Args:
+        listens_df: Listening history DataFrame with a ``date_text`` datetime column.
+        transit_days: Set of ISO date strings returned by :func:`get_transit_days`.
+
+    Returns:
+        Tuple ``(transit_df, home_df)`` — both are subsets of ``listens_df``.
+    """
+    if listens_df.empty or "date_text" not in listens_df.columns:
+        return listens_df.iloc[:0].copy(), listens_df.iloc[:0].copy()
+
+    date_strs = listens_df["date_text"].dt.strftime("%Y-%m-%d")
+    mask = date_strs.isin(transit_days)
+    return listens_df[mask].copy(), listens_df[~mask].copy()
+
+
+def get_avg_plays_per_day(df: pd.DataFrame) -> float:
+    """Return the mean number of plays per calendar day.
+
+    Args:
+        df: Listening history DataFrame with a ``date_text`` datetime column.
+
+    Returns:
+        Average plays per day, or 0.0 when the DataFrame is empty.
+    """
+    if df.empty or "date_text" not in df.columns:
+        return 0.0
+    unique_days = int(df["date_text"].dt.date.nunique())
+    return float(len(df)) / unique_days if unique_days > 0 else 0.0
+
+
+def get_new_artist_discovery_rate(
+    subset_df: pd.DataFrame, full_df: pd.DataFrame
+) -> tuple[int, float]:
+    """Count artists heard for the first time within *subset_df*.
+
+    An artist is a *discovery* if their earliest listen in the full dataset
+    falls within the subset (i.e. the first listen is on a transit/home day).
+
+    Args:
+        subset_df: Subset of listens (e.g. transit days only).
+        full_df: Complete listening history.
+
+    Returns:
+        Tuple ``(discovery_count, discovery_rate)`` where ``discovery_rate`` is
+        the fraction of unique artists in the subset that were first heard there.
+    """
+    if subset_df.empty or full_df.empty or "artist" not in full_df.columns:
+        return 0, 0.0
+
+    # Earliest listen date per artist in the full dataset.
+    first_listens = full_df.groupby("artist")["date_text"].min()
+
+    subset_artists = subset_df["artist"].unique()
+    subset_dates = subset_df["date_text"]
+    min_date = subset_dates.min()
+    max_date = subset_dates.max()
+
+    discoveries = sum(
+        1
+        for artist in subset_artists
+        if artist in first_listens.index and min_date <= first_listens[artist] <= max_date
+    )
+
+    total = len(subset_artists)
+    rate = discoveries / total if total > 0 else 0.0
+    return discoveries, rate
+
+
+def get_transit_listening_hours(transit_df: pd.DataFrame) -> pd.DataFrame:
+    """Return the hourly play distribution for transit-day listens.
+
+    Args:
+        transit_df: Subset of listens recorded on transit days; must have a
+            ``date_text`` datetime column.
+
+    Returns:
+        DataFrame with columns ``hour`` (0–23) and ``Plays`` (int).
+    """
+    return get_hourly_distribution(transit_df)
+
+
+def get_longest_transit_session(transit_df: pd.DataFrame, gap_minutes: int = 60) -> int:
+    """Return the number of tracks in the longest unbroken transit listening session.
+
+    Two consecutive tracks are considered part of the same session when the gap
+    between them is less than *gap_minutes*.
+
+    Args:
+        transit_df: Transit-day listens with a ``timestamp`` column (Unix seconds).
+        gap_minutes: Maximum gap (in minutes) between consecutive tracks within
+            one session.
+
+    Returns:
+        Length (track count) of the longest session, or 0 when there are no
+        transit listens.
+    """
+    if transit_df.empty or "timestamp" not in transit_df.columns:
+        return 0
+
+    timestamps = transit_df["timestamp"].sort_values().values
+    if len(timestamps) == 0:
+        return 0
+
+    gap_sec = gap_minutes * 60
+    max_session = 1
+    current_session = 1
+
+    for i in range(1, len(timestamps)):
+        if timestamps[i] - timestamps[i - 1] <= gap_sec:
+            current_session += 1
+            max_session = max(max_session, current_session)
+        else:
+            current_session = 1
+
+    return max_session

--- a/pages/in_transit.py
+++ b/pages/in_transit.py
@@ -1,0 +1,209 @@
+"""In Transit page — airport and travel hub listening patterns (Issue #61).
+
+Compares listening behaviour on days with airport/transit Foursquare check-ins
+("travel days") against all other days ("home days").
+
+Metrics surfaced:
+- Top-20 transit artists
+- Average plays per travel day vs. non-travel day
+- New artist discovery rate on transit vs. home days
+- Common listening hours during transit
+- Longest transit session (track count)
+"""
+
+from __future__ import annotations
+
+import plotly.express as px
+import streamlit as st
+from pandas import DataFrame
+
+from analysis_utils import (
+    get_avg_plays_per_day,
+    get_longest_transit_session,
+    get_new_artist_discovery_rate,
+    get_top_entities,
+    get_transit_days,
+    get_transit_listening_hours,
+    split_transit_listens,
+)
+from components.theme import ACCENT_INDIGO, AMBER, COLORWAY, TEAL, apply_dark_theme, card_container
+
+
+def render_in_transit() -> None:
+    """Render the In Transit page.
+
+    Reads ``st.session_state['df']`` (Last.fm listens) and
+    ``st.session_state['swarm_df']`` (Foursquare/Swarm check-ins).
+    Shows an informative empty state when either dataset is absent.
+    """
+    st.header("In Transit")
+    st.caption(
+        "Listening patterns on days with airport or transit hub check-ins versus all other days."
+    )
+
+    listens_df: DataFrame | None = st.session_state.get("df")
+    swarm_df: DataFrame | None = st.session_state.get("swarm_df")
+
+    # ── Guard: require both datasets ─────────────────────────────────────────
+    if listens_df is None or listens_df.empty:
+        st.info(
+            "No music data loaded yet. "
+            "Configure a Last.fm source in the sidebar and select a data file."
+        )
+        return
+
+    if swarm_df is None or swarm_df.empty:
+        st.info(
+            "No Foursquare/Swarm data loaded. "
+            "Configure the Swarm export directory in the sidebar to enable transit analysis."
+        )
+        return
+
+    # ── Identify transit days ────────────────────────────────────────────────
+    transit_days = get_transit_days(swarm_df)
+
+    if not transit_days:
+        st.warning(
+            "No transit check-ins found (Airport, Train Station, Transit, etc.). "
+            "Make sure your Swarm export includes venue category data."
+        )
+        return
+
+    transit_df, home_df = split_transit_listens(listens_df, transit_days)
+
+    if transit_df.empty:
+        st.info(
+            f"Found {len(transit_days)} transit day(s) in Swarm data "
+            "but no Last.fm listens overlap with those days."
+        )
+        return
+
+    # ── Summary metrics ───────────────────────────────────────────────────────
+    n_transit_days = len(transit_days)
+    avg_transit = get_avg_plays_per_day(transit_df)
+    avg_home = get_avg_plays_per_day(home_df)
+    transit_discoveries, transit_rate = get_new_artist_discovery_rate(transit_df, listens_df)
+    _home_discoveries, home_rate = get_new_artist_discovery_rate(home_df, listens_df)
+    longest_session = get_longest_transit_session(transit_df)
+
+    col1, col2, col3, col4 = st.columns(4)
+    with col1:
+        with card_container():
+            st.metric("Transit Days", n_transit_days)
+    with col2:
+        delta_pct = round((avg_transit - avg_home) / avg_home * 100, 1) if avg_home else None
+        delta_str = f"{delta_pct:+.1f}% vs home" if delta_pct is not None else None
+        with card_container():
+            st.metric(
+                "Avg Plays / Transit Day",
+                f"{avg_transit:.1f}",
+                delta=delta_str,
+            )
+    with col3:
+        with card_container():
+            st.metric(
+                "New Artist Discovery Rate",
+                f"{transit_rate:.0%}",
+                delta=(
+                    f"{transit_rate - home_rate:+.0%} vs home" if home_rate is not None else None
+                ),
+            )
+    with col4:
+        with card_container():
+            st.metric("Longest Transit Session", f"{longest_session} tracks")
+
+    st.markdown("---")
+
+    # ── Top transit artists ───────────────────────────────────────────────────
+    col_left, col_right = st.columns(2)
+
+    with col_left:
+        st.subheader("Top 20 Transit Artists")
+        top_transit = get_top_entities(transit_df, entity="artist", limit=20)
+        if not top_transit.empty:
+            fig_artists = px.bar(
+                top_transit,
+                x="Plays",
+                y="artist",
+                orientation="h",
+                title="Most played artists on transit days",
+                color_discrete_sequence=[ACCENT_INDIGO],
+            )
+            fig_artists.update_layout(yaxis={"categoryorder": "total ascending"})
+            apply_dark_theme(fig_artists)
+            st.plotly_chart(fig_artists, width="stretch")
+        else:
+            st.info("No artist data available for transit days.")
+
+    # ── Plays per day comparison bar ──────────────────────────────────────────
+    with col_right:
+        st.subheader("Avg Plays per Day")
+        comparison_data = {
+            "Day Type": ["Transit Days", "Home Days"],
+            "Avg Plays": [avg_transit, avg_home],
+        }
+        import pandas as pd
+
+        fig_cmp = px.bar(
+            pd.DataFrame(comparison_data),
+            x="Day Type",
+            y="Avg Plays",
+            title="Average plays: transit vs. home",
+            color="Day Type",
+            color_discrete_map={"Transit Days": TEAL, "Home Days": AMBER},
+        )
+        apply_dark_theme(fig_cmp)
+        fig_cmp.update_layout(showlegend=False)
+        st.plotly_chart(fig_cmp, width="stretch")
+
+    st.markdown("---")
+
+    # ── Hourly listening distribution during transit ───────────────────────────
+    st.subheader("Listening Hours During Transit")
+    hourly = get_transit_listening_hours(transit_df)
+    if not hourly.empty:
+        fig_hours = px.bar(
+            hourly,
+            x="hour",
+            y="Plays",
+            title="Play count by hour of day (transit days only)",
+            color_discrete_sequence=COLORWAY,
+        )
+        fig_hours.update_layout(xaxis={"dtick": 1, "title": "Hour of Day (local)"})
+        apply_dark_theme(fig_hours)
+        st.plotly_chart(fig_hours, width="stretch")
+
+    st.markdown("---")
+
+    # ── Discovery rate comparison ────────────────────────────────────────────
+    st.subheader("New Artist Discovery")
+
+    disc_col1, disc_col2 = st.columns(2)
+    with disc_col1:
+        st.markdown(
+            f"**{transit_discoveries}** new artists were first heard on a transit day "
+            f"({transit_rate:.0%} of transit-day artists)."
+        )
+    with disc_col2:
+        fig_disc = px.bar(
+            x=["Transit Days", "Home Days"],
+            y=[transit_rate * 100, home_rate * 100],
+            labels={"x": "Day Type", "y": "Discovery Rate (%)"},
+            title="New artist discovery rate (%)",
+            color=["Transit Days", "Home Days"],
+            color_discrete_map={"Transit Days": TEAL, "Home Days": AMBER},
+        )
+        apply_dark_theme(fig_disc)
+        fig_disc.update_layout(showlegend=False)
+        st.plotly_chart(fig_disc, width="stretch")
+
+    st.markdown("---")
+
+    # ── Raw data expander ────────────────────────────────────────────────────
+    with st.expander("Transit day listens (raw data)"):
+        candidate_cols = ["date_text", "artist", "track", "album"]
+        display_cols = [c for c in candidate_cols if c in transit_df.columns]
+        st.dataframe(
+            transit_df[display_cols].sort_values("date_text", ascending=False),
+            hide_index=True,
+        )

--- a/tests/test_in_transit.py
+++ b/tests/test_in_transit.py
@@ -1,0 +1,449 @@
+"""Tests for the In Transit page and supporting analysis utilities (Issue #61)."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from analysis_utils import (
+    TRANSIT_CATEGORY_KEYWORDS,
+    get_avg_plays_per_day,
+    get_longest_transit_session,
+    get_new_artist_discovery_rate,
+    get_transit_days,
+    get_transit_listening_hours,
+    load_swarm_data,
+    split_transit_listens,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_listens(dates: list[str], artists: list[str] | None = None) -> pd.DataFrame:
+    """Build a minimal listening history DataFrame."""
+    n = len(dates)
+    if artists is None:
+        artists = [f"Artist {i}" for i in range(n)]
+    return pd.DataFrame(
+        {
+            "artist": artists,
+            "track": [f"Track {i}" for i in range(n)],
+            "album": [f"Album {i}" for i in range(n)],
+            "timestamp": list(range(1_700_000_000, 1_700_000_000 + n)),
+            "date_text": pd.to_datetime(dates),
+        }
+    )
+
+
+def _make_swarm_dir_with_categories(tmp_dir: str, items: list[dict]) -> str:
+    """Write a checkins1.json with the given items into tmp_dir and return tmp_dir."""
+    payload = {"items": items}
+    with open(os.path.join(tmp_dir, "checkins1.json"), "w") as f:
+        json.dump(payload, f)
+    return tmp_dir
+
+
+# ---------------------------------------------------------------------------
+# load_swarm_data — venue_category parsing
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSwarmDataCategory(unittest.TestCase):
+    """venue_category is captured from venue.categories[0].name."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp)
+
+    def test_category_extracted_when_present(self) -> None:
+        items = [
+            {
+                "createdAt": 1_700_000_000,
+                "timeZoneOffset": 0,
+                "venue": {
+                    "name": "JFK Airport",
+                    "categories": [{"name": "Airport"}],
+                    "location": {"city": "New York", "country": "United States"},
+                },
+            }
+        ]
+        _make_swarm_dir_with_categories(self.tmp, items)
+        df = load_swarm_data(self.tmp)
+        self.assertIn("venue_category", df.columns)
+        self.assertEqual(df.iloc[0]["venue_category"], "Airport")
+
+    def test_category_empty_when_missing(self) -> None:
+        items = [
+            {
+                "createdAt": 1_700_000_000,
+                "timeZoneOffset": 0,
+                "venue": {
+                    "name": "Coffee Shop",
+                    "location": {"city": "London", "country": "United Kingdom"},
+                },
+            }
+        ]
+        _make_swarm_dir_with_categories(self.tmp, items)
+        df = load_swarm_data(self.tmp)
+        self.assertEqual(df.iloc[0]["venue_category"], "")
+
+    def test_first_category_only_used(self) -> None:
+        items = [
+            {
+                "createdAt": 1_700_000_001,
+                "timeZoneOffset": 0,
+                "venue": {
+                    "name": "Hub",
+                    "categories": [{"name": "Transit"}, {"name": "Bus Station"}],
+                    "location": {"city": "Chicago", "country": "United States"},
+                },
+            }
+        ]
+        _make_swarm_dir_with_categories(self.tmp, items)
+        df = load_swarm_data(self.tmp)
+        self.assertEqual(df.iloc[0]["venue_category"], "Transit")
+
+    def test_empty_dir_returns_venue_category_column(self) -> None:
+        df = load_swarm_data(self.tmp)  # no files
+        self.assertIn("venue_category", df.columns)
+        self.assertTrue(df.empty)
+
+
+# ---------------------------------------------------------------------------
+# get_transit_days
+# ---------------------------------------------------------------------------
+
+
+class TestGetTransitDays(unittest.TestCase):
+    """get_transit_days returns date strings for transit check-in days."""
+
+    def _swarm(self, cats: list[str], timestamps: list[int]) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "timestamp": timestamps,
+                "venue_category": cats,
+                "venue": ["v"] * len(cats),
+            }
+        )
+
+    def test_returns_dates_for_airport_checkins(self) -> None:
+        ts = int(pd.Timestamp("2023-06-12").timestamp())
+        df = self._swarm(["Airport"], [ts])
+        days = get_transit_days(df)
+        self.assertIn("2023-06-12", days)
+
+    def test_returns_dates_for_train_station(self) -> None:
+        ts = int(pd.Timestamp("2023-06-15").timestamp())
+        df = self._swarm(["Train Station"], [ts])
+        days = get_transit_days(df)
+        self.assertIn("2023-06-15", days)
+
+    def test_ignores_non_transit_categories(self) -> None:
+        ts = int(pd.Timestamp("2023-06-20").timestamp())
+        df = self._swarm(["Coffee Shop"], [ts])
+        days = get_transit_days(df)
+        self.assertEqual(len(days), 0)
+
+    def test_empty_swarm_returns_empty_set(self) -> None:
+        days = get_transit_days(pd.DataFrame())
+        self.assertEqual(days, set())
+
+    def test_missing_venue_category_column(self) -> None:
+        df = pd.DataFrame({"timestamp": [1_700_000_000], "venue": ["Place"]})
+        days = get_transit_days(df)
+        self.assertEqual(days, set())
+
+    def test_case_insensitive_matching(self) -> None:
+        ts = int(pd.Timestamp("2023-07-01").timestamp())
+        df = self._swarm(["airport"], [ts])  # lowercase
+        days = get_transit_days(df)
+        self.assertIn("2023-07-01", days)
+
+    def test_multiple_transit_days(self) -> None:
+        ts1 = int(pd.Timestamp("2023-08-01").timestamp())
+        ts2 = int(pd.Timestamp("2023-08-05").timestamp())
+        df = self._swarm(["Airport", "Metro Station"], [ts1, ts2])
+        days = get_transit_days(df)
+        self.assertEqual(len(days), 2)
+
+    def test_transit_category_keywords_list_non_empty(self) -> None:
+        self.assertGreater(len(TRANSIT_CATEGORY_KEYWORDS), 0)
+        self.assertIn("Airport", TRANSIT_CATEGORY_KEYWORDS)
+
+
+# ---------------------------------------------------------------------------
+# split_transit_listens
+# ---------------------------------------------------------------------------
+
+
+class TestSplitTransitListens(unittest.TestCase):
+    """split_transit_listens correctly partitions a listening DataFrame."""
+
+    def test_partitions_correctly(self) -> None:
+        transit_days = {"2023-06-12", "2023-06-15"}
+        df = _make_listens(
+            ["2023-06-12", "2023-06-14", "2023-06-15", "2023-06-20"],
+            ["Artist A", "Artist B", "Artist C", "Artist D"],
+        )
+        t_df, h_df = split_transit_listens(df, transit_days)
+        self.assertEqual(len(t_df), 2)
+        self.assertEqual(len(h_df), 2)
+        self.assertSetEqual(set(t_df["artist"]), {"Artist A", "Artist C"})
+
+    def test_all_home_when_no_overlap(self) -> None:
+        df = _make_listens(["2023-01-01", "2023-01-02"])
+        t_df, h_df = split_transit_listens(df, {"2024-01-01"})
+        self.assertEqual(len(t_df), 0)
+        self.assertEqual(len(h_df), 2)
+
+    def test_empty_listens_returns_empty_both(self) -> None:
+        t_df, h_df = split_transit_listens(pd.DataFrame(), {"2023-06-12"})
+        self.assertTrue(t_df.empty)
+        self.assertTrue(h_df.empty)
+
+
+# ---------------------------------------------------------------------------
+# get_avg_plays_per_day
+# ---------------------------------------------------------------------------
+
+
+class TestGetAvgPlaysPerDay(unittest.TestCase):
+    def test_basic_average(self) -> None:
+        df = _make_listens(["2023-01-01", "2023-01-01", "2023-01-02"])
+        avg = get_avg_plays_per_day(df)
+        self.assertAlmostEqual(avg, 1.5)
+
+    def test_empty_returns_zero(self) -> None:
+        self.assertEqual(get_avg_plays_per_day(pd.DataFrame()), 0.0)
+
+    def test_single_day(self) -> None:
+        df = _make_listens(["2023-05-01"] * 10)
+        avg = get_avg_plays_per_day(df)
+        self.assertAlmostEqual(avg, 10.0)
+
+
+# ---------------------------------------------------------------------------
+# get_new_artist_discovery_rate
+# ---------------------------------------------------------------------------
+
+
+class TestGetNewArtistDiscoveryRate(unittest.TestCase):
+    def test_discovery_on_transit_day(self) -> None:
+        # Transit subset: Artist A first heard on 2023-06-12
+        # Full dataset: Artist A first appeared on 2023-06-12 (transit day)
+        full = _make_listens(
+            ["2023-06-11", "2023-06-12", "2023-06-13"],
+            ["Artist B", "Artist A", "Artist B"],
+        )
+        transit = _make_listens(["2023-06-12"], ["Artist A"])
+        count, rate = get_new_artist_discovery_rate(transit, full)
+        self.assertEqual(count, 1)
+        self.assertAlmostEqual(rate, 1.0)
+
+    def test_no_discoveries(self) -> None:
+        # Artist A first heard before the transit window
+        full = _make_listens(
+            ["2023-06-01", "2023-06-12"],
+            ["Artist A", "Artist A"],
+        )
+        transit = _make_listens(["2023-06-12"], ["Artist A"])
+        count, rate = get_new_artist_discovery_rate(transit, full)
+        self.assertEqual(count, 0)
+        self.assertAlmostEqual(rate, 0.0)
+
+    def test_empty_inputs(self) -> None:
+        count, rate = get_new_artist_discovery_rate(pd.DataFrame(), pd.DataFrame())
+        self.assertEqual(count, 0)
+        self.assertAlmostEqual(rate, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# get_longest_transit_session
+# ---------------------------------------------------------------------------
+
+
+class TestGetLongestTransitSession(unittest.TestCase):
+    def test_single_session(self) -> None:
+        # 5 tracks 3 minutes apart → one session of 5
+        base = 1_700_000_000
+        df = pd.DataFrame({"timestamp": [base + i * 180 for i in range(5)]})
+        self.assertEqual(get_longest_transit_session(df, gap_minutes=60), 5)
+
+    def test_two_sessions_returns_longer(self) -> None:
+        base = 1_700_000_000
+        session1 = [base + i * 180 for i in range(3)]  # 3 tracks
+        session2 = [base + 7200 + i * 180 for i in range(6)]  # 2h gap, 6 tracks
+        df = pd.DataFrame({"timestamp": session1 + session2})
+        self.assertEqual(get_longest_transit_session(df, gap_minutes=60), 6)
+
+    def test_empty_returns_zero(self) -> None:
+        self.assertEqual(get_longest_transit_session(pd.DataFrame()), 0)
+
+    def test_single_track(self) -> None:
+        df = pd.DataFrame({"timestamp": [1_700_000_000]})
+        self.assertEqual(get_longest_transit_session(df, gap_minutes=60), 1)
+
+
+# ---------------------------------------------------------------------------
+# get_transit_listening_hours
+# ---------------------------------------------------------------------------
+
+
+class TestGetTransitListeningHours(unittest.TestCase):
+    def test_returns_hourly_counts(self) -> None:
+        df = _make_listens(["2023-06-12 10:00", "2023-06-12 10:30", "2023-06-12 14:00"])
+        hourly = get_transit_listening_hours(df)
+        self.assertIn("hour", hourly.columns)
+        self.assertIn("Plays", hourly.columns)
+        hour_10 = hourly[hourly["hour"] == 10]["Plays"].values
+        self.assertEqual(hour_10[0], 2)
+
+    def test_empty_df_returns_empty(self) -> None:
+        hourly = get_transit_listening_hours(pd.DataFrame())
+        self.assertTrue(hourly.empty)
+
+
+# ---------------------------------------------------------------------------
+# render_in_transit (UI smoke tests)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderInTransit(unittest.TestCase):
+    """Smoke tests for the Streamlit page render function."""
+
+    def _transit_swarm(self) -> pd.DataFrame:
+        """Return a minimal swarm DataFrame with one Airport check-in."""
+        ts = int(pd.Timestamp("2023-06-12").timestamp())
+        return pd.DataFrame(
+            {
+                "timestamp": [ts],
+                "venue": ["JFK Airport"],
+                "venue_category": ["Airport"],
+                "city": ["New York"],
+                "state": ["NY"],
+                "country": ["United States"],
+                "lat": [40.6413],
+                "lng": [-73.7781],
+                "offset": [0],
+            }
+        )
+
+    def _listens(self) -> pd.DataFrame:
+        return _make_listens(
+            ["2023-06-12", "2023-06-13", "2023-06-12"],
+            ["Artist A", "Artist B", "Artist C"],
+        )
+
+    @patch("streamlit.header")
+    @patch("streamlit.caption")
+    @patch("streamlit.info")
+    def test_renders_info_when_no_listens(
+        self, mock_info: MagicMock, _cap: MagicMock, _hdr: MagicMock
+    ) -> None:
+        with patch("streamlit.session_state", {"df": None, "swarm_df": None}):
+            from pages.in_transit import render_in_transit
+
+            render_in_transit()
+        mock_info.assert_called_once()
+
+    @patch("streamlit.header")
+    @patch("streamlit.caption")
+    @patch("streamlit.info")
+    def test_renders_info_when_no_swarm(
+        self, mock_info: MagicMock, _cap: MagicMock, _hdr: MagicMock
+    ) -> None:
+        listens = self._listens()
+        with patch("streamlit.session_state", {"df": listens, "swarm_df": None}):
+            from pages.in_transit import render_in_transit
+
+            render_in_transit()
+        mock_info.assert_called_once()
+
+    @patch("streamlit.header")
+    @patch("streamlit.caption")
+    @patch("streamlit.warning")
+    def test_renders_warning_when_no_transit_checkins(
+        self, mock_warning: MagicMock, _cap: MagicMock, _hdr: MagicMock
+    ) -> None:
+        listens = self._listens()
+        swarm = pd.DataFrame(
+            {
+                "timestamp": [1_700_000_000],
+                "venue": ["Coffee Shop"],
+                "venue_category": ["Cafe"],
+                "city": ["London"],
+                "state": ["England"],
+                "country": ["United Kingdom"],
+                "lat": [51.5],
+                "lng": [-0.1],
+                "offset": [0],
+            }
+        )
+        with patch("streamlit.session_state", {"df": listens, "swarm_df": swarm}):
+            from pages.in_transit import render_in_transit
+
+            render_in_transit()
+        mock_warning.assert_called_once()
+
+    @patch("streamlit.plotly_chart")
+    @patch("streamlit.dataframe")
+    @patch("streamlit.markdown")
+    @patch("streamlit.metric")
+    @patch("streamlit.subheader")
+    @patch("streamlit.expander")
+    @patch("streamlit.columns")
+    @patch("streamlit.header")
+    @patch("streamlit.caption")
+    def test_renders_full_page(
+        self,
+        _cap: MagicMock,
+        _hdr: MagicMock,
+        mock_columns: MagicMock,
+        mock_expander: MagicMock,
+        _sub: MagicMock,
+        _metric: MagicMock,
+        _md: MagicMock,
+        _df: MagicMock,
+        _pc: MagicMock,
+    ) -> None:
+        # Arrange column mocks — st.columns() is called with 4, 2, 2, and 2 args.
+        def _make_col() -> MagicMock:
+            c = MagicMock()
+            c.__enter__ = MagicMock(return_value=c)
+            c.__exit__ = MagicMock(return_value=False)
+            return c
+
+        def _columns_side_effect(n: int) -> list[MagicMock]:
+            return [_make_col() for _ in range(n)]
+
+        mock_columns.side_effect = _columns_side_effect
+
+        exp_ctx = MagicMock()
+        exp_ctx.__enter__ = MagicMock(return_value=exp_ctx)
+        exp_ctx.__exit__ = MagicMock(return_value=False)
+        mock_expander.return_value = exp_ctx
+
+        listens = self._listens()
+        swarm = self._transit_swarm()
+
+        with patch("streamlit.session_state", {"df": listens, "swarm_df": swarm}):
+            from pages.in_transit import render_in_transit
+
+            render_in_transit()
+
+        # The page must have called st.plotly_chart at least once
+        self.assertGreater(_pc.call_count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/visualize.py
+++ b/visualize.py
@@ -22,6 +22,7 @@ from pages.beer import render_beer
 from pages.culture import render_culture
 from pages.data_sources import render_data_sources, render_plugin_page
 from pages.fitness import render_fitness
+from pages.in_transit import render_in_transit
 from pages.insights import render_insights, render_insights_and_narrative  # noqa: F401
 from pages.music import render_music, render_top_charts  # noqa: F401
 from pages.overview import render_overview  # noqa: F401
@@ -129,6 +130,7 @@ def main() -> None:
             "Places": [
                 st.Page(render_places, title="Check-ins", icon=":material/location_on:"),
                 st.Page(render_checkin_insights, title="Insights", icon=":material/insights:"),
+                st.Page(render_in_transit, title="In Transit", icon=":material/flight:"),
             ],
             "Health": [
                 st.Page(render_fitness, title="Fitness", icon=":material/fitness_center:"),


### PR DESCRIPTION
## Summary

- Adds a new **In Transit** page under the Places nav group (`:material/flight:` icon) that surfaces listening patterns on Foursquare/Swarm transit-hub days (Airport, Train Station, Metro, etc.) vs. all other days
- Extends `load_swarm_data()` to capture `venue_category` from `venue.categories[0].name` so transit check-ins can be identified by Foursquare category
- Adds six new utility functions to `analysis_utils.py`: `get_transit_days`, `split_transit_listens`, `get_avg_plays_per_day`, `get_new_artist_discovery_rate`, `get_transit_listening_hours`, `get_longest_transit_session`

## Metrics surfaced

- Top-20 transit artists (horizontal bar chart)
- Avg plays per travel day vs. non-travel day (comparison bar + metric delta)
- New artist discovery rate on transit days vs. home days
- Common listening hours during transit (hourly distribution bar chart)
- Longest transit listening session (track count)

## Test plan

- [x] 31 new unit + smoke tests in `tests/test_in_transit.py` covering all utility functions and UI render paths
- [x] Full test suite passes: 286 tests, 0 failures
- [x] `ruff check` and `ruff format --check` pass with no issues
- [x] `mypy analysis_utils.py visualize.py` passes with no issues
- [x] Pre-commit hooks pass (ruff + mypy)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)