### PR TITLE
feat: Late Night Sessions — listening after midnight by location (#68)

### DIFF
--- a/pages/late_night.py
+++ b/pages/late_night.py
@@ -417,7 +417,7 @@ def _render_latest_session(df: pd.DataFrame) -> None:
     <p style="color: #f0f4ff; font-size: 1.1rem; margin: 0.25rem 0;">
         <strong>{start_str} – {end_str}</strong>
         &nbsp;&middot;&nbsp;
-        {session['track_count']} tracks
+        {session["track_count"]} tracks
         &nbsp;&middot;&nbsp;
         {duration_min} min
     </p>

--- a/pages/late_night.py
+++ b/pages/late_night.py
@@ -1,0 +1,500 @@
+"""Late Night Sessions page — listening after midnight by location (issue #68).
+
+Night-sky aesthetic.  Surfaces:
+- Top-20 late-night artists (midnight–4 AM local time)
+- City dot map with glow effect
+- Late-night play rate per location type (home / hotel / trip)
+- Hourly clock highlighting midnight–4 AM slice vs. full day
+- "Latest session" — most extreme consecutive late-night streak
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+import streamlit as st
+
+from components.theme import (
+    ACCENT_CYAN,
+    ACCENT_INDIGO,
+    ACCENT_PURPLE,
+    TEXT_DIM,
+    apply_dark_theme,
+)
+
+# Local hours considered "late night" (0 inclusive, 4 exclusive).
+_LATE_NIGHT_START = 0
+_LATE_NIGHT_END = 4  # exclusive: hours 0, 1, 2, 3
+
+# Maximum gap in minutes between consecutive plays within one session.
+_SESSION_GAP_MINUTES = 30
+
+# Colour constants for the night-sky aesthetic.
+_GLOW_COLOUR = "rgba(99, 102, 241, 0.55)"  # indigo glow for dot map
+_LATE_COLOUR = ACCENT_INDIGO  # bars for midnight–4 AM window
+_DAY_COLOUR = "rgba(139, 148, 167, 0.4)"  # muted colour for rest of day
+
+
+def _filter_late_night(df: pd.DataFrame) -> pd.DataFrame:
+    """Return rows where the local hour falls in the midnight–4 AM window.
+
+    Args:
+        df: Listening history with a ``date_text`` column (local time).
+
+    Returns:
+        Filtered DataFrame; empty when no late-night rows exist.
+    """
+    if df.empty or "date_text" not in df.columns:
+        return pd.DataFrame()
+    mask = (df["date_text"].dt.hour >= _LATE_NIGHT_START) & (
+        df["date_text"].dt.hour < _LATE_NIGHT_END
+    )
+    return df[mask]
+
+
+def get_top_late_night_artists(df: pd.DataFrame, limit: int = 20) -> pd.DataFrame:
+    """Return the top ``limit`` artists by late-night play count.
+
+    Only scrobbles recorded between midnight and 4 AM (local time) are
+    considered.
+
+    Args:
+        df: Full listening history DataFrame with ``date_text`` and ``artist``.
+        limit: Maximum number of artists to return.
+
+    Returns:
+        DataFrame with columns ``artist`` and ``plays``, sorted descending.
+    """
+    late = _filter_late_night(df)
+    if late.empty or "artist" not in late.columns:
+        return pd.DataFrame(columns=["artist", "plays"])
+    counts = late["artist"].value_counts().head(limit).reset_index()
+    counts.columns = ["artist", "plays"]
+    return counts
+
+
+def get_late_night_by_city(df: pd.DataFrame) -> pd.DataFrame:
+    """Return late-night play counts grouped by city with lat/lng.
+
+    Args:
+        df: Listening history with ``date_text``, ``city``, ``lat``, ``lng``.
+
+    Returns:
+        DataFrame with columns ``city``, ``lat``, ``lng``, ``plays`` sorted
+        descending by play count.  Empty when no late-night plays exist.
+    """
+    late = _filter_late_night(df)
+    if late.empty or "city" not in late.columns:
+        return pd.DataFrame(columns=["city", "lat", "lng", "plays"])
+    groups = ["city"]
+    if "lat" in late.columns and "lng" in late.columns:
+        groups = ["city", "lat", "lng"]
+    result = late.groupby(groups).size().reset_index(name="plays")
+    return result.sort_values("plays", ascending=False).reset_index(drop=True)
+
+
+def get_late_night_by_location_type(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute late-night rate per inferred location type.
+
+    Location type is inferred from the city name heuristic:
+    - "hotel" / "inn" / "hostel" anywhere in the city string → "Hotel"
+    - Otherwise: if the city appears in both late-night and daytime plays the
+      ratio determines the label; all cities without a hotel keyword are
+      grouped as either "Home" (city most frequently seen) or "Trip" (others).
+
+    The result contains one row per inferred type with ``plays`` (total
+    late-night plays) and ``rate`` (late-night plays / all plays for that
+    type, 0–1).
+
+    Args:
+        df: Listening history with ``date_text`` and ``city``.
+
+    Returns:
+        DataFrame with columns ``location_type``, ``plays``, ``rate``.
+        Empty when input is empty or lacks required columns.
+    """
+    if df.empty or "date_text" not in df.columns or "city" not in df.columns:
+        return pd.DataFrame(columns=["location_type", "plays", "rate"])
+
+    late = _filter_late_night(df)
+    if late.empty:
+        return pd.DataFrame(columns=["location_type", "plays", "rate"])
+
+    # Infer type for each city.
+    def _infer_type(city: str, home_city: str) -> str:
+        city_lower = city.lower()
+        if any(k in city_lower for k in ("hotel", "inn", "hostel", "motel")):
+            return "Hotel"
+        if city == home_city:
+            return "Home"
+        return "Trip"
+
+    # The most-played city across all hours is treated as "home".
+    home_city: str = str(df["city"].mode().iloc[0]) if not df.empty else ""
+
+    late = late.copy()
+    late["location_type"] = late["city"].astype(str).apply(lambda c: _infer_type(c, home_city))
+
+    all_df = df.copy()
+    all_df["location_type"] = all_df["city"].astype(str).apply(lambda c: _infer_type(c, home_city))
+
+    late_counts = late.groupby("location_type").size().rename("plays")
+    all_counts = all_df.groupby("location_type").size().rename("total")
+
+    result = pd.concat([late_counts, all_counts], axis=1).fillna(0).reset_index()
+    result.columns = ["location_type", "plays", "total"]
+    result["rate"] = (result["plays"] / result["total"].replace(0, 1)).round(3)
+    result["plays"] = result["plays"].astype(int)
+    return result.sort_values("plays", ascending=False).reset_index(drop=True)
+
+
+def get_late_night_hourly(df: pd.DataFrame) -> pd.DataFrame:
+    """Return hourly play counts for all 24 hours with a late-night flag.
+
+    Args:
+        df: Listening history with ``date_text``.
+
+    Returns:
+        DataFrame with columns ``hour`` (0–23), ``plays`` (int), and
+        ``is_late_night`` (bool) — True for hours 0–3.
+    """
+    all_hours = pd.DataFrame({"hour": range(24)})
+    if df.empty or "date_text" not in df.columns:
+        all_hours["plays"] = 0
+        all_hours["is_late_night"] = all_hours["hour"] < _LATE_NIGHT_END
+        return all_hours
+
+    hourly = (
+        df.assign(hour=df["date_text"].dt.hour).groupby("hour").size().reset_index(name="plays")
+    )
+    merged = all_hours.merge(hourly, on="hour", how="left").fillna(0)
+    merged["plays"] = merged["plays"].astype(int)
+    merged["is_late_night"] = merged["hour"] < _LATE_NIGHT_END
+    return merged
+
+
+def find_latest_session(df: pd.DataFrame) -> dict[str, Any] | None:
+    """Find the most extreme consecutive late-night listening session.
+
+    A "session" is defined as consecutive plays in the midnight–4 AM window
+    with inter-play gaps of less than ``_SESSION_GAP_MINUTES`` minutes.
+    The "latest" session is the one with the highest track count; ties are
+    broken by the most recent start time.
+
+    Args:
+        df: Listening history with ``date_text``, ``timestamp``, and
+            ``artist``.
+
+    Returns:
+        Dictionary with keys:
+        - ``start``: session start ``pd.Timestamp``
+        - ``end``: session end ``pd.Timestamp``
+        - ``track_count``: number of plays in the session
+        - ``artists``: list of unique artists
+
+        Returns ``None`` when no late-night plays are present.
+    """
+    late = _filter_late_night(df)
+    if late.empty:
+        return None
+
+    late = late.sort_values("date_text").reset_index(drop=True)
+
+    # Compute gap to previous play (in minutes).
+    gap_minutes = late["date_text"].diff().dt.total_seconds().fillna(0) / 60
+
+    # Assign session IDs: new session whenever gap exceeds threshold.
+    session_ids = (gap_minutes > _SESSION_GAP_MINUTES).cumsum()
+    late = late.copy()
+    late["session_id"] = session_ids
+
+    # Aggregate sessions.
+    sessions: list[dict[str, Any]] = []
+    for sid, grp in late.groupby("session_id"):
+        sessions.append(
+            {
+                "session_id": sid,
+                "start": grp["date_text"].iloc[0],
+                "end": grp["date_text"].iloc[-1],
+                "track_count": len(grp),
+                "artists": grp["artist"].dropna().unique().tolist()
+                if "artist" in grp.columns
+                else [],
+            }
+        )
+
+    if not sessions:
+        return None
+
+    # Return the session with the most tracks (latest start for ties).
+    best = sorted(sessions, key=lambda s: (s["track_count"], s["start"]), reverse=True)[0]
+    return best
+
+
+# ---------------------------------------------------------------------------
+# Rendering helpers
+# ---------------------------------------------------------------------------
+
+
+def _render_top_artists(df: pd.DataFrame) -> None:
+    """Render a horizontal bar chart of top late-night artists.
+
+    Args:
+        df: Full listening history DataFrame.
+    """
+    top = get_top_late_night_artists(df, limit=20)
+    if top.empty:
+        st.caption("No late-night plays found in this dataset.")
+        return
+
+    ranked_labels = [f"#{r}  {n}" for r, n in enumerate(top["artist"], 1)]
+    colors = [ACCENT_INDIGO] + [ACCENT_PURPLE] * (len(top) - 1)
+
+    fig = go.Figure(
+        go.Bar(
+            x=top["plays"].tolist(),
+            y=ranked_labels,
+            orientation="h",
+            marker_color=colors,
+            text=[f"{p:,}" for p in top["plays"]],
+            textposition="outside",
+            cliponaxis=False,
+        )
+    )
+    fig.update_layout(
+        title="Top 20 Late-Night Artists (Midnight – 4 AM)",
+        yaxis={"categoryorder": "total ascending"},
+        margin={"r": 80},
+        paper_bgcolor="rgba(0,0,0,0)",
+        plot_bgcolor="rgba(0,0,0,0)",
+    )
+    apply_dark_theme(fig)
+    st.plotly_chart(fig, width="stretch")
+
+
+def _render_city_dot_map(df: pd.DataFrame) -> None:
+    """Render a scatter-geo dot map of late-night listening cities.
+
+    Uses a glow-style opacity effect to evoke a night-sky aesthetic.
+
+    Args:
+        df: Full listening history DataFrame.
+    """
+    city_data = get_late_night_by_city(df)
+    if city_data.empty or "lat" not in city_data.columns or "lng" not in city_data.columns:
+        st.caption("No geographic data available for the city map.")
+        return
+
+    city_data = city_data.dropna(subset=["lat", "lng"])
+    if city_data.empty:
+        st.caption("No geographic data available for the city map.")
+        return
+
+    fig = px.scatter_geo(
+        city_data,
+        lat="lat",
+        lon="lng",
+        size="plays",
+        hover_name="city",
+        hover_data={"plays": True, "lat": False, "lng": False},
+        title="Late-Night Listening Locations",
+        size_max=40,
+        color="plays",
+        color_continuous_scale=[
+            [0.0, "#1e1b4b"],
+            [0.5, ACCENT_INDIGO],
+            [1.0, ACCENT_CYAN],
+        ],
+    )
+    fig.update_geos(
+        bgcolor="rgba(0,0,0,0)",
+        showland=True,
+        landcolor="#0c1120",
+        showocean=True,
+        oceancolor="#090e1a",
+        showcoastlines=True,
+        coastlinecolor="#2d3a52",
+        showframe=False,
+    )
+    fig.update_layout(
+        geo={"showframe": False, "bgcolor": "rgba(0,0,0,0)"},
+        coloraxis_showscale=False,
+        margin={"l": 0, "r": 0, "t": 40, "b": 0},
+    )
+    apply_dark_theme(fig)
+    st.plotly_chart(fig, width="stretch")
+
+
+def _render_location_type_chart(df: pd.DataFrame) -> None:
+    """Render late-night play rate per location type (home / hotel / trip).
+
+    Args:
+        df: Full listening history DataFrame.
+    """
+    loc_data = get_late_night_by_location_type(df)
+    if loc_data.empty:
+        st.caption("No location-type data available.")
+        return
+
+    loc_data = loc_data.copy()
+    loc_data["rate_pct"] = (loc_data["rate"] * 100).round(1)
+
+    fig = px.bar(
+        loc_data,
+        x="location_type",
+        y="rate_pct",
+        color="location_type",
+        text=loc_data["rate_pct"].astype(str) + "%",
+        title="Late-Night Rate by Location Type",
+        labels={"location_type": "Location Type", "rate_pct": "Late-Night %"},
+        color_discrete_sequence=[ACCENT_INDIGO, ACCENT_PURPLE, ACCENT_CYAN],
+    )
+    fig.update_traces(textposition="outside")
+    fig.update_layout(showlegend=False)
+    apply_dark_theme(fig)
+    st.plotly_chart(fig, width="stretch")
+
+
+def _render_hourly_clock(df: pd.DataFrame) -> None:
+    """Render a 24-hour bar chart highlighting the midnight–4 AM window.
+
+    Late-night hours are shown in indigo; all other hours are muted.
+
+    Args:
+        df: Full listening history DataFrame.
+    """
+    hourly = get_late_night_hourly(df)
+    colors = [_LATE_COLOUR if h else _DAY_COLOUR for h in hourly["is_late_night"]]
+
+    fig = go.Figure(
+        go.Bar(
+            x=hourly["hour"],
+            y=hourly["plays"],
+            marker_color=colors,
+            hovertemplate="Hour %{x}:00 — %{y} plays<extra></extra>",
+        )
+    )
+    fig.update_layout(
+        title="Plays by Hour — Midnight–4 AM Highlighted",
+        xaxis={"tickmode": "linear", "tick0": 0, "dtick": 2, "title": "Hour of Day"},
+        yaxis={"title": "Plays"},
+    )
+    apply_dark_theme(fig)
+    st.plotly_chart(fig, width="stretch")
+
+
+def _render_latest_session(df: pd.DataFrame) -> None:
+    """Render the 'Latest Session' card showing the longest consecutive streak.
+
+    Args:
+        df: Full listening history DataFrame.
+    """
+    session = find_latest_session(df)
+    if session is None:
+        st.caption("No late-night sessions found.")
+        return
+
+    start_str = session["start"].strftime("%Y-%m-%d %H:%M")
+    end_str = session["end"].strftime("%H:%M")
+    duration_min = int((session["end"] - session["start"]).total_seconds() / 60)
+    artists_str = ", ".join(str(a) for a in session["artists"][:5])
+    if len(session["artists"]) > 5:
+        artists_str += f" +{len(session['artists']) - 5} more"
+
+    st.markdown(
+        f"""
+<div style="
+    background: linear-gradient(135deg, #1e1b4b, #0c1120);
+    border: 1px solid {ACCENT_INDIGO};
+    border-radius: 12px;
+    padding: 1.5rem 2rem;
+    margin-bottom: 1rem;
+">
+    <h3 style="color: {ACCENT_CYAN}; margin-top: 0;">Latest Session</h3>
+    <p style="color: #f0f4ff; font-size: 1.1rem; margin: 0.25rem 0;">
+        <strong>{start_str} – {end_str}</strong>
+        &nbsp;&middot;&nbsp;
+        {session['track_count']} tracks
+        &nbsp;&middot;&nbsp;
+        {duration_min} min
+    </p>
+    <p style="color: {TEXT_DIM}; margin: 0.5rem 0 0 0; font-size: 0.9rem;">
+        {artists_str}
+    </p>
+</div>
+""",
+        unsafe_allow_html=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Page entry point
+# ---------------------------------------------------------------------------
+
+
+def render_late_night() -> None:
+    """Render the Late Night Sessions page.
+
+    Reads the active merged DataFrame from ``st.session_state['df']``.
+    Shows an empty state when no data has been loaded.
+
+    The page surfaces:
+    - Top-20 late-night artists (midnight–4 AM)
+    - City dot map with glow effect
+    - Late-night rate per location type
+    - Hourly clock with midnight–4 AM window highlighted
+    - Latest session card (longest consecutive streak)
+    """
+    df = st.session_state.get("df")
+    if df is None or df.empty:
+        st.info(
+            "No music data loaded yet. "
+            "Configure a Last.fm source in the sidebar and select a data file."
+        )
+        return
+
+    st.header("Late Night Sessions")
+    st.markdown(
+        f'<p style="color:{TEXT_DIM}; margin-top:-0.5rem;">'
+        "Listening after midnight · Local time · Midnight – 4 AM window"
+        "</p>",
+        unsafe_allow_html=True,
+    )
+
+    late = _filter_late_night(df)
+    total_plays = len(df)
+    late_plays = len(late)
+    late_pct = late_plays / total_plays * 100 if total_plays else 0
+
+    col1, col2 = st.columns(2)
+    with col1:
+        st.metric("Late-Night Plays", f"{late_plays:,}")
+    with col2:
+        st.metric("% of All Plays", f"{late_pct:.1f}%")
+
+    st.divider()
+
+    _render_latest_session(df)
+
+    st.divider()
+
+    st.subheader("Top Artists")
+    _render_top_artists(df)
+
+    st.divider()
+
+    col_map, col_type = st.columns(2)
+    with col_map:
+        st.subheader("Listening Locations")
+        _render_city_dot_map(df)
+    with col_type:
+        st.subheader("By Location Type")
+        _render_location_type_chart(df)
+
+    st.divider()
+
+    st.subheader("Hourly Breakdown")
+    _render_hourly_clock(df)

--- a/pages/late_night.py
+++ b/pages/late_night.py
@@ -457,12 +457,12 @@ def render_late_night() -> None:
         return
 
     st.header("Late Night Sessions")
-    st.markdown(
+    subtitle = (
         f'<p style="color:{TEXT_DIM}; margin-top:-0.5rem;">'
-        "Listening after midnight · Local time · Midnight – 4 AM window"
-        "</p>",
-        unsafe_allow_html=True,
+        "Listening after midnight · Local time · Midnight – 4 AM window"
+        "</p>"
     )
+    st.markdown(subtitle, unsafe_allow_html=True)
 
     late = _filter_late_night(df)
     total_plays = len(df)

--- a/tests/test_late_night.py
+++ b/tests/test_late_night.py
@@ -1,0 +1,289 @@
+"""Tests for the Late Night Sessions page (issue #68)."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from pages.late_night import (
+    find_latest_session,
+    get_late_night_by_city,
+    get_late_night_by_location_type,
+    get_late_night_hourly,
+    get_top_late_night_artists,
+    render_late_night,
+)
+
+
+def _make_df(hours: list[int], cities: list[str], artists: list[str]) -> pd.DataFrame:
+    """Build a minimal merged DataFrame suitable for late-night analysis.
+
+    Args:
+        hours: Local hour for each row (0–23).
+        cities: City label for each row.
+        artists: Artist name for each row.
+
+    Returns:
+        DataFrame with ``date_text``, ``artist``, ``city``, ``lat``, ``lng``,
+        ``timestamp``, ``country``, ``state`` columns.
+    """
+    base_ts = 1700000000  # arbitrary fixed epoch
+    timestamps = [base_ts + i * 60 for i in range(len(hours))]
+    date_texts = [pd.Timestamp("2024-01-15") + pd.Timedelta(hours=h) for h in hours]
+    return pd.DataFrame(
+        {
+            "date_text": pd.to_datetime(date_texts),
+            "timestamp": timestamps,
+            "artist": artists,
+            "city": cities,
+            "state": ["State"] * len(hours),
+            "country": ["Country"] * len(hours),
+            "lat": [40.0] * len(hours),
+            "lng": [-74.0] * len(hours),
+        }
+    )
+
+
+class TestGetTopLateNightArtists(unittest.TestCase):
+    """Tests for get_top_late_night_artists."""
+
+    def test_returns_only_midnight_to_4am(self) -> None:
+        """Only scrobbles in hours 0–3 are included in the artist counts."""
+        df = _make_df(
+            hours=[1, 2, 10, 14, 23],
+            cities=["NYC"] * 5,
+            artists=["NightOwl", "NightOwl", "Morning", "Afternoon", "Evening"],
+        )
+        top = get_top_late_night_artists(df)
+        self.assertIn("NightOwl", top["artist"].values)
+        self.assertNotIn("Morning", top["artist"].values)
+        self.assertNotIn("Afternoon", top["artist"].values)
+
+    def test_limit_respected(self) -> None:
+        """Result has at most ``limit`` rows."""
+        artists = [f"Artist{i}" for i in range(30)]
+        hours = [2] * 30
+        cities = ["NYC"] * 30
+        df = _make_df(hours=hours, cities=cities, artists=artists)
+        top = get_top_late_night_artists(df, limit=20)
+        self.assertLessEqual(len(top), 20)
+
+    def test_empty_df_returns_empty(self) -> None:
+        """Empty DataFrame input yields an empty result."""
+        df = pd.DataFrame(columns=["date_text", "artist", "city", "lat", "lng"])
+        top = get_top_late_night_artists(df)
+        self.assertTrue(top.empty)
+
+    def test_no_late_night_rows_returns_empty(self) -> None:
+        """No rows in hours 0–3 yields an empty result."""
+        df = _make_df(hours=[9, 10, 11], cities=["NYC"] * 3, artists=["A", "B", "C"])
+        top = get_top_late_night_artists(df)
+        self.assertTrue(top.empty)
+
+
+class TestGetLateNightByCity(unittest.TestCase):
+    """Tests for get_late_night_by_city."""
+
+    def test_groups_by_city(self) -> None:
+        """Late-night plays are summed per city."""
+        df = _make_df(
+            hours=[1, 2, 3, 1],
+            cities=["NYC", "NYC", "LA", "LA"],
+            artists=["A", "B", "C", "D"],
+        )
+        result = get_late_night_by_city(df)
+        self.assertIn("city", result.columns)
+        self.assertIn("plays", result.columns)
+        nyc_row = result[result["city"] == "NYC"]
+        self.assertEqual(int(nyc_row["plays"].iloc[0]), 2)
+
+    def test_excludes_daytime(self) -> None:
+        """Daytime plays do not appear in the city summary."""
+        df = _make_df(hours=[9, 12], cities=["NYC", "NYC"], artists=["A", "B"])
+        result = get_late_night_by_city(df)
+        self.assertTrue(result.empty)
+
+    def test_empty_df_returns_empty(self) -> None:
+        df = pd.DataFrame(columns=["date_text", "artist", "city", "lat", "lng"])
+        result = get_late_night_by_city(df)
+        self.assertTrue(result.empty)
+
+
+class TestGetLateNightByLocationType(unittest.TestCase):
+    """Tests for get_late_night_by_location_type."""
+
+    def test_returns_three_types(self) -> None:
+        """Result contains rows for home, hotel, and trip."""
+        df = _make_df(
+            hours=[1, 2, 3],
+            cities=["Home City", "Hotel XYZ", "Trip Town"],
+            artists=["A", "B", "C"],
+        )
+        # All three cities map to distinct location type groups
+        result = get_late_night_by_location_type(df)
+        self.assertIn("location_type", result.columns)
+        self.assertIn("plays", result.columns)
+        self.assertGreater(len(result), 0)
+
+    def test_rate_column_present(self) -> None:
+        """A ``rate`` column expressing late-night fraction is included."""
+        df = _make_df(
+            hours=[1, 10, 2, 12],
+            cities=["Home", "Home", "Trip", "Trip"],
+            artists=["A", "B", "C", "D"],
+        )
+        result = get_late_night_by_location_type(df)
+        self.assertIn("rate", result.columns)
+
+    def test_empty_df_returns_empty(self) -> None:
+        df = pd.DataFrame(columns=["date_text", "artist", "city", "lat", "lng"])
+        result = get_late_night_by_location_type(df)
+        self.assertTrue(result.empty)
+
+
+class TestGetLateNightHourly(unittest.TestCase):
+    """Tests for get_late_night_hourly."""
+
+    def test_returns_all_24_hours(self) -> None:
+        """Result always has exactly 24 rows (one per hour)."""
+        df = _make_df(hours=[0, 1, 2, 3], cities=["NYC"] * 4, artists=["A"] * 4)
+        result = get_late_night_hourly(df)
+        self.assertEqual(len(result), 24)
+
+    def test_late_night_hours_highlighted(self) -> None:
+        """The ``is_late_night`` flag is True for hours 0–3 only."""
+        df = _make_df(hours=[0, 1, 2, 3, 4, 5], cities=["NYC"] * 6, artists=["A"] * 6)
+        result = get_late_night_hourly(df)
+        self.assertIn("is_late_night", result.columns)
+        late = result[result["is_late_night"]]
+        self.assertEqual(set(late["hour"].tolist()), {0, 1, 2, 3})
+
+    def test_empty_df_returns_24_rows_with_zero_plays(self) -> None:
+        """Even with no data, 24 zero-play hours are returned."""
+        df = pd.DataFrame(columns=["date_text", "artist", "city", "lat", "lng"])
+        result = get_late_night_hourly(df)
+        self.assertEqual(len(result), 24)
+        self.assertTrue((result["plays"] == 0).all())
+
+
+class TestFindLatestSession(unittest.TestCase):
+    """Tests for find_latest_session (consecutive late-night streak detection)."""
+
+    def test_detects_consecutive_streak(self) -> None:
+        """Plays within 30-min gaps form a single session."""
+        # Three plays two minutes apart — all one session
+        base_ts = 1700000000
+        df = pd.DataFrame(
+            {
+                "date_text": pd.to_datetime(
+                    [
+                        pd.Timestamp("2024-01-15 01:00"),
+                        pd.Timestamp("2024-01-15 01:02"),
+                        pd.Timestamp("2024-01-15 01:04"),
+                    ]
+                ),
+                "timestamp": [base_ts, base_ts + 120, base_ts + 240],
+                "artist": ["A", "A", "A"],
+                "city": ["NYC"] * 3,
+                "state": ["NY"] * 3,
+                "country": ["US"] * 3,
+                "lat": [40.0] * 3,
+                "lng": [-74.0] * 3,
+            }
+        )
+        session = find_latest_session(df)
+        self.assertIsNotNone(session)
+        assert session is not None
+        self.assertEqual(session["track_count"], 3)
+
+    def test_gap_over_30_min_breaks_session(self) -> None:
+        """A gap larger than 30 minutes separates plays into different sessions."""
+        base_ts = 1700000000
+        df = pd.DataFrame(
+            {
+                "date_text": pd.to_datetime(
+                    [
+                        pd.Timestamp("2024-01-15 01:00"),
+                        pd.Timestamp("2024-01-15 01:40"),  # 40 min later — new session
+                    ]
+                ),
+                "timestamp": [base_ts, base_ts + 2400],
+                "artist": ["A", "B"],
+                "city": ["NYC"] * 2,
+                "state": ["NY"] * 2,
+                "country": ["US"] * 2,
+                "lat": [40.0] * 2,
+                "lng": [-74.0] * 2,
+            }
+        )
+        session = find_latest_session(df)
+        # Both are single-track sessions; the latest (most recent) is returned
+        self.assertIsNotNone(session)
+        assert session is not None
+        self.assertEqual(session["track_count"], 1)
+
+    def test_returns_none_when_no_late_night_plays(self) -> None:
+        """Returns None when there are no plays in hours 0–3."""
+        df = _make_df(hours=[9, 10], cities=["NYC"] * 2, artists=["A", "B"])
+        session = find_latest_session(df)
+        self.assertIsNone(session)
+
+    def test_empty_df_returns_none(self) -> None:
+        df = pd.DataFrame(columns=["date_text", "artist", "city", "lat", "lng", "timestamp"])
+        session = find_latest_session(df)
+        self.assertIsNone(session)
+
+
+class TestRenderLateNight(unittest.TestCase):
+    """Integration tests for render_late_night page function."""
+
+    def _make_full_df(self) -> pd.DataFrame:
+        """Return a DataFrame with enough variety for all page sections."""
+        return _make_df(
+            hours=[0, 1, 2, 3, 10, 14],
+            cities=["NYC", "NYC", "LA", "LA", "NYC", "LA"],
+            artists=["Artist1", "Artist2", "Artist1", "Artist3", "Artist4", "Artist5"],
+        )
+
+    @patch("streamlit.info")
+    def test_empty_state_shows_info(self, mock_info: MagicMock) -> None:
+        """render_late_night shows an info message when no data is loaded."""
+        with patch("streamlit.session_state", {"df": None}):
+            render_late_night()
+        mock_info.assert_called_once()
+
+    @patch("streamlit.header")
+    @patch("streamlit.subheader")
+    @patch("streamlit.plotly_chart")
+    @patch("streamlit.metric")
+    @patch("streamlit.columns")
+    @patch("streamlit.markdown")
+    @patch("streamlit.dataframe")
+    @patch("streamlit.caption")
+    @patch("streamlit.divider")
+    def test_renders_with_data(
+        self,
+        mock_divider: MagicMock,
+        mock_caption: MagicMock,
+        mock_dataframe: MagicMock,
+        mock_markdown: MagicMock,
+        mock_columns: MagicMock,
+        mock_metric: MagicMock,
+        mock_plotly: MagicMock,
+        mock_subheader: MagicMock,
+        mock_header: MagicMock,
+    ) -> None:
+        """render_late_night completes without error when data is present."""
+        df = self._make_full_df()
+        col_mock = MagicMock()
+        col_mock.__enter__ = MagicMock(return_value=col_mock)
+        col_mock.__exit__ = MagicMock(return_value=False)
+        mock_columns.return_value = [col_mock, col_mock]
+
+        with patch("streamlit.session_state", {"df": df}):
+            render_late_night()
+
+        mock_header.assert_called_once_with("Late Night Sessions")
+        self.assertTrue(mock_plotly.called)

--- a/visualize.py
+++ b/visualize.py
@@ -23,6 +23,7 @@ from pages.culture import render_culture
 from pages.data_sources import render_data_sources, render_plugin_page
 from pages.fitness import render_fitness
 from pages.insights import render_insights, render_insights_and_narrative  # noqa: F401
+from pages.late_night import render_late_night
 from pages.music import render_music, render_top_charts  # noqa: F401
 from pages.overview import render_overview  # noqa: F401
 from pages.places import (  # noqa: F401
@@ -125,6 +126,9 @@ def main() -> None:
             "Music": [
                 st.Page(render_music, title="Listening", icon=":material/headphones:"),
                 st.Page(render_insights, title="Insights", icon=":material/auto_stories:"),
+                st.Page(
+                    render_late_night, title="Late Night Sessions", icon=":material/nights_stay:"
+                ),
             ],
             "Places": [
                 st.Page(render_places, title="Check-ins", icon=":material/location_on:"),


### PR DESCRIPTION
## Summary

- Adds `pages/late_night.py` with `render_late_night()` — a new Music page surfacing late-night listening analytics with a night-sky aesthetic
- Five analysis helpers: `get_top_late_night_artists`, `get_late_night_by_city`, `get_late_night_by_location_type`, `get_late_night_hourly`, `find_latest_session`
- Registers the page under **Music > Late Night Sessions** (`icon=":material/nights_stay:"`) in `visualize.py`
- Tests in `tests/test_late_night.py` cover all pure-logic functions and the page render entry point

## Features (per issue spec)

- **Top-20 late-night artists** (midnight–4 AM local time, from `date_text` after `apply_swarm_offsets`)
- **City dot map** — `px.scatter_geo` with indigo→cyan glow color scale
- **Late-night rate by location type** — home / hotel / trip inferred from city name heuristic
- **Hourly clock** — 24-hour bar chart with midnight–4 AM window highlighted in indigo, rest in muted grey
- **Latest session card** — most plays-dense consecutive streak (gap < 30 min) styled as an inline dark card

## Test plan

- [ ] `pytest tests/test_late_night.py` passes
- [ ] Full quality gate passes (`ruff check`, `ruff format --check`, `mypy`, `pytest`)
- [ ] Page renders without error when music data is loaded
- [ ] Page shows empty-state info when no data is loaded

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)