### PR TITLE
feat: add FlickrPlugin for localizer (issue #19)

### DIFF
--- a/handoff.md
+++ b/handoff.md
@@ -3,1398 +3,1000 @@
 ## Plan Status
 status: COMPLETE
 
-**Final summary**: All 5 subtasks are `APPROVED`. This plan preserved `source_id` through
-both the broker (DuckDB) and legacy flat-file data pipelines (Subtasks 1 and 2, PR group
-`preserve-source-id`, already merged in a prior PR), added a shared, pure, Streamlit-free
-`core/source_filter.py` helper (Subtask 3), and wired a `st.selectbox("Source", …)` filter
-into both consuming pages — Geo Explorer (Subtask 4) and Check-in Insights (Subtask 5),
-PR group `geo-source-filter-ui` — so a user can now isolate Swarm/Foursquare check-ins from
-Google Timeline check-ins (or view "All") on both pages, with the filter consistently
-applied before map plotting, groupby aggregation, and the shareable HTML export. The
-full-suite gate (`python -m pytest`, no path filter) passed at 905/905 before this PR group
-was opened. Follow-up recommendation (out of scope, documented in the Task Overview): the
-same `core/source_filter.py` helper could be extended to `pages/overview.py`,
-`pages/life_in_chapters.py`, `pages/listening_lifestyle.py`, and `pages/insights.py`, which
-all read `swarm_df` for derived analytics but were intentionally left untouched here to
-keep the diff focused.
+**Final summary**: All three subtasks are `APPROVED`. (1) Fixed `LetterboxdPlugin`'s
+field mapping to match issue #10 (`label`/`sublabel` = film title, `category` =
+release year, typed `rating`/`rewatch` preserved in `raw_json`). (2) Added
+`FlickrPlugin` (issue #19) — directory-of-JSON-files export, `PLACES` output,
+`geotagged_only` toggle with NaN lat/lng for the un-geotagged/toggle-off case. (3)
+Added `UntappdPlugin` (issue #20) — single-CSV-file export, `EVENTS` output,
+`label`/`sublabel`/`category` = `brewery_name`/`beer_name`/`beer_type`, typed
+`rating`/`venue_lat`/`venue_lng` preserved in `raw_json` as `None` (not `NaN`) when
+missing. Each subtask has its own `PR Group` (`letterboxd-field-mapping-fix`,
+`flickr-plugin`, `untappd-plugin`) — three separate PR groups are now ready for the
+orchestrator to close via the full-suite integration gate, branch/commit, and
+`gh pr create`, per `AGENTS.md`'s "After each subtask is APPROVED" section.
+**Follow-up recommendations**: none blocking. Two non-blocking notes carried over
+from review: (a) the shared `pyproject.toml` ruff-ignore line for
+`packages/localizer/tests/*` is currently uncommitted in this worktree and should
+land alongside whichever PR group closes first; (b) the leftover stale-editable-install
+worktree (`.claude/worktrees/agent-adb530a22a6adcac5`) noted in Subtask 1's
+Implementation Notes is still on disk and out of this plan's scope, but may be worth
+cleaning up separately.
 
 ## Task Overview
 
-**The problem**: `~/.localizer/store.duckdb`'s `places` table has a `source_id` column
-distinguishing `swarm` (Foursquare/Swarm check-ins, 7,829 rows) from `google_timeline` (Google
-Maps Timeline, 3,076 rows) — but `core/localizer_frames.py::places_to_swarm_frame()` drops
-`source_id` when adapting the broker's raw places frame into the legacy `swarm_df` shape used
-throughout the app. The legacy flat-file loading path (`components/sidebar.py`) has the same gap:
-it concatenates Swarm and Google Timeline rows with no source tag at all. Once data reaches
-`swarm_df`, there is no way to tell which source a given point came from, and no UI lets the user
-isolate one. Google Timeline rows currently populate `venue`/`city` with activity-segment labels
-(`home`, `work`, `activity:in_bus`, etc.) rather than real venue categories, so the two sources look
-visibly different today, but there is no filter control.
+**The task**: build out three GitHub issues from `little-big-data/autobiographer` —
+issue #10 (`LetterboxdPlugin`), #19 (`FlickrPlugin`), #20 (`UntappdPlugin`) — aligned
+to the **new** `packages/localizer/src/localizer/plugins/` architecture (`SourcePlugin`
+ABC with `FetchMode`/`OutputTable` enums, `fetch_records()` yielding dicts, `@register`
+into `localizer.plugins.REGISTRY`), **not** the old `plugins/sources/` system. All
+three issues were written against the old system's contract (free-form normalized
+DataFrame columns, `PLUGIN_TYPE` where-when/what-when, `load()`) — every field mapping
+below has been translated to the new system's fixed 3-flexible-column `events`/`places`
+schema (`packages/localizer/src/localizer/store/schema.py`), not copied verbatim.
 
-**The fix**, four parts:
+**Existing state verified by reading the code directly (not inferred)**:
+- `packages/localizer/src/localizer/plugins/letterboxd/loader.py` and its test file
+  (`packages/localizer/tests/test_letterboxd_plugin.py`) already exist, are already
+  registered in `load_builtin_plugins()`, and pass (12 tests green). Its field mapping
+  is confirmed to genuinely mismatch issue #10: it currently sets `sublabel` = release
+  year and `category` = rating string; issue #10 requires `label` = `sublabel` = film
+  title and `category` = release year, with `rating` (float) and `rewatch` (bool)
+  preserved as **typed** values, not just present somewhere in the raw CSV row dump.
+  This is a real defect worth fixing (Subtask 1), not an acceptable interpretation —
+  the mismatch is on the two fields that most directly identify "what happened" (the
+  film) and the DB architecture's fixed-column constraint is not the cause of the
+  mismatch (both mappings fit equally well in `label`/`sublabel`/`category`), so there
+  is no architectural reason to keep the current, issue-incompatible mapping.
+- `packages/localizer/src/localizer/plugins/flickr/` and `.../untappd/` do not exist —
+  confirmed via `Glob` — both are greenfield.
+- `packages/localizer/src/localizer/store/schema.py` confirmed directly: `events` has
+  only `id, source_id, timestamp, label, sublabel, category, raw_json, fetched_at`
+  (no lat/lng); `places` has `id, source_id, timestamp, lat, lng, place_name,
+  place_type, raw_json, fetched_at` (`lat`/`lng` are `DOUBLE NOT NULL`, i.e. NULL is
+  disallowed but `NaN` is a legal IEEE754 double distinct from SQL NULL — the issue's
+  literal "NaN lat/lng" requirement for Flickr's un-geotagged case is achievable and
+  intentional, not a mistake).
+- `packages/localizer/src/localizer/store/db.py`'s `upsert_events`/`upsert_places`
+  confirmed by reading directly: they only pull the **named** schema columns off each
+  yielded dict via `rec.get(...)`; anything else in the dict is silently dropped. There
+  is no automatic "everything unnamed goes to raw_json" behavior — **each plugin must
+  manually build `raw_json` itself** to include preserved fields like Untappd's
+  `venue_name`/`venue_lat`/`venue_lng`/`rating` or Flickr's `tags`/`album`/`description`.
+- The CLI (`packages/localizer/src/localizer/cli.py`, `fetch_cmd`/`sync_cmd`) always
+  instantiates plugins with **zero constructor arguments** (`plugin_cls()`) and calls
+  `plugin.fetch_records(since=effective_since)` with no path kwarg. This means every
+  plugin must be able to resolve its own file/directory config from
+  `LocalizerSettings().get_setting(...)` when no path is passed in — either in
+  `__init__` (Swarm/GoogleTimeline's convention) or lazily inside `fetch_records()`
+  (Letterboxd's convention, which is equally CLI-compatible since it defaults its
+  `csv_path` kwarg to `None` and does the settings lookup itself). Both conventions
+  work; each new plugin below mirrors whichever sibling is the closer structural match
+  (Flickr → directory export, mirrors Swarm; Untappd → single CSV file, mirrors
+  Letterboxd).
 
-1. **Preserve `source_id` through the broker (DuckDB) pipeline** — extend `SWARM_COLUMNS` in
-   `core/localizer_frames.py` and stop dropping `source_id` in `places_to_swarm_frame()`
-   (Subtask 1).
-2. **Preserve `source_id` through the legacy flat-file pipeline** — tag rows with `"swarm"` /
-   `"google_timeline"` at the point `components/sidebar.py::_load_data_with_progress()` calls
-   `load_swarm_data()` / `load_google_timeline()`, immediately before the existing
-   `pd.concat()` (Subtask 2).
-3. **A shared, pure, Streamlit-free filtering helper** (`core/source_filter.py`) that computes
-   selectbox options from whatever `source_id` values are present (or gracefully falls back to a
-   single `"All"` option when the column is absent or empty) and filters a `swarm_df` by a chosen
-   label. This mirrors `core/localizer_frames.py`'s existing pure-adapter convention and avoids
-   duplicating source→label mapping logic across the two consuming pages (Subtask 3).
-4. **Wire a `st.selectbox("Source", …)` widget into `pages/geo_explorer.py`** (inside the existing
-   "⚡ Filter" popover, alongside the Artist selectbox) and **into `pages/places.py`'s
-   `render_checkin_insights()`** (the "Check-in Insights" page — confirmed via `visualize.py` line
-   163, which registers `render_checkin_insights` under the page title "Check-in Insights"),
-   filtering `swarm_df` before it reaches map plotting, aggregation, or the shareable HTML export
-   in both pages (Subtasks 4 and 5).
+**Design decisions requiring interpretation beyond the issues' literal text**:
+1. **Missing/nonexistent *directory* configs yield gracefully, not `FileNotFoundError`.**
+   Both existing directory-based MANUAL plugins (Swarm, GoogleTimeline) already
+   established this: a missing/absent directory silently yields nothing so one
+   misconfigured plugin never aborts a multi-plugin `localizer sync` run. Flickr
+   (directory-based, per issue #19) follows this same established convention, which
+   supersedes issue #19's generic "raises FileNotFoundError" architecture blurb (that
+   blurb describes the *old* system's contract verbatim and was not restated per-plugin
+   in the new system's actual precedent). Untappd and the Letterboxd fix are
+   single-*file* configs, where the established precedent (Letterboxd's existing,
+   unmodified-by-this-plan behavior) is to raise `FileNotFoundError` when a path is
+   configured but does not exist — Untappd mirrors that exactly.
+2. **`raw_json`-only preserved fields use `None`, not literal `NaN`, for "missing".**
+   Untappd's `venue_lat`/`venue_lng`/`rating` are *not* promoted to real DB columns
+   (the `events` table has no lat/lng at all) — they live only inside the `raw_json`
+   dict, which must be `json.dumps`-able. `float("nan")` is **not** valid JSON (RFC
+   8259) and would either corrupt the stored JSON or fail to round-trip; `None` (JSON
+   `null`) is the correct, DB-safe equivalent of "missing" for a JSON-embedded field.
+   This is a deliberate, documented deviation from issue #20's literal "NaN" wording,
+   which was written for the old DataFrame-based system where `NaN` is pandas' native
+   missing-float sentinel. Flickr's `lat`/`lng` are the opposite case: they map to
+   **real** `DOUBLE NOT NULL` place columns, where `float("nan")` is legal and is
+   exactly what issue #19 asks for — no deviation there.
+3. **Both new plugins mirror an existing sibling's structure rather than inventing a
+   new pattern.** Flickr (JSON-file-per-record export directory, `PLACES` output)
+   mirrors `swarm/loader.py`'s directory-glob-with-graceful-empty-yield shape.
+   Untappd (single CSV export file, `EVENTS` output) mirrors
+   `letterboxd/loader.py`'s CSV-parsing-with-`FileNotFoundError`-on-configured-missing-
+   path shape almost exactly.
 
-**Design decisions**:
+**Test-suite / quality-gate note (verified directly, not assumed)**: root
+`pyproject.toml` sets `[tool.pytest.ini_options] testpaths = ["tests"]`, and running
+`python -m pytest --collect-only -q` from the repo root collects **exactly 905 tests,
+all under `tests/`, zero from `packages/localizer/tests`**. `.github/workflows/ci.yml`'s
+`quality` job runs a bare `pytest` from the repo root — it therefore **never executes
+`packages/localizer`'s own test suite** (currently 212 passing tests, confirmed via
+`cd packages/localizer && python -m pytest`). The same CI job's `ruff check .` /
+`ruff format --check .` **do** cover `packages/localizer` (no exclude for it in
+`[tool.ruff]`), confirmed by running `ruff check` against a file under
+`packages/localizer/src/`. CI's bare `mypy` does **not** cover it either — root
+`[tool.mypy] files = [...]` is an explicit allowlist of top-level modules/dirs that
+does not include `packages/localizer` or `localizer` anywhere.
+**Consequence for this plan**: because CI's `pytest` step will not catch a regression
+in `packages/localizer/tests`, this plan's own full-suite integration gate (run by the
+orchestrator before each PR group closes, per `AGENTS.md` §"After each subtask is
+APPROVED") must run **both** of the following, not just root `pytest`:
+- `python -m pytest` from the repo root (905+ tests; expected to stay green and
+  unaffected, since no subtask below touches any file under root `tests/`, `core/`,
+  `pages/`, or any other root-level module).
+- `cd packages/localizer && python -m pytest` (or equivalent invocation using the
+  activated venv) — this is the suite that actually exercises every file this plan
+  touches, and it is not enforced by CI, so it must be treated as the authoritative
+  gate for this plan's correctness regardless of what CI reports green.
+`ruff check .` / `ruff format --check .` from the repo root already cover the new/
+changed files under `packages/localizer` and should be run as normal. `mypy` (bare,
+root config) does not need to pass for `packages/localizer` files to satisfy CI, but
+all new code should still carry full type hints matching the existing sibling plugins'
+style, per this project's general Python standards.
 
-- **Widget choice — `st.selectbox`, not `st.radio`.** `tests/test_geo_explorer.py` has several
-  tests with exact-length `mock_radio.side_effect` lists (e.g. `test_table_view_dispatches` expects
-  exactly two `st.radio` calls: "By Artist"/"By City" then "Sort by"). An unconditional third radio
-  call would exhaust those lists and break passing tests. A selectbox mirrors the existing "Artist"
-  selectbox pattern and, gated behind `has_swarm`, never executes in any currently-passing test —
-  every existing test in `test_geo_explorer.py` passes `swarm_df: None`.
-- **Label wording is a judgment call, resolved as**: `"All"`, `"Swarm"`, `"Google Timeline"` — a
-  `SOURCE_LABELS` dict in `core/source_filter.py` maps known `source_id` values to these labels,
-  falling back to `source_id.replace("_", " ").title()` for any future/unknown source so the
-  filter never crashes on new plugins.
-- **Legacy-path parity is in scope.** Both `load_swarm_data()` and `load_google_timeline()` are
-  called as two separate steps in `_load_data_with_progress()` immediately before the existing
-  `pd.concat()` — tagging `source_id` there is a small, additive change requiring no modification
-  to `analysis_utils.py` itself (both loader functions stay untouched and reusable elsewhere).
-- **`apply_swarm_offsets()` is unaffected.** Read in full (`analysis_utils.py` lines 538+): it only
-  reads `swarm_df["timestamp"/"offset"/"city"/"state"/"country"/"lat"/"lng"]` via positional
-  `.values` indexing — it never iterates over "all columns," so adding `source_id` to the frame it
-  receives is safe and was verified by reading the function, not assumed.
-- **Filter placement**: the filter must apply to `swarm_df` before any consumption — map plotting,
-  groupby aggregation, and the shareable HTML export alike — so all downstream views/exports agree
-  on what's currently selected. In both pages, the filter is applied once, immediately after
-  reading `swarm_df` from session state (mirroring how `geo_explorer.py` already filters `music_df`
-  once, right after its own popover, before view dispatch).
+**Scope boundaries (explicit, do not expand)**: in scope is only the plugin modules
+under `packages/localizer/src/localizer/plugins/{letterboxd,flickr,untappd}/`, their
+registration in `packages/localizer/src/localizer/plugins/__init__.py`, and their unit
+tests under `packages/localizer/tests/`. Out of scope: `pages/data_sources.py` (old-
+registry config UI), any new Streamlit display/consumption page for this data, the old
+`plugins/sources/` system, and `core/broker.py`/`core/localizer_frames.py` (both already
+read generically from DuckDB via `source_id`/table — no changes needed for new sources
+to become queryable through the existing Geo Explorer / Check-in Insights pages'
+`source_id` filter, added in the immediately-preceding, now-`COMPLETE` plan).
 
-**Explicit out-of-scope pages (documented so they aren't re-litigated later)**: `pages/data_sources.py`
-(the config/loader page — not a display consumer), `pages/overview.py`, `pages/life_in_chapters.py`,
-`pages/listening_lifestyle.py`, and `pages/insights.py` all read `swarm_df`, but only for derived
-analytics (residency inference, venue-pattern scoring, chapter maps, transit-day computation,
-AI-generated narrative text) rather than the direct map/breakdown display this task targets. The
-task's own framing ("at minimum" Geo Explorer and Check-in Insights) permits but does not require
-expanding scope to these; keeping the diff focused on the two named pages avoids scope creep. A
-reasonable follow-up would extend the same `core/source_filter.py` helper to these pages later.
-
-**Files never touched by this plan**: `analysis_utils.py` (both `load_swarm_data()` and the
-localizer-side `load_google_timeline()` parser stay byte-for-byte unchanged — tagging happens at
-the call site in `sidebar.py`, not inside the loaders), `core/broker.py` (its `get_places_frame()`
-already returns `source_id` — confirmed by reading Subtask 1 of the prior `handoff.md`, now
-`Plan Status: COMPLETE`), `record_flythrough.py`.
-
-**Architecture context**: no prior `/feature-dev` or `/plan-feature` run occurred for this task. The
-user supplied a fully diagnosed problem statement and asked for investigation-driven planning. All
-findings above were verified by reading `core/localizer_frames.py`, `components/sidebar.py`,
-`analysis_utils.py` (`load_swarm_data`, `apply_swarm_offsets`), `pages/geo_explorer.py`,
-`pages/places.py`, `visualize.py`, and the existing test files (`tests/test_localizer_frames.py`,
-`tests/test_sidebar.py`, `tests/test_geo_explorer.py`) in full — not inferred from names alone.
-
-Plan Review: APPROVED — Four-part fix to preserve `source_id` through both the broker and legacy
-data pipelines and expose a shared, pure source filter in Geo Explorer and Check-in Insights,
-implemented via 5 falsifiable, dependency-ordered, file-disjoint subtasks (2 independent
-pipeline-tagging subtasks, a shared pure helper, and two consuming-page wiring subtasks that both
-depend on the helper).
-
-Re-review after revision: Subtask 4's Description, AC #1, and AC #5 were rewritten by the planner to
-fix the two defects flagged in the prior review round, and both fixes were verified directly against
-`pages/geo_explorer.py` rather than trusting the planner's self-report:
-- AC #1 now correctly attributes the check-in groupby variable named `ci` to `_render_2d_map` (lines
-  562-576, confirmed by reading the file) and `checkin_geo` to the separate `_render_3d_globe`
-  function (lines 275-284, confirmed). The "By City" mode only relabels `city` → `"Check-ins"`
-  (line 573) without changing which rows are included, matching AC #1's claim that filtering is
-  identical across "By Artist"/"By City" modes.
-- AC #5 was rewritten from the factually-wrong claim about a swarm-driven "By City" breakdown table
-  into a regression guard: `_build_city_stats()`/`_render_city_breakdown()`/`_render_atlas_city_detail()`
-  (lines 793-1037) must remain untouched and `music_df`-only. Verified by grepping every `swarm_df`
-  reference in the file (lines 262, 280, 517, 563, 1063-1227) — none fall inside that line range —
-  and by reading `_build_city_stats(df)`'s docstring/signature directly, which requires
-  `city`/`country`/`lat`/`lng`/`artist`/`track` (scrobble-only fields absent from `swarm_df`).
-- The filter-placement description (apply `filter_by_source()` right after `music_df`'s existing
-  date/artist filtering, lines 1191-1199, before the Share button section at line 1201) and the
-  `has_swarm`-gating pattern (mirroring the existing `has_music`-gated Artist selectbox, lines
-  1106-1128) were both confirmed against the live code.
-
-Nothing else regressed: DAG edges (4→3, 5→3) remain acyclic and `current: 1,2,3,4,5` is still a
-valid topological order; all 5 subtasks still carry ≥2 falsifiable ACs and Test Guidance; file and
-test-file disjointness across the batch is unchanged (`core/localizer_frames.py`+
-`tests/test_localizer_frames.py`, `components/sidebar.py`+`tests/test_sidebar.py`,
-`core/source_filter.py`+`tests/test_source_filter.py`, `pages/geo_explorer.py`+
-`tests/test_geo_explorer.py`, `pages/places.py`+`tests/test_places.py` all touch disjoint files).
-Subtasks 1, 2, 3, and 5 were untouched by this revision and remain accurate per the prior review
-round. The out-of-scope rationale (excluding overview.py, life_in_chapters.py,
-listening_lifestyle.py, insights.py, data_sources.py) still holds. Plan is ready to proceed.
+**Architecture context**: no prior `/feature-dev` or `/plan-feature` run occurred for
+this task. The user supplied the three GitHub issues directly and pre-diagnosed the
+old-vs-new architecture mismatch; this plan translates each issue's spec into the new
+system's contract, as verified above by reading `base.py`, `plugins/__init__.py`,
+`store/schema.py`, `store/db.py`, `cli.py`, `settings.py`, and the `swarm`/
+`google_timeline`/`letterboxd` loader+test files in full.
 
 ## Current Subtask
-current: 5
+current: 3
 
 ---
 
 ## Subtasks
 
-### Subtask 1 — Preserve `source_id` through the broker column-shape adapter
+### Subtask 1 — Fix Letterboxd field mapping to match issue #10's spec
 
 **Status**: APPROVED
 
-**PR Group**: preserve-source-id
+**PR Group**: letterboxd-field-mapping-fix
 
 **Depends On**: none
 
 **Description**:
-Modify `core/localizer_frames.py::places_to_swarm_frame()` so `source_id` survives the adapter
-from the broker's generic places schema into the legacy `swarm_df` shape, instead of being dropped.
-Add `source_id` to the `SWARM_COLUMNS` module-level constant (at the end, mirroring
-`LASTFM_COLUMNS`'s existing `source_id`-last convention) and pass it through unchanged in the
-non-empty path. Update the function's docstring, which currently states `source_id` is dropped, to
-reflect the new behavior. The existing test suite (`tests/test_localizer_frames.py`) has assertions
-that explicitly check `source_id` is **absent** — these must be inverted to check it is present and
-correct, not merely relaxed, since a silently-wrong inversion would reintroduce exactly the "silent
-breakage" risk this module's own docstring warns about.
+`packages/localizer/src/localizer/plugins/letterboxd/loader.py`'s `_parse_csv()`
+currently yields `sublabel` = the CSV `Year` column and `category` = the CSV `Rating`
+column (as a raw string), and does not surface `rewatch` as a typed value anywhere.
+Issue #10 requires: `label` = `sublabel` = film title (CSV `Name` column), `category`
+= release year (CSV `Year` column, as a string), `rating` preserved as a **float**
+(`None`-equivalent when unrated) inside `raw_json`, and `rewatch` preserved as a
+**Python bool** inside `raw_json` (`True` when the CSV `Rewatch` column is `"Yes"`,
+`False` when blank/absent — this is the real-world Letterboxd export convention: the
+column is either the literal string `Yes` or empty).
+
+Rewrite `_parse_csv()`'s per-row dict construction so:
+- `label` and `sublabel` are both set to the `Name` column value.
+- `category` is set to the `Year` column value (unchanged from its current source
+  column, just no longer sourced from `Rating`).
+- `raw_json` is built as the full raw CSV row dict (`dict(row)`, preserving every
+  original column including `Tags` and `Letterboxd URI` verbatim, matching the current
+  behavior for those fields) **plus** two added/overridden keys: `"rating"` (a Python
+  `float` parsed from the `Rating` column, or `None` when the column is blank/
+  unparseable — never a raw string) and `"rewatch"` (a Python `bool`, `True` only when
+  `Rewatch` case-sensitively equals `"Yes"` after stripping whitespace, `False`
+  otherwise), then `json.dumps()`'d as before.
+
+Do not change `FETCH_MODE`, `OUTPUT_TABLES`, `PLUGIN_ID`, `DISPLAY_NAME`,
+`get_config_fields()`, `get_manual_download_instructions()`, the `FileNotFoundError`-
+on-missing-configured-CSV behavior, or the `fetched_at`/timestamp logic — only the
+`label`/`sublabel`/`category`/`raw_json` construction inside `_parse_csv()` changes.
+
+This is the riskiest subtask in the plan: it modifies an already-green, already-shipped
+plugin rather than adding new code, so two of the *existing* tests in
+`packages/localizer/tests/test_letterboxd_plugin.py`
+(`test_letterboxd_sublabel_is_year_string` and `test_letterboxd_category_is_rating`)
+currently assert the **old, issue-incompatible** mapping and must be rewritten (not
+merely relaxed or deleted) to assert the new, correct mapping — a careless edit here
+could silently reintroduce the exact defect this subtask exists to fix, in a
+differently-shaped way that still passes a weakened test.
 
 **Acceptance Criteria**:
-- [ ] `places_to_swarm_frame()` on a 3-row input with mixed `source_id` values (`"swarm"`,
-  `"google_timeline"`, `"swarm"`) produces an output where each row's `source_id` matches its input
-  row's `source_id` **after** the timestamp-based sort reorders rows (i.e. verified row-for-row
-  post-sort, not just "the values exist somewhere").
-- [ ] `list(places_to_swarm_frame(df).columns) == SWARM_COLUMNS` where `SWARM_COLUMNS` now ends
-  with `"source_id"` — both for a non-empty and an empty input.
-- [ ] `place_name` and `place_type` remain absent from the output (unchanged from today) — only
-  `source_id`'s drop behavior changes, nothing else.
-- [ ] `events_to_lastfm_frame()` is untouched and its existing tests pass with zero modification
-  (it already preserves `source_id`; this subtask must not touch it).
-- [ ] `core/localizer_frames.py` still contains no `streamlit`, `duckdb`, or `localizer.store.db`
-  substrings (the existing `test_localizer_frames_module_has_no_forbidden_imports` source-inspection
-  test must keep passing unmodified).
+- [ ] `fetch_records()` on the existing two-row diary CSV fixture
+  (`LETTERBOXD_CSV_TWO_ROWS`: "The Godfather"/1972/4.5 and "Pulp Fiction"/1994/5.0)
+  yields records where, for each row, `record["label"] == record["sublabel"] ==` the
+  film's `Name` column value exactly (e.g. both `"The Godfather"`), and
+  `record["category"] ==` the film's `Year` column value as a string (e.g. `"1972"`)
+  — verified per-row by name, not just "two distinct labels exist somewhere."
+- [ ] `json.loads(record["raw_json"])["rating"]` is a Python `float` equal to `4.5` for
+  the Godfather row and `5.0` for the Pulp Fiction row (type-checked with
+  `isinstance(..., float)`, not just value equality, since a passing string `"4.5"`
+  must not satisfy this).
+- [ ] For a CSV row with a blank `Rating` field (reuse or extend the existing
+  `LETTERBOXD_CSV_ONE_ROW_NO_RATING` fixture), `json.loads(record["raw_json"])["rating"]
+  is None` — parsing a blank rating must not raise `ValueError`.
+- [ ] For a CSV row with `Rewatch == "Yes"`, `json.loads(record["raw_json"])["rewatch"]
+  is True`; for a row with a blank `Rewatch` field, `json.loads(record["raw_json"])["rewatch"] is False`
+  — both checked with `is`, not truthiness, to catch an accidental string
+  (`"True"`/`"False"`) slipping through instead of a real bool.
+- [ ] `test_letterboxd_sublabel_is_year_string` and `test_letterboxd_category_is_rating`
+  no longer exist under those names asserting the old mapping — they are rewritten (or
+  replaced by equivalently-named new tests) to assert the mapping above; grepping the
+  final test file for the literal old assertions (`sublabels = {r["sublabel"] ...}`
+  checked against year strings, or `category == "4.5"`) finds nothing.
+- [ ] Every other existing test in `test_letterboxd_plugin.py` not touched by this
+  subtask (registration, `FETCH_MODE`, `OUTPUT_TABLES`, missing-CSV
+  `FileNotFoundError`, `fetched_at` recency, `get_manual_download_instructions`
+  wording, `get_config_fields` shape, `source_id == "letterboxd"`) continues to pass
+  unmodified.
 
 **Files to Touch**:
-- `core/localizer_frames.py` (edit: add `"source_id"` to `SWARM_COLUMNS`; stop excluding it in
-  `places_to_swarm_frame()`'s result construction; update docstring)
-- `tests/test_localizer_frames.py` (edit: update the module-level `SWARM_COLUMNS` test fixture list
-  to include `"source_id"`; invert `test_places_to_swarm_frame_renames_and_fills_defaults`'s
-  `assert "source_id" not in result.columns` into a row-level correctness assertion; update
-  `test_places_to_swarm_frame_empty_input_exact_columns`'s expected column list; update
-  `test_places_to_swarm_frame_sorted_ascending_by_timestamp`'s and `..._single_row`'s assertions to
-  also check `source_id` survives the sort correctly)
+- `packages/localizer/src/localizer/plugins/letterboxd/loader.py` (edit: `_parse_csv()`
+  only)
+- `packages/localizer/tests/test_letterboxd_plugin.py` (edit: rewrite the two
+  mismatched tests; add rating-float, unrated-rating-None, rewatch-True, and
+  rewatch-False tests; leave all other tests untouched)
 
 **Test Guidance**:
-- This is the riskiest subtask in the plan (per the module's own docstring: "a wrong column rename
-  or a silently-swapped assignment would not raise any exception anywhere downstream"). Assert on
-  actual `source_id` values at specific row indices after sorting, not on set membership alone.
-- Cover: 3-row mixed-source input (existing `_places_fixture_out_of_order()` fixture already has
-  mixed `source_id` values — reuse it rather than building a new fixture), single-row input,
-  empty input (exact column list, in order, including `source_id` at the end), and a fixture where
-  every row shares the same `source_id` (proving the passthrough doesn't accidentally collapse or
-  dedupe by source).
-- Explicitly re-assert that `place_name`/`place_type` are still dropped — this subtask changes only
-  `source_id`'s fate, and a test should catch a coder accidentally also passing through `place_name`.
-- Do not weaken the existing forbidden-imports source-inspection test; it must keep passing as-is.
+- Cover: rated film (float rating parses correctly for both `4.5` and `5.0`, proving
+  the parse isn't hardcoded to one value), unrated film (blank `Rating` →
+  `None`, not an exception, not `0.0`, not `NaN` — `None` specifically, since it must
+  round-trip through `json.dumps`/`json.loads` cleanly and `float("nan")` does not),
+  `Rewatch == "Yes"` → `True`, blank `Rewatch` → `False`.
+- Assert `label == sublabel` on the *same* row (not just that both fields individually
+  contain plausible values) to catch a coder who fixes one field but not the other.
+- After editing, run the *entire* `test_letterboxd_plugin.py` file (not just the new/
+  changed tests) to prove no other test silently broke — this file's own docstring
+  states it is meant to stay independently green.
+- Verify `raw_json` still parses via `json.loads` without error on every row (a bug in
+  the added float/bool logic must not produce a non-JSON-serializable value, e.g. a
+  raw `NaN` float slipping into the dict before `json.dumps`).
 
 **Test Files**:
-`tests/test_localizer_frames.py` — RED-confirmed (`python -m pytest tests/test_localizer_frames.py -v`: 5 failed / 8 passed; failures are `KeyError: 'source_id'`/column-set mismatches, the correct pre-implementation failure mode).
-- `test_places_to_swarm_frame_renames_and_fills_defaults` (inverted from "absent" to row-level post-sort correctness)
-- `test_places_to_swarm_frame_sorted_ascending_by_timestamp` (added source_id-survives-sort assertions)
-- `test_places_to_swarm_frame_single_row` (added source_id assertion)
-- `test_places_to_swarm_frame_empty_input_exact_columns` (exercises updated `SWARM_COLUMNS` fixture)
-- `test_places_to_swarm_frame_same_source_id_not_collapsed` (new — proves passthrough doesn't dedupe by source)
+`packages/localizer/tests/test_letterboxd_plugin.py` (edited — 2 tests rewritten, 7 new
+tests added, 14 pre-existing tests left untouched; 23 tests total in file). Confirmed RED:
+`cd packages/localizer && python -m pytest tests/test_letterboxd_plugin.py -v --no-cov` →
+**9 failed, 14 passed**.
 
-**Revision (NEEDS_REVISION cycle, owner finding on AC #2)**: tightened
-`test_places_to_swarm_frame_renames_and_fills_defaults` (line 178) from
-`assert set(result.columns) == set(SWARM_COLUMNS)` to
-`assert list(result.columns) == SWARM_COLUMNS`, matching the exact-order check
-AC #2 requires for the non-empty-input path (the empty-input counterpart,
-`test_places_to_swarm_frame_empty_input_exact_columns`, already asserted exact
-order and was untouched). No implementation edit was made — the owner's finding
-noted the current implementation's unconditional `result[SWARM_COLUMNS]`
-re-index already satisfies exact order; this was a test-strength gap only.
-Confirmed the tightened assertion passes against the current (unchanged)
-implementation: `python -m pytest tests/test_localizer_frames.py -v --no-cov`
-— 13 passed, 0 failed (including
-`test_places_to_swarm_frame_renames_and_fills_defaults` individually, 1 passed).
+Rewritten (replace the old issue-incompatible tests named in the AC):
+- `test_letterboxd_label_and_sublabel_both_equal_film_title` (replaces
+  `test_letterboxd_sublabel_is_year_string`)
+- `test_letterboxd_category_is_release_year` (replaces `test_letterboxd_category_is_rating`)
+
+New:
+- `test_letterboxd_raw_json_rating_is_typed_float`
+- `test_letterboxd_raw_json_rating_is_none_when_blank`
+- `test_letterboxd_raw_json_rewatch_is_true_for_yes`
+- `test_letterboxd_raw_json_rewatch_is_false_for_blank`
+- `test_letterboxd_raw_json_rewatch_strips_whitespace`
+- `test_letterboxd_raw_json_rewatch_is_case_sensitive`
+- `test_letterboxd_raw_json_round_trips_for_every_row`
+- `test_letterboxd_raw_json_preserves_original_columns`
+
+New fixtures: `LETTERBOXD_CSV_REWATCH_MIXED`, `LETTERBOXD_CSV_REWATCH_EDGE_CASES`. The
+tester verified via Grep (not a self-referential source-grep test) that the literal old
+assertions no longer exist in the file, satisfying AC #4 directly. All 14 unaffected
+pre-existing tests (registration, `FETCH_MODE`, `OUTPUT_TABLES`, missing-CSV, `fetched_at`,
+instructions wording, config fields, `source_id`) still pass unmodified — no collateral
+damage. `loader.py` was not touched by the tester.
 
 **Implementation Notes**:
-Added `"source_id"` as the last entry in the module-level `SWARM_COLUMNS` constant and
-added `"source_id": places_df["source_id"]` as the last key in the dict passed to
-`pd.DataFrame(...)` inside `places_to_swarm_frame()`, so it passes through unchanged
-(no rename, no default-fill) exactly like the pre-existing `lat`/`lng` passthrough
-columns. Updated the function's docstring to state `source_id` is preserved instead of
-dropped, and to list it as the final column in the returned shape. `place_name` and
-`place_type` remain dropped — only `source_id`'s fate changed, matching AC #3.
+Rewrote only the per-row dict construction inside `_parse_csv()` in
+`packages/localizer/src/localizer/plugins/letterboxd/loader.py`:
+- `name = row.get("Name", "")` is now used for both `label` and `sublabel`.
+- `category` is now `year` (the existing `Year`-derived string, previously used
+  for `sublabel`) instead of the raw `Rating` string.
+- `rating` is parsed from the stripped `Rating` column via `float(rating_str)`
+  inside a `try/except ValueError`, yielding `None` when blank or unparseable
+  (never a raw string, never `NaN`).
+- `rewatch` is computed as `(row.get("Rewatch", "") or "").strip() == "Yes"` —
+  a strict, case-sensitive, whitespace-tolerant Python `bool`.
+- `raw_json` is built from `dict(row)` (preserving every original CSV column,
+  e.g. `Tags`, `Letterboxd URI`, verbatim) with `"rating"` and `"rewatch"`
+  added/overridden on top, then `json.dumps()`'d exactly as before.
+- No other method, class attribute, `FETCH_MODE`/`OUTPUT_TABLES`/`PLUGIN_ID`/
+  `DISPLAY_NAME`, `get_config_fields()`, `get_manual_download_instructions()`,
+  `FileNotFoundError`-on-missing-CSV behavior, or `fetched_at`/timestamp logic
+  was touched, per the subtask's explicit restriction.
 
-The test file (`tests/test_localizer_frames.py`) was already written by the tester
-agent in the RED phase with `SWARM_COLUMNS` (test-local copy) ending in `"source_id"`
-and with inverted/augmented assertions checking `source_id` presence and row-for-row
-correctness post-sort; no test-file edits were needed or made in this GREEN phase.
+Deviation/environment note (not a code deviation from the plan): the shared
+project `venv` at `C:\Users\johns\Code\autobiographer\venv` had a stale
+editable install of the `localizer` package pointing at a leftover git
+worktree (`.claude\worktrees\agent-adb530a22a6adcac5`) from an unrelated prior
+session, so `import localizer` initially resolved to that worktree's copy of
+`loader.py` instead of this repo's `packages/localizer/src/...`, making the
+first test run appear to still show the old (unfixed) behavior even though
+the edit was correctly applied. Fixed by re-running
+`pip install -e packages/localizer/ --no-deps` from the main repo root inside
+the activated venv, which repointed the editable install back to
+`C:\Users\johns\Code\autobiographer\packages\localizer`. No test or source
+file content was affected by this — it was purely a local environment/install
+pointer issue, not a plan or code change. Did not touch or remove the stale
+worktree itself, since that is out of this subtask's scope.
 
-Ran `python -m pytest tests/test_localizer_frames.py -v`: 13 passed, 0 failed.
-Ran `ruff check core/localizer_frames.py`: no issues found.
-Ran `ruff format --check core/localizer_frames.py`: already formatted, no changes needed.
+The tester's test file (`packages/localizer/tests/test_letterboxd_plugin.py`)
+was already correctly written per the plan and required no further edits.
 
-No deviations from the plan; no files touched beyond `core/localizer_frames.py` (the
-`Files to Touch` list's test-file edits were already done by the tester, so only the
-source file required a coder edit).
+Test run: `cd packages/localizer && python -m pytest tests/test_letterboxd_plugin.py -v --no-cov`
+→ **23 passed**.
+Lint: `ruff check --fix packages/localizer/src/localizer/plugins/letterboxd/loader.py`
+→ "No issues found"; `ruff format packages/localizer/src/localizer/plugins/letterboxd/loader.py`
+→ "All files formatted correctly" (no changes needed).
 
-**Post-revision confirmation (second GREEN pass)**: Re-verified the owner's NEEDS_REVISION
-finding. The tester already tightened
-`test_places_to_swarm_frame_renames_and_fills_defaults` (line 178,
-`tests/test_localizer_frames.py`) from `assert set(result.columns) ==
-set(SWARM_COLUMNS)` to `assert list(result.columns) == SWARM_COLUMNS`, closing the
-exact-order gap the owner flagged for the non-empty-input path. Confirmed via
-`Grep` that line 178 (and the empty-input counterpart at line 286) both now use
-the exact-list-order assertion. Ran `python -m pytest tests/test_localizer_frames.py
--v --no-cov`: 13 passed, 0 failed, exit code 0 — the tightened assertion passes
-against the current, unmodified `core/localizer_frames.py` implementation (its
-unconditional `result[SWARM_COLUMNS]` re-index at the end of
-`places_to_swarm_frame()` already enforces column order deterministically). No
-implementation change was required or made in this pass; only the test file was
-touched, and it was touched by the tester agent, not this coder pass. Ran
-`python -m ruff check core/localizer_frames.py tests/test_localizer_frames.py` —
-all checks passed. Ran `python -m ruff format --check core/localizer_frames.py
-tests/test_localizer_frames.py` — 2 files already formatted, no new lint/format
-violations introduced.
+**Formatting-only follow-up (post code-review NEEDS_REVISION)**: the reviewer
+found that the tester's `test_letterboxd_plugin.py` had one assert line
+(the Pulp Fiction `category == "1994"` check, ~line 192) wrapped across 3
+lines instead of ruff's preferred single-line form; `ruff format --check`
+had only been run against `loader.py`, not the test file, so this was
+missed. Fixed by running
+`./venv/Scripts/python.exe -m ruff format packages/localizer/tests/test_letterboxd_plugin.py`
+(1 file reformatted), then re-verifying
+`./venv/Scripts/python.exe -m ruff format --check packages/localizer/tests/test_letterboxd_plugin.py`
+→ "1 file already formatted". No test assertions or logic changed — purely
+whitespace/line-wrapping. Re-ran
+`cd packages/localizer && ../../venv/Scripts/python.exe -m pytest tests/test_letterboxd_plugin.py -v --no-cov`
+→ **23 passed**. Re-ran
+`./venv/Scripts/python.exe -m ruff check packages/localizer/tests/test_letterboxd_plugin.py packages/localizer/src/localizer/plugins/letterboxd/loader.py`
+→ "All checks passed!". Did not touch the `Code Review:` line above, `Current
+Subtask`, or any other subtask.
 
 **Review Notes**:
-Code Review: APPROVED — checks clean
+Code Review: NEEDS_REVISION — one mechanical formatting failure found; everything
+else (tests, lint, diff scope, environment) is clean:
 
-Automated checks (all run scoped to `tests/test_localizer_frames.py`, the current
-subtask's only Test Files entry; no other subtask is yet GREEN/APPROVED):
-- `python -m ruff check core/localizer_frames.py tests/test_localizer_frames.py` — All checks passed!
-- `python -m ruff format --check core/localizer_frames.py tests/test_localizer_frames.py` — 2 files already formatted
-- `python -m mypy core/localizer_frames.py` — no issues found (this file is in `[tool.mypy] files`)
-- `python -m pytest tests/test_localizer_frames.py -v` — 13 passed, 0 failed
+- `ruff format --check packages/localizer/tests/test_letterboxd_plugin.py` fails:
+  "Would reformat: packages\localizer\tests\test_letterboxd_plugin.py" (via the
+  project venv's ruff — `C:\Users\johns\Code\autobiographer\venv\Scripts\python.exe
+  -m ruff format --check ...`). The diff (`ruff format --diff`) shows one long
+  assert line (`pulp_fiction["category"] == "1994"`) is wrapped across 3 lines but
+  should be a single line per this project's ruff formatting rules. Fix: run
+  `ruff format packages/localizer/tests/test_letterboxd_plugin.py` (or the repo-
+  root `ruff format .` per CLAUDE.md's Local Quality Gate Step 1) and re-verify
+  `ruff format --check` passes. `ruff check` (lint) itself is clean — this is
+  formatting only. Per CLAUDE.md's Local Quality Gate, `ruff format --check .`
+  must pass with zero errors before any commit; this was missed because the
+  coder's Implementation Notes only ran `ruff format` against `loader.py`, not
+  against the test file the tester wrote.
 
-Diff review (`git diff HEAD -- core/localizer_frames.py`, +9/-5, only touches
-`SWARM_COLUMNS`, the docstring, and the one new dict key): matches the plan exactly —
-`"source_id"` appended to `SWARM_COLUMNS`, `"source_id": places_df["source_id"]` added
-as the final key in the `pd.DataFrame(...)` construction (straight passthrough, no
-rename/default-fill, consistent with the existing `lat`/`lng` passthrough style), and
-the docstring updated to describe preservation instead of dropping. No dead code, no
-commented-out blocks, no secrets/tokens, no N+1 or hot-path synchronous-call concerns
-(pure in-memory DataFrame construction). `events_to_lastfm_frame()` is untouched, and
-`place_name`/`place_type` remain excluded from the result dict — matching AC #3 and
-AC #4.
+Everything else verified clean:
+- Scoped tests: `cd packages/localizer && <venv>\python.exe -m pytest
+  tests/test_letterboxd_plugin.py -v --no-cov` → **23 passed** (confirmed using the
+  project's actual `venv/Scripts/python.exe` — an initial run through a non-venv
+  Python picked up a stale editable `localizer` install pointing at the leftover
+  `.claude/worktrees/agent-adb530a22a6adcac5` copy and falsely showed 9 failures;
+  re-running through the correct venv confirms the coder's reported 23-passed
+  result is accurate).
+- `ruff check` on both touched files: "All checks passed!"
+- Diff review of `loader.py`: matches the subtask spec exactly — `label`/`sublabel`
+  both set to `name`, `category` set to `year`, `rating` parsed as typed
+  `float`/`None` inside a `try/except ValueError`, `rewatch` computed as a strict
+  `bool`, `raw_json` built from `dict(row)` plus the two overridden keys. No dead
+  code, no secrets/credentials, no N+1/blocking calls, no changes outside
+  `_parse_csv()`'s per-row construction — `FETCH_MODE`, `OUTPUT_TABLES`,
+  `PLUGIN_ID`, `get_config_fields()`, `get_manual_download_instructions()`, and the
+  `FileNotFoundError` behavior are all untouched, per the subtask's restriction.
+- AC #5 verified directly via grep: no occurrence of the old test names
+  (`test_letterboxd_sublabel_is_year_string`, `test_letterboxd_category_is_rating`)
+  or the old assertion patterns remains in the test file.
+- `git status`/`git diff --stat` confirm only `loader.py`, `test_letterboxd_plugin.py`,
+  and `handoff.md` were modified in-scope; the two untracked
+  `test_flickr_plugin.py`/`test_untappd_plugin.py` files belong to Subtasks 2/3's
+  already-completed test-ahead batch, not this subtask, and were not touched here.
+- Environment note verified: `pip show localizer` inside the actual project venv
+  (`C:\Users\johns\Code\autobiographer\venv\Scripts\pip.exe`) correctly shows
+  `Editable project location: C:\Users\johns\Code\autobiographer\packages\localizer`
+  — i.e. it already points at the right path, not the stale worktree. The venv is
+  in a consistent state; no worktree-related files were committed or modified in
+  the repo diff. (A different, non-venv global Python on this machine happens to
+  have its own stale editable install pointing at the leftover worktree — that is
+  a pre-existing, unrelated environment artifact outside the project venv and out
+  of this subtask's scope; it does not affect the project venv checked above.)
 
-All 5 Acceptance Criteria verified:
-- AC #1 (row-for-row post-sort `source_id` correctness) — covered by
-  `test_places_to_swarm_frame_renames_and_fills_defaults` and
-  `test_places_to_swarm_frame_sorted_ascending_by_timestamp`, both passing.
-- AC #2 (`list(...columns) == SWARM_COLUMNS`, source_id last, non-empty + empty) — the
-  empty-input case is checked with an exact `list(...)` equality
-  (`test_places_to_swarm_frame_empty_input_exact_columns`); the non-empty case
-  (`test_places_to_swarm_frame_renames_and_fills_defaults`) only asserts `set(...) ==
-  set(SWARM_COLUMNS)`, not list order. This is a minor test-coverage gap against the AC's
-  literal wording, but not a functional defect: the implementation's final line always
-  does `result[SWARM_COLUMNS]` bracket-indexing, which deterministically enforces column
-  order on every call regardless of input, so the order guarantee holds even though no
-  non-empty test asserts it directly. Not blocking — noting for the owner's awareness.
-- AC #3 (`place_name`/`place_type` still absent) — explicit assertions present and passing.
-- AC #4 (`events_to_lastfm_frame` untouched) — confirmed via `git diff` (zero lines
-  changed in that function) and its 5 existing tests passing unmodified.
-- AC #5 (forbidden-imports source-inspection test) — `test_localizer_frames_module_has_no_forbidden_imports`
-  passing.
+Status flipped GREEN → RED for the coder to fix the formatting-only issue above and
+re-run `ruff format --check` before flipping back to GREEN.
 
-No issues found that require reversal to RED.
+Code Review: APPROVED — re-verified clean. `ruff format --check` on both touched
+files (`packages/localizer/tests/test_letterboxd_plugin.py`,
+`packages/localizer/src/localizer/plugins/letterboxd/loader.py`) via the project's
+own `venv/Scripts/python.exe -m ruff format --check ...` → "2 files already
+formatted" (the prior wrapped-assert nit is fixed). `ruff check` on both files →
+"All checks passed!". Scoped test run via
+`cd packages/localizer && ../../venv/Scripts/python.exe -m pytest
+tests/test_letterboxd_plugin.py -v --no-cov` → **23 passed**, no regressions.
+`git status`/`git diff --stat` confirm no scope creep: only `handoff.md`,
+`packages/localizer/src/localizer/plugins/letterboxd/loader.py`, and
+`packages/localizer/tests/test_letterboxd_plugin.py` show as modified; the
+untracked `test_flickr_plugin.py`/`test_untappd_plugin.py` belong to Subtasks 2/3's
+already-completed test-ahead batch and are untouched by this round. No dead code,
+secrets, or scope-creep issues found. Ready for the owner agent.
 
-Owner Review: NEEDS_REVISION — implementation is correct and the code-mode review above
-stands; this is a test-coverage-only gap the code reviewer flagged but left as
-non-blocking. On independent review I'm sending it back because it's a real (if narrow)
-hole, not merely cosmetic:
-
-- **Finding**: `test_places_to_swarm_frame_renames_and_fills_defaults`
-  (`tests/test_localizer_frames.py` line 178) asserts
-  `set(result.columns) == set(SWARM_COLUMNS)`, which does not verify AC #2's literal
-  requirement — `list(places_to_swarm_frame(df).columns) == SWARM_COLUMNS` — for the
-  **non-empty**-input path. `test_places_to_swarm_frame_empty_input_exact_columns`
-  already does the exact-list check, but only for the empty-input branch
-  (`pd.DataFrame(columns=SWARM_COLUMNS)`, a structurally separate code path from the
-  non-empty branch's dict-construction-then-`[SWARM_COLUMNS]`-reindex). A future edit to
-  the non-empty branch that reorders the dict literal and drops the trailing
-  `[SWARM_COLUMNS]` re-index would silently break column order with zero test failure —
-  exactly the "silent breakage" risk class this subtask's own docstring and Test
-  Guidance call out ("assert ... not on set membership alone").
-- **What correct looks like**: change line 178 to
-  `assert list(result.columns) == SWARM_COLUMNS` (or add it alongside the existing set
-  check) in `test_places_to_swarm_frame_renames_and_fills_defaults`. This is a test-only
-  change — no implementation edit is required, since `core/localizer_frames.py` already
-  satisfies it via the unconditional `[SWARM_COLUMNS]` re-index at the end of
-  `places_to_swarm_frame()`.
-- Everything else in this subtask (row-for-row `source_id` correctness post-sort,
-  `place_name`/`place_type` still absent, `events_to_lastfm_frame` untouched, forbidden-imports
-  test intact, ruff/format/pytest all clean) is verified and does not need to change.
-
-Code Review: APPROVED (re-review) — Verified directly against the file on disk, not just
-the notes above: `tests/test_localizer_frames.py` line 178 now reads
-`assert list(result.columns) == SWARM_COLUMNS`, exactly closing the exact-order gap
-raised in the finding above. No implementation edit was made or needed — the
-unconditional `result[...][SWARM_COLUMNS]` re-index at the end of
-`places_to_swarm_frame()` (`core/localizer_frames.py` line 96) already guarantees exact
-column order on every call. Re-ran the scoped suite directly:
-`python -m pytest tests/test_localizer_frames.py -v --no-cov` — 13 passed, 0 failed.
-`python -m ruff check core/localizer_frames.py tests/test_localizer_frames.py` — all
-checks passed. `python -m ruff format --check ...` — 2 files already formatted.
-`python -m mypy core/localizer_frames.py` — no issues found. Confirmed all Test Guidance
-items are present: mixed-source 3-row fixture, single-row, empty-input exact columns,
-`test_places_to_swarm_frame_same_source_id_not_collapsed` (line 309, proves passthrough
-doesn't dedupe by source), and `test_localizer_frames_module_has_no_forbidden_imports`
-(line 324) all present and passing. All 5 Acceptance Criteria are satisfied with no
-remaining gaps. Approved — advancing to Subtask 2.
+**Owner Review: APPROVED** — independently re-verified, not just re-reading prior
+notes: `_parse_csv()`'s rating parse (`float(rating_str) if rating_str else None`
+inside `try/except ValueError`) and rewatch parse (`.strip() == "Yes"`, strict
+case-sensitive) traced line-by-line against every AC — all correct, including the
+`"0"`-rating-is-not-blank edge case and the coexistence of the raw `"Rating"`/
+`"Rewatch"` CSV columns alongside the new typed `rating`/`rewatch` keys in
+`raw_json`. Re-ran independently: `pytest tests/test_letterboxd_plugin.py -v
+--no-cov` → 23 passed; `ruff check` on both touched files → All checks passed;
+`ruff format --check` on both → already formatted; `mypy` on `loader.py` → no
+issues. Grep confirms no remnant of the old sublabel=year/category=rating
+assertions. `git status`/diff confirms scope is exactly `loader.py` + the test
+file (plus `handoff.md`) — no scope creep; untracked Flickr/Untappd test files
+belong to Subtasks 2/3 and are untouched. Every Test Guidance item has a
+corresponding test, several exceeded (whitespace-strip, case-sensitivity).
+Diff is minimal, simple, and scoped strictly to the per-row dict construction
+as required. Subtask 1 is complete; `current` advanced to Subtask 2 (Flickr,
+already `RED` from the test-ahead batch — ready for the coder).
 
 ---
 
-### Subtask 2 — Preserve `source_id` through the legacy flat-file pipeline
+### Subtask 2 — Add `FlickrPlugin` (issue #19)
 
 **Status**: APPROVED
 
-**PR Group**: preserve-source-id
+**PR Group**: flickr-plugin
 
 **Depends On**: none
 
 **Description**:
-Modify `components/sidebar.py::_load_data_with_progress()` so the legacy (non-broker) loading path
-also tags each row with its origin. Immediately after `load_swarm_data(swarm_dir)` returns a
-non-empty frame, assign `swarm_df["source_id"] = "swarm"`. Immediately after
-`load_google_timeline(timeline_path)` returns a non-empty frame, assign
-`timeline_df["source_id"] = "google_timeline"`, before the existing `pd.concat()` call. Do not
-modify `analysis_utils.py`'s `load_swarm_data()` or the localizer-side `load_google_timeline()`
-parser — both stay exactly as they are; tagging happens only at this call site. When neither
-source is configured, `swarm_df` remains the existing empty `pd.DataFrame()` with no `source_id`
-column at all — this is an acceptable, already-handled edge case that Subtask 3's filter helper
-must tolerate gracefully (not this subtask's concern to guard against).
+Add a new `FlickrPlugin` under `packages/localizer/src/localizer/plugins/flickr/`,
+`OutputTable.PLACES`, `FetchMode.MANUAL`, mirroring `swarm/loader.py`'s structure (the
+closest existing sibling: directory-of-JSON-files export, graceful-empty-on-missing-
+directory, per-file try/except so one malformed file doesn't abort the whole
+directory).
+
+- **Constructor**: `__init__(self, export_dir: str | None = None, geotagged_only: bool | None = None)`.
+  When `export_dir` is `None`, fall back to
+  `LocalizerSettings().get_setting("export_dir")` (mirrors Swarm's `swarm_dir`
+  resolution exactly, including the `try/except ImportError: pass` guard). When
+  `geotagged_only` is `None`, fall back to
+  `LocalizerSettings().get_setting("geotagged_only", True)`, coercing the result to a
+  real `bool` (the settings layer round-trips values as strings, so accept an actual
+  `bool`, or a string, treating `"false"`/`"0"`/`""`/`"no"` — case-insensitively — as
+  `False` and anything else as `True`; this coercion is a small private helper, not a
+  new public API).
+- **`get_config_fields()`**: one `dir_path` field (`key="export_dir"`) and one boolean
+  toggle field (`key="geotagged_only"`, `type="bool"`, default `True`).
+- **`get_manual_download_instructions()`**: multi-line string mentioning
+  `flickr.com` and the export/ZIP flow (mirrors the existing plugins' instruction-
+  string convention and testability pattern — lowercased instruction text must contain
+  `"flickr.com"`).
+- **`fetch_records()`**: if `export_dir` is falsy, or the path doesn't exist, or isn't
+  a directory, `return` immediately (yield nothing) — matches Swarm's exact guard.
+  Otherwise glob `sorted(export_path.glob("photo_*.json"))`; for each file, parse JSON
+  inside a `try/except (json.JSONDecodeError, OSError): continue` (one bad file must
+  not abort the rest, matching Swarm). For each parsed `data` dict:
+  - Parse `date_taken` to a Unix timestamp using the same forgiving approach already
+    used elsewhere in this codebase (`datetime.fromisoformat` after replacing a space
+    separator with `"T"`); on any parse failure, fall back to this batch's
+    `fetched_at` (matches Letterboxd's existing fallback pattern) rather than raising.
+  - Determine geotagging: `geo = data.get("geo")`; treat the photo as geotagged only
+    when `geo` is a non-empty dict whose `"latitude"`/`"longitude"` values both parse
+    to `float` without error.
+  - If not geotagged and `geotagged_only` is `True` (the default): skip this photo
+    entirely (`continue`).
+  - If not geotagged and `geotagged_only` is `False`: yield the record with
+    `lat = float("nan")`, `lng = float("nan")` (legal here because `places.lat`/`lng`
+    are real `DOUBLE NOT NULL` columns, and `NaN` is a distinct, valid double — not
+    SQL `NULL`).
+  - If geotagged: yield with the parsed float `lat`/`lng` regardless of
+    `geotagged_only`.
+  - `place_name = data.get("name") or ""` (empty string, not a crash, when the title
+    is missing — covered by the issue's "missing title" edge case).
+  - `place_type = "photo"` (constant, per the issue spec).
+  - `raw_json = data` (the entire parsed photo dict, passed through as-is — this
+    trivially satisfies "preserve tags/album/description/url" since nothing needs to
+    be hand-picked; `store.upsert_places()` already `json.dumps()`s whatever dict is
+    given).
+  - Honor `since`: skip photos whose parsed timestamp is `<= since`.
+- Register in `packages/localizer/src/localizer/plugins/__init__.py`: add
+  `from localizer.plugins.flickr.loader import FlickrPlugin` to the import block inside
+  `load_builtin_plugins()` and add `REGISTRY[FlickrPlugin.PLUGIN_ID] = FlickrPlugin` —
+  purely additive; do not reorder or remove any existing import/registration line
+  (Subtask 3 also edits this same function for Untappd, so both edits must be
+  independently additive and non-conflicting).
 
 **Acceptance Criteria**:
-- [ ] With both `swarm_dir` and `timeline_path` configured, the resulting `swarm_df` in
-  `st.session_state["swarm_df"]` has every Swarm-derived row's `source_id == "swarm"` and every
-  Timeline-derived row's `source_id == "google_timeline"`, verified by cross-referencing specific
-  `timestamp` values from each mocked loader's fixture (not just checking two distinct values
-  exist).
-- [ ] With only `swarm_dir` configured (no `timeline_path`), every resulting row has
-  `source_id == "swarm"`.
-- [ ] The existing `TestLoadDataCombination` tests (`test_timeline_rows_appended_to_swarm`,
-  `test_combined_frame_sorted_by_timestamp`, `test_no_timeline_leaves_swarm_only`) continue to pass
-  with their row-count and sort-order assertions unchanged — only augmented with `source_id`
-  assertions, not altered in their existing checks.
-- [ ] `load_swarm_data` and `load_google_timeline` are called with the exact same arguments as
-  today (no signature change) — confirmed by the existing mocks (`patch.object(sidebar,
-  "load_swarm_data", ...)`) requiring zero changes to their call sites' argument lists.
+- [ ] `FlickrPlugin` is present in `REGISTRY` after `REGISTRY.clear(); load_builtin_plugins()`.
+- [ ] A directory containing one `photo_*.json` file with a valid `geo.latitude`/
+  `geo.longitude` yields exactly one record with `lat`/`lng` as Python `float`s equal
+  to the source values and `place_type == "photo"`.
+- [ ] A directory containing one `photo_*.json` file with `geo` absent/`null` yields
+  **zero** records when `geotagged_only=True` (default), and **exactly one** record
+  with `math.isnan(record["lat"])` and `math.isnan(record["lng"])` when
+  `geotagged_only=False` — both toggle states covered against the same fixture file.
+  - **AC caution**: don't check "no exception raised" as a stand-in for "excluded" —
+    assert the exact record count (0 vs 1) for each toggle state.
+- [ ] A photo JSON with no `"name"` key yields a record with `place_name == ""`
+  (not a `KeyError`, not `None`).
+- [ ] An empty export directory (exists, zero matching files) yields an empty list,
+  and a nonexistent export directory path also yields an empty list — neither raises.
+- [ ] Multiple `photo_*.json` files in the directory all get parsed (glob picks up all
+  matches, not just the first).
+- [ ] `raw_json` for a geotagged photo, once made JSON-serializable (it may be handed
+  to `store.upsert_places` as a dict directly, per this plugin's own convention — but
+  the test itself should call `json.dumps(record["raw_json"])` if it's still a dict,
+  or `json.loads` if already a string, to prove it's JSON-serializable either way),
+  contains the original `tags`/`albums`/`description`/`photopage` fields verbatim.
+- [ ] `packages/localizer/src/localizer/plugins/flickr/loader.py` contains no
+  `import requests`, `urllib`, `httpx`, or `socket` — zero network code, matching the
+  issue's explicit requirement.
 
 **Files to Touch**:
-- `components/sidebar.py` (edit: `_load_data_with_progress()` — tag `source_id` on `swarm_df` and
-  `timeline_df` before the concat; update module docstring's "Broker mode"/session-state contract
-  section if it references `swarm_df`'s column shape)
-- `tests/test_sidebar.py` (edit: extend `TestLoadDataCombination` with `source_id` assertions on
-  the existing fixtures; add a case for swarm-only, keeping all existing assertions intact)
+- `packages/localizer/src/localizer/plugins/flickr/__init__.py` (new, empty package
+  marker — mirrors `swarm/__init__.py`'s existing 0-byte convention)
+- `packages/localizer/src/localizer/plugins/flickr/loader.py` (new)
+- `packages/localizer/src/localizer/plugins/__init__.py` (edit: additive import +
+  registry entry only)
+- `packages/localizer/tests/test_flickr_plugin.py` (new)
 
 **Test Guidance**:
-- Reuse the existing `self.swarm_df` / `self.timeline_df` fixtures in `TestLoadDataCombination`'s
-  `setUp()` — do not rebuild new fixtures; add `source_id` assertions on top of the existing
-  row-count/sort-order checks so the diff stays minimal and provably non-regressive.
-- Cover: both sources present (mixed `source_id` values, verified per-row against known timestamps
-  from each fixture), swarm-only (`timeline_path=""`, all rows `"swarm"`), and — as a documented
-  edge case, not a new requirement — confirm that when neither source is configured the empty
-  `pd.DataFrame()` path (already covered by other existing tests in this file) is untouched by this
-  change.
-- This is a plain column-tagging change with no branching complexity; a single focused test class
-  extension is sufficient — no need for exhaustive combinatorial cases beyond what's listed above.
+- Cover every edge case issue #19 names explicitly: geotagged photo, non-geotagged
+  photo with the toggle both on and off, missing title, empty export directory —
+  each as its own test, per the existing sibling test files' one-behavior-per-test
+  style.
+- Also cover: nonexistent (not just empty) export directory, a directory with a
+  malformed/corrupt `photo_*.json` file mixed in with a valid one (the valid one
+  should still be yielded — proves per-file isolation, mirroring
+  `test_swarm_plugin.py`'s pattern), multiple valid files, and the `since` cursor
+  (a photo older than `since` is excluded).
+- Test `get_config_fields()` returns the two expected keys (`export_dir`,
+  `geotagged_only`) each with `key`/`label` present.
+- Test `get_manual_download_instructions()` is non-empty and mentions `flickr.com`.
+- Do not route any test through `LocalizerStore`/DuckDB — test `fetch_records()` in
+  isolation with `tmp_path`-based fixture files, matching every sibling plugin test
+  file's approach.
 
 **Test Files**:
-`tests/test_sidebar.py` — RED-confirmed (`pytest tests/test_sidebar.py -v`: 2 failed / 7 passed; failures are `AssertionError: 'source_id' not found in Index(...)`, the correct pre-implementation failure mode; all 7 pre-existing tests pass unmodified).
-- `TestLoadDataCombination::test_source_id_tagged_per_row_when_both_sources_present` (cross-references known timestamps against `source_id`)
-- `TestLoadDataCombination::test_source_id_all_swarm_when_only_swarm_dir_configured` (swarm-only case)
-- AC #4 (loader call-argument stability) intentionally has no dedicated test — it's vacuously true pre-implementation since tagging doesn't touch call sites; verify by inspection at review time.
+**Recovery note**: this working directory is shared (no git worktree isolation) with
+other, unrelated, concurrent Claude Code sessions. Mid-subtask, one such session
+created and committed its own `chore/add-dependabot-config` branch (merged
+separately as PR #118 — fully committed, no data lost there), and in doing so wiped
+this subtask's then-uncommitted `test_flickr_plugin.py` (originally written and
+confirmed RED by a tester, then used by a coder to build a GREEN implementation)
+along with the live `handoff.md` working copy — twice, confirmed via the polisher
+agent's own report of reverting drifted `handoff.md` copies with `git checkout --`.
+The `FlickrPlugin` implementation files (`flickr/__init__.py`, `flickr/loader.py`,
+and the additive `plugins/__init__.py` registration edit) survived both collisions
+on disk untouched, since they were never part of either colliding branch's diff. A
+coder's attempt to reconstruct the lost test file from memory was discarded as
+untrustworthy for a TDD baseline rather than kept; a tester instead rewrote it fresh.
+**As of this note, the orchestrator has moved all further work for this plan into an
+isolated git worktree** (`C:\Users\johns\Code\autobiographer\.claude\worktrees\
+localizer-plugins-flickr-untappd`, its own venv) specifically to stop this class of
+collision from recurring for Subtask 3 and beyond.
+
+`packages/localizer/tests/test_flickr_plugin.py` (rewritten from scratch, from
+Subtask 2's Description/AC/Test Guidance only — the tester did not read the
+surviving `loader.py` before writing tests, to avoid reverse-engineering the
+implementation instead of testing the spec — 37 test cases: 35 plain functions + 2
+parametrizations, `test_fetch_records_geotagged_photo_always_included_regardless_of_toggle`
+×2 and `test_geotagged_only_string_coercion_from_settings` ×9).
+
+**RED→GREEN round-trip confirmed genuine, preserving TDD integrity despite the
+implementation pre-existing**: `loader.py` was temporarily moved to `loader.py.bak`,
+all 37 tests failed with `ModuleNotFoundError` (no other failure types, no vacuous
+passes), then `loader.py` was restored and `cd packages/localizer &&
+../../venv/Scripts/python.exe -m pytest tests/test_flickr_plugin.py -v --no-cov` →
+**37 passed, 0 failed**. No test was weakened to pass — every AC is satisfied by the
+pre-collision implementation exactly as originally built (float typing via
+`isinstance`, exact record counts rather than truthiness, `math.isnan` checks,
+`is`-based bool/count assertions, black-box settings-coercion behavior, per-file
+malformed-JSON isolation, glob selectivity, `since`-cursor filtering, no-network-
+import scan).
+
+Test names: `test_flickr_plugin_is_registered`, `test_flickr_plugin_plugin_id`,
+`test_flickr_plugin_fetch_mode_manual`, `test_flickr_plugin_output_tables_places`,
+`test_flickr_plugin_get_config_fields`,
+`test_flickr_plugin_geotagged_only_field_is_bool_type_default_true`,
+`test_flickr_plugin_manual_download_instructions`,
+`test_fetch_records_geotagged_photo_yields_float_lat_lng`,
+`test_fetch_records_non_geotagged_geotagged_only_true_yields_zero`,
+`test_fetch_records_non_geotagged_geotagged_only_false_yields_nan`,
+`test_fetch_records_geotagged_only_default_is_true`,
+`test_fetch_records_geotagged_photo_always_included_regardless_of_toggle`,
+`test_geotagged_only_string_coercion_from_settings` (parametrized x9: `"false"`,
+`"False"`, `"0"`, `""`, `"no"`, `"No"`, `"true"`, `"1"`, `"yes"`),
+`test_fetch_records_missing_title_yields_empty_place_name`,
+`test_fetch_records_raw_json_preserves_tags_albums_description_photopage`,
+`test_fetch_records_empty_export_dir_yields_empty_list`,
+`test_fetch_records_nonexistent_export_dir_yields_empty_list`,
+`test_fetch_records_unconfigured_export_dir_yields_empty_list`,
+`test_fetch_records_multiple_files_all_parsed`,
+`test_fetch_records_ignores_non_matching_files`,
+`test_fetch_records_malformed_json_file_skipped_valid_still_yielded`,
+`test_fetch_records_date_taken_parses_to_expected_timestamp`,
+`test_fetch_records_unparseable_date_taken_falls_back_to_fetched_at`,
+`test_fetch_records_since_cursor_excludes_older_photo`,
+`test_fetch_records_dict_has_required_keys`, `test_fetch_records_source_id_is_flickr`,
+`test_fetch_records_fetched_at_is_recent`, `test_flickr_loader_has_no_network_imports`.
+
+`raw_json` tests accept either a dict or a JSON string (handoff.md explicitly permits
+handing a dict straight to `store.upsert_places()`). No `LocalizerStore`/DuckDB
+involved — all fixtures are `tmp_path`-based JSON files.
+
+**IMPORTANT — also discovered during recovery**: `packages/localizer/tests/
+test_untappd_plugin.py` (Subtask 3's test file) was ALSO wiped by the same collision
+and has NOT been recovered — Subtask 3's `Test Files` block below is now stale/
+inaccurate and must be redone by a fresh tester before Subtask 3's coder work is
+trusted. Subtask 3 has no implementation yet, so this just means re-running its
+test-ahead step, not a recovery like this one, and it will happen entirely inside
+the isolated worktree from the start.
 
 **Implementation Notes**:
-In `components/sidebar.py::_load_data_with_progress()`, tagged `swarm_df["source_id"]
-= "swarm"` immediately after `load_swarm_data(swarm_dir)` returns (guarded by the
-existing `if not swarm_df.empty:` check, added inline), and tagged
-`timeline_df["source_id"] = "google_timeline"` immediately after
-`load_google_timeline(timeline_path)` returns non-empty, before the existing
-`pd.concat()` call. Neither `load_swarm_data` nor `load_google_timeline` call sites'
-arguments changed — tagging is a pure post-return DataFrame column assignment, so
-`analysis_utils.py` was not touched at all, matching the plan.
+`FlickrPlugin` was implemented (pre-collision) per Subtask 2's spec exactly:
+`packages/localizer/src/localizer/plugins/flickr/__init__.py` (new, empty package
+marker) and `packages/localizer/src/localizer/plugins/flickr/loader.py` (new),
+mirroring `swarm/loader.py`'s directory-glob/graceful-empty-yield structure, with a
+private `_coerce_bool` helper for `geotagged_only` string coercion, `date_taken`
+parsing with a `fetched_at` fallback on parse failure, and NaN-lat/lng handling for
+non-geotagged photos when `geotagged_only=False`. `packages/localizer/src/localizer/
+plugins/__init__.py` was edited additively only (one import line inserted
+alphabetically, one `REGISTRY[...] = FlickrPlugin` line appended) — re-applied by
+hand in the isolated worktree after the original diff was lost to the collision
+(the mangled `rtk`-wrapped `git diff` output saved as a backup wasn't a valid patch
+for `git apply`; the two-line edit was re-typed directly instead, matching the
+original exactly). Confirmed the registration edit disturbs no existing line —
+Subtask 3's Untappd edit to the same function remains independently safe.
 
-Also added one clarifying sentence to the module docstring's session-state contract
-(`swarm_df` entry) noting each row now carries a `source_id` of `"swarm"` or
-`"google_timeline"`, since the docstring previously didn't describe the column shape
-at all — a minor addition beyond the letter of "Files to Touch" but within its
-explicit allowance to "update module docstring's ... session-state contract section
-if it references swarm_df's column shape."
-
-The two new tests in `tests/test_sidebar.py`
-(`test_source_id_tagged_per_row_when_both_sources_present` and
-`test_source_id_all_swarm_when_only_swarm_dir_configured`) were already written by
-the tester agent in the RED phase; no test-file edits were made in this GREEN pass.
-
-When neither source is configured, `swarm_df` stays the pre-existing empty
-`pd.DataFrame()` with no `source_id` column — untouched by this change, as specified
-(Subtask 3's filter helper is responsible for tolerating that case).
-
-Ran `python -m pytest tests/test_sidebar.py -v --no-cov`: 9 passed, 0 failed (7
-pre-existing + 2 new). Ran the scoped set including Subtask 1's GREEN/APPROVED tests:
-`python -m pytest tests/test_sidebar.py tests/test_localizer_frames.py -v --no-cov`:
-22 passed, 0 failed.
-Ran `python -m ruff check components/sidebar.py tests/test_sidebar.py`: all checks
-passed. Ran `python -m ruff format --check components/sidebar.py tests/test_sidebar.py`:
-2 files already formatted, no changes needed. Ran `python -m mypy components/sidebar.py`:
-no issues found.
-
-No deviations from the plan; no files touched beyond `components/sidebar.py` (test-file
-edits were already made by the tester in the RED phase).
+Re-verified in the isolated worktree's fresh, dedicated venv (not the shared main
+checkout's venv, to avoid the same stale-editable-install class of bug seen in
+Subtask 1): `cd packages/localizer && ../../venv/Scripts/python.exe -m pytest
+tests/test_flickr_plugin.py -v --no-cov` → **37 passed, 0 failed**.
 
 **Review Notes**:
-Code Review: APPROVED — checks clean
+Code Review: skipped by orchestrator instruction — the recovery process (fresh
+tester rewrite + verified `ModuleNotFoundError`→GREEN round-trip + independent
+lint/format checks, documented above) already covers everything a code-mode
+reviewer would check, so this pass does both code review and owner review.
 
-Automated checks (scoped to the current subtask's Test Files entry
-(`tests/test_sidebar.py`) plus Subtask 1's GREEN/APPROVED `tests/test_localizer_frames.py`;
-no other subtask is yet GREEN/APPROVED):
-- `python -m ruff check components/sidebar.py tests/test_sidebar.py` — All checks passed!
-- `python -m ruff format --check components/sidebar.py tests/test_sidebar.py` — 2 files already formatted
-- `python -m mypy components/sidebar.py` — no issues found
-- `python -m pytest tests/test_sidebar.py tests/test_localizer_frames.py -v --no-cov` — 22 passed, 0 failed
+**Owner Review: APPROVED** — independently re-verified from scratch, not from
+prior notes:
 
-Diff review (`git diff -- components/sidebar.py`, +6/-1; `git diff -- tests/test_sidebar.py`,
-+33/-0): matches the plan exactly. `components/sidebar.py`'s only functional change is two
-guarded assignments — `swarm_df["source_id"] = "swarm"` right after `load_swarm_data()`
-returns non-empty, and `timeline_df["source_id"] = "google_timeline"` right after
-`load_google_timeline()` returns non-empty, before the existing `pd.concat()` — plus a
-docstring sentence describing the new `source_id` column in the session-state contract.
-`tests/test_sidebar.py`'s diff is purely additive (two new test methods appended to
-`TestLoadDataCombination`); the three pre-existing tests
-(`test_timeline_rows_appended_to_swarm`, `test_combined_frame_sorted_by_timestamp`,
-`test_no_timeline_leaves_swarm_only`) are byte-for-byte unchanged and still pass. No dead
-code, no commented-out blocks, no secrets/tokens, no N+1 or hot-path synchronous-call
-concerns (pure in-memory pandas column assignment). Confirmed `analysis_utils.py` has zero
-diff (`git diff --stat -- analysis_utils.py` empty) — `load_swarm_data()` and
-`load_google_timeline()` were not touched, matching the subtask's explicit constraint.
+- Read `flickr/loader.py`, `flickr/__init__.py` (confirmed 0-byte package
+  marker, matching `swarm/__init__.py`'s convention), the additive diff to
+  `plugins/__init__.py`, and all 579 lines of `test_flickr_plugin.py`.
+- Traced the geotagging logic line-by-line: `geo = data.get("geo")` combined
+  with `isinstance(geo, dict) and geo` correctly treats `None`/missing/empty
+  `geo` as non-geotagged; `lat`/`lng` are pre-seeded to `nan` before the
+  `try`, so a partial/invalid `geo` dict safely falls back to non-geotagged
+  instead of raising. `since` filtering and the `geotagged_only` skip are
+  independent `continue`s — their order doesn't affect the yielded set.
+  `raw_json = data` is the direct output of `json.loads()`, so it is
+  JSON-round-trippable by construction (AC #7's serializability requirement
+  is structurally guaranteed even though no test calls `json.dumps()` on it
+  explicitly — traced as a non-issue, not a gap).
+- Re-ran independently (not trusting the coder's reported numbers):
+  `pytest tests/test_flickr_plugin.py -v --no-cov` → **37 passed**;
+  `ruff check` on all 4 touched files → All checks passed; `ruff format
+  --check` on all 4 → already formatted; `mypy` on `loader.py` → no issues
+  (ignoring the known pre-existing Python-3.9 config warning, not this
+  subtask's concern); full `packages/localizer` sub-suite → **249 passed**,
+  0 failures (`test_untappd_plugin.py` doesn't exist yet in this worktree —
+  Subtask 3's test-ahead phase hasn't been re-run here yet, exactly matching
+  the recovery note; confirmed zero regression in `test_flickr_plugin.py` or
+  any other sibling test file).
+- Verified every AC against the passing tests one-by-one: registration,
+  float lat/lng + `place_type=="photo"` for a geotagged photo, exact 0-vs-1
+  record counts for both `geotagged_only` states against equivalent
+  non-geotagged fixtures (not truthiness-based), `math.isnan` checks,
+  missing-title → `""`, empty and nonexistent directories → `[]` without
+  raising, multi-file glob correctness, `tags`/`albums`/`description`/
+  `photopage` preserved verbatim in `raw_json`, and a static-source scan
+  confirming no `requests`/`urllib`/`httpx`/`socket` import.
+- Every Test Guidance item has a corresponding test (cross-checked against
+  the full test list) — nothing called out in guidance is missing.
+- Scope check: `git diff --stat` confirms `plugins/__init__.py`'s edit is
+  exactly the 2 additive lines described (import + registry entry,
+  alphabetically placed, disturbing no existing line — Subtask 3's Untappd
+  edit to the same function remains independently safe).
+- One process note (not a defect, not blocking): the working tree also
+  carries an uncommitted one-line `pyproject.toml` ruff-ignore addition
+  (`"packages/localizer/tests/*" = ["S", "B", "E501"]`) that isn't listed in
+  this subtask's Files to Touch. Verified by temporarily stashing it and
+  re-running `ruff check` on the test file: it fails with 3× `E501` without
+  that line, so the addition is necessary, minimal, and precedented
+  (identical to Subtask 1's own already-committed fix on its separate,
+  not-yet-merged branch — this worktree's HEAD simply predates that commit
+  landing on `main`). No action needed; noting it only so a future PR-close
+  diff review isn't surprised by it.
+- No dead code, no premature abstraction, naming and docstrings consistent
+  with `swarm`/`letterboxd` sibling conventions, no secrets, no blocking
+  calls, no network code. Diff is simple and scoped exactly to the subtask.
 
-All 4 Acceptance Criteria verified:
-- AC #1 (mixed-source row-for-row tagging, cross-referenced by timestamp) — covered by
-  `test_source_id_tagged_per_row_when_both_sources_present`, passing.
-- AC #2 (swarm-only → all rows `"swarm"`) — covered by
-  `test_source_id_all_swarm_when_only_swarm_dir_configured`, passing.
-- AC #3 (existing `TestLoadDataCombination` tests unchanged and passing) — confirmed via
-  diff (only additions) and the pytest run above.
-- AC #4 (loader call-argument stability) — confirmed by inspection: `load_swarm_data(swarm_dir)`
-  and `load_google_timeline(timeline_path)` call sites are unmodified; tagging happens only via
-  a post-return attribute assignment on the returned DataFrame.
-
-No issues found that require reversal to RED.
-
-Owner Review: APPROVED — Independently verified, not just re-reading the code-review notes:
-- Re-read `components/sidebar.py` lines 230-289 in full. Traced both branches: swarm-only
-  (`timeline_path` falsy short-circuits the second `if`, so only the guarded
-  `swarm_df["source_id"] = "swarm"` assignment runs) and both-configured (swarm tagged first,
-  then `timeline_df["source_id"] = "google_timeline"` immediately before the existing
-  `pd.concat()`/re-sort). Both traces match AC #1 and AC #2 exactly, including the
-  `if not swarm_df.empty` / `if not timeline_df.empty` guards that keep the untouched
-  "neither configured" empty-`pd.DataFrame()` path (no `source_id` column at all) exactly as
-  it was before this diff — that path is out of scope per the subtask's own description and
-  Subtask 3 is responsible for tolerating it.
-- Re-ran the scoped set independently rather than trusting the coder/reviewer's prior output:
-  `python -m pytest tests/test_sidebar.py tests/test_localizer_frames.py -v --no-cov` → 22
-  passed, 0 failed. `python -m ruff check components/sidebar.py tests/test_sidebar.py` → all
-  checks passed. `python -m ruff format --check components/sidebar.py tests/test_sidebar.py` →
-  2 files already formatted. `python -m mypy components/sidebar.py` → no issues found.
-- Diff is minimal (+6/-1 in `components/sidebar.py`, purely additive +33/-0 in
-  `tests/test_sidebar.py`) and `analysis_utils.py` has zero diff, confirmed via
-  `git diff HEAD -- components/sidebar.py tests/test_sidebar.py`. No dead code, no
-  over-abstraction — two guarded one-line column assignments, exactly what the plan called for.
-  Mutating the DataFrame returned by `load_swarm_data()`/`load_google_timeline()` in place is
-  safe here: both loaders build a fresh `pd.DataFrame` from a Python list on every call
-  (confirmed by reading `analysis_utils.py::load_swarm_data`), so there is no shared/cached
-  frame elsewhere that this mutation could corrupt.
-- All 4 Acceptance Criteria verified directly (not merely by re-reading the code reviewer's
-  claims): AC #1 (`test_source_id_tagged_per_row_when_both_sources_present` cross-references
-  the exact fixture timestamps 100/300 → "swarm", 200/400 → "google_timeline"), AC #2
-  (`test_source_id_all_swarm_when_only_swarm_dir_configured`), AC #3 (the three pre-existing
-  `TestLoadDataCombination` tests are byte-for-byte unchanged in the diff and still pass), AC #4
-  (loader call sites `load_swarm_data(swarm_dir)` / `load_google_timeline(timeline_path)`
-  unmodified — tagging is a post-return attribute assignment only).
-- One non-blocking observation for the record: the Test Guidance's claim that the
-  "neither source configured" empty-`pd.DataFrame()`-with-no-`source_id` case is "already
-  covered by other existing tests in this file" is not literally accurate — grepping this file
-  shows exactly one call site to `_load_data_with_progress()` (inside `_run()`), and it always
-  passes a truthy `swarm_dir` with `os.path.exists` mocked `True`, so that exact branch
-  combination is never exercised end-to-end here. This is not a functional gap, though: the
-  `else: swarm_df = pd.DataFrame()` branch is completely untouched by this diff (confirmed via
-  the diff above — no lines changed in that branch), so there is no new regression risk, and a
-  test asserting today's unchanged behavior would pass vacuously either way. Not blocking.
-
-Both subtasks in PR Group `preserve-source-id` (Subtask 1 and Subtask 2) are now `APPROVED`.
-Proceeding per AGENTS.md "After each subtask is APPROVED" §4 (full PR-group close).
+Subtask 2 is complete; `current` advanced to Subtask 3 (Untappd, `RED` per
+the plan but its `Test Files` block is stale per the recovery note above —
+a fresh tester must re-run the test-ahead step for Untappd inside this
+isolated worktree before a coder begins).
 
 ---
 
-### Subtask 3 — Shared pure source-filter helper (`core/source_filter.py`)
+### Subtask 3 — Add `UntappdPlugin` (issue #20)
 
 **Status**: APPROVED
 
-**PR Group**: geo-source-filter-ui
+**PR Group**: untappd-plugin
 
 **Depends On**: none
 
 **Description**:
-Create `core/source_filter.py` with three small, pure, Streamlit-free functions used by both
-consuming pages (Subtasks 4 and 5) so the source→label mapping and filtering logic exists in
-exactly one place:
+Add a new `UntappdPlugin` under `packages/localizer/src/localizer/plugins/untappd/`,
+`OutputTable.EVENTS`, `FetchMode.MANUAL`, mirroring `letterboxd/loader.py`'s structure
+almost exactly (the closest existing sibling: single CSV export file,
+`FileNotFoundError` when a configured path doesn't exist, `fetch_records(csv_path=...)`
+-style kwarg resolved from `LocalizerSettings` when not passed).
 
-- `source_label(source_id: str) -> str` — returns `SOURCE_LABELS.get(source_id,
-  source_id.replace("_", " ").title())` where `SOURCE_LABELS = {"swarm": "Swarm",
-  "google_timeline": "Google Timeline"}`. Unknown/future `source_id` values get a humanized
-  fallback label rather than crashing or being hidden.
-- `get_source_options(swarm_df: pd.DataFrame | None) -> list[str]` — returns `["All"]` when
-  `swarm_df` is `None`, empty, or lacks a `source_id` column; otherwise returns `["All"]` followed
-  by the sorted, de-duplicated human labels of every distinct `source_id` present.
-- `filter_by_source(swarm_df: pd.DataFrame | None, selected_label: str) -> pd.DataFrame | None` —
-  returns `swarm_df` unchanged when it is `None`/empty, when `selected_label == "All"`, or when the
-  `source_id` column is absent (graceful passthrough, never an exception). Otherwise returns only
-  the rows whose `source_label(row.source_id) == selected_label`, with a reset index.
-
-This module has no dependency on Streamlit, DuckDB, or `LocalizerBroker` — pure DataFrame-in/
-DataFrame-out logic, independently testable with hand-built fixtures, mirroring
-`core/localizer_frames.py`'s existing convention.
-
-**Acceptance Criteria**:
-- [ ] `get_source_options()` on a `None` input, an empty DataFrame, and a DataFrame with no
-  `source_id` column all return exactly `["All"]`.
-- [ ] `get_source_options()` on a DataFrame with `source_id` values `["swarm", "google_timeline",
-  "swarm"]` returns exactly `["All", "Google Timeline", "Swarm"]` (alphabetically sorted labels
-  after `"All"`).
-- [ ] `filter_by_source(df, "All")` returns a frame with the same row count as the input, for both
-  a `source_id`-bearing and a `source_id`-lacking input.
-- [ ] `filter_by_source(df, "Swarm")` on a mixed-source 4-row fixture (2 swarm, 2 google_timeline)
-  returns exactly the 2 rows whose `source_id == "swarm"`, values matching the input row-for-row
-  (not just row count).
-- [ ] `filter_by_source(df, "Nonexistent Label")` (a label matching no present source) returns an
-  empty-but-correctly-shaped DataFrame (same columns, zero rows) rather than raising or returning
-  the unfiltered frame.
-- [ ] `source_label("swarm") == "Swarm"`, `source_label("google_timeline") == "Google Timeline"`,
-  and `source_label("some_future_plugin") == "Some Future Plugin"` (humanized fallback).
-
-**Files to Touch**:
-- `core/source_filter.py` (new)
-- `tests/test_source_filter.py` (new)
-
-**Test Guidance**:
-- Cover all three functions independently with hand-built fixtures (do not route through
-  `LocalizerBroker`, `core/localizer_frames.py`, or Streamlit — that integration belongs to
-  Subtasks 4/5).
-- Explicitly test the "graceful passthrough" edge cases required by the acceptance criteria: `None`
-  input, empty DataFrame, missing `source_id` column, and a single-distinct-value `source_id`
-  column (proving the filter is a harmless no-op rather than something that needs to be hidden by
-  the caller).
-- Test the unknown-label fallback in `source_label()` with at least two different underscore-
-  separated inputs to confirm the humanization formula generalizes (not hardcoded to one string).
-- Test that `filter_by_source()` never mutates its input DataFrame in place (assert the original
-  `df` still has all rows after calling the function) — pure functions must not have side effects
-  on caller-owned data.
-
-**Test Files**:
-`tests/test_source_filter.py` (new) — RED-confirmed (`pytest tests/test_source_filter.py`: collection error `ModuleNotFoundError: No module named 'core.source_filter'`, fails all 20 tests — correct pre-implementation state since the module doesn't exist yet).
-20 tests covering all 6 ACs plus edge cases: `test_source_label_known_swarm`, `test_source_label_known_google_timeline`, `test_source_label_unknown_humanized_fallback_first_example`, `test_source_label_unknown_humanized_fallback_second_example`, `test_get_source_options_none_input_returns_all_only`, `test_get_source_options_empty_dataframe_returns_all_only`, `test_get_source_options_missing_source_id_column_returns_all_only`, `test_get_source_options_mixed_sources_sorted_after_all`, `test_get_source_options_single_distinct_source_value`, `test_filter_by_source_none_input_returns_none`, `test_filter_by_source_empty_dataframe_returns_unchanged`, `test_filter_by_source_all_label_mixed_source_row_count_unchanged`, `test_filter_by_source_all_label_no_source_id_row_count_unchanged`, `test_filter_by_source_missing_source_id_column_is_graceful_passthrough`, `test_filter_by_source_swarm_label_returns_only_swarm_rows_row_for_row`, `test_filter_by_source_google_timeline_label_returns_only_those_rows`, `test_filter_by_source_nonexistent_label_returns_empty_but_correctly_shaped`, `test_filter_by_source_result_has_reset_index`, `test_filter_by_source_does_not_mutate_input_in_place`, `test_source_filter_module_has_no_forbidden_imports`.
-
-**Implementation Notes**:
-Created `core/source_filter.py` (new) with the three pure functions specified in the
-plan, mirroring `core/localizer_frames.py`'s module docstring/style convention:
-
-- `SOURCE_LABELS = {"swarm": "Swarm", "google_timeline": "Google Timeline"}` module-level
-  dict.
-- `source_label(source_id)` — `SOURCE_LABELS.get(source_id, source_id.replace("_", "
-  ").title())`.
-- `get_source_options(swarm_df)` — returns `["All"]` when `swarm_df` is `None`, empty,
-  or lacks a `source_id` column; otherwise `["All", *sorted({source_label(sid) for sid
-  in swarm_df["source_id"]})]` (sorted, de-duplicated labels via a set comprehension).
-- `filter_by_source(swarm_df, selected_label)` — returns `swarm_df` unchanged for
-  `None`/empty input, `selected_label == "All"`, or a missing `source_id` column
-  (graceful passthrough in all three cases, checked before any filtering logic runs).
-  Otherwise builds a boolean mask via `swarm_df["source_id"].map(source_label) ==
-  selected_label` and returns `swarm_df[mask].reset_index(drop=True)` — boolean-mask
-  indexing plus `reset_index` naturally avoids mutating the input (confirmed by the
-  `test_filter_by_source_does_not_mutate_input_in_place` test).
-
-The test file (`tests/test_source_filter.py`) was already written by the tester agent in
-the RED phase with all 20 tests; no test-file edits were needed or made in this GREEN
-phase.
-
-Ran `python -m pytest tests/test_source_filter.py -v --no-cov`: 20 passed, 0 failed.
-Ran the scoped set including Subtasks 1 and 2's GREEN/APPROVED tests: `python -m pytest
-tests/test_source_filter.py tests/test_localizer_frames.py tests/test_sidebar.py -v
---no-cov`: 42 passed, 0 failed.
-
-Ran `python -m ruff check core/source_filter.py tests/test_source_filter.py`: all checks
-passed. Ran `python -m ruff format --check core/source_filter.py
-tests/test_source_filter.py`: `ruff format` initially flagged `core/source_filter.py`
-for one long function signature line; ran `python -m ruff format core/source_filter.py`
-to auto-fix it (wrapped `filter_by_source`'s signature across lines), then re-ran the
-full scoped pytest set above to confirm no regression from the reformat (still 42
-passed) before re-confirming `ruff format --check` clean on both files. Ran `python -m
-mypy core/source_filter.py`: no issues found.
-
-No deviations from the plan; no files touched beyond `core/source_filter.py` (the
-`Files to Touch` list's test-file entry was already created by the tester in the RED
-phase).
-
-**Review Notes**:
-Code Review: APPROVED — checks clean
-
-Automated checks (scoped to the current subtask's Test Files entry
-(`tests/test_source_filter.py`) plus Subtasks 1 and 2's GREEN/APPROVED test files
-(`tests/test_localizer_frames.py`, `tests/test_sidebar.py`); no other subtask is yet
-GREEN/APPROVED — `tests/test_places.py` exists on disk from the test-ahead batch but
-Subtask 5 is still `RED`, so it is correctly excluded from this scoped run):
-- `python -m ruff check core/source_filter.py tests/test_source_filter.py` — All checks passed!
-- `python -m ruff format --check core/source_filter.py tests/test_source_filter.py` — 2 files already formatted
-- `python -m mypy core/source_filter.py` — no issues found
-- `python -m pytest tests/test_source_filter.py tests/test_localizer_frames.py tests/test_sidebar.py -v --no-cov` — 42 passed, 0 failed
-
-Diff review (`core/source_filter.py` and `tests/test_source_filter.py` are new files,
-read in full): no dead code, no commented-out blocks, no secrets/tokens, no N+1 or
-hot-path synchronous-call concerns (pure in-memory pandas/dict logic, no I/O). Module
-docstring and per-function docstrings match the plan's spec. `SOURCE_LABELS` dict and
-all three functions match the Description's exact signatures.
-
-Focused check on the two flagged risk areas:
-- **No mutation of input**: `filter_by_source()`'s only non-passthrough path builds a
-  boolean mask via `.map()` (which allocates a new Series) and indexes with
-  `swarm_df[mask].reset_index(drop=True)` — boolean-mask fancy indexing returns a new
-  DataFrame in pandas, never a view, so the original is never written to.
-  `test_filter_by_source_does_not_mutate_input_in_place` exercises exactly this path
-  (label `"Swarm"` against the mixed-source fixture) and passes. The three passthrough
-  branches (`None`/empty, `"All"`, missing `source_id` column) return the identical
-  input object by reference rather than a defensive copy — this matches the spec's
-  literal wording ("returns `swarm_df` unchanged") and no AC or test requires a copy on
-  the passthrough path, so this is not a defect, just worth the owner's awareness if a
-  future caller ever mutates a passthrough result in place.
-- **Graceful passthrough for None/empty/missing-column**: verified row-by-row against
-  the implementation — `get_source_options()` checks `swarm_df is None or
-  swarm_df.empty or "source_id" not in swarm_df.columns` in one guard (all three
-  return `["All"]`); `filter_by_source()` checks `None`/empty first (returns
-  `swarm_df` as-is, so `None` stays `None` rather than erroring on `.empty`), then
-  checks `selected_label == "All" or "source_id" not in swarm_df.columns` (also
-  passthrough). No branch can raise on these inputs — confirmed by
-  `test_get_source_options_none_input_returns_all_only`,
-  `..._empty_dataframe_returns_all_only`, `..._missing_source_id_column_returns_all_only`,
-  `test_filter_by_source_none_input_returns_none`,
-  `test_filter_by_source_empty_dataframe_returns_unchanged`, and
-  `test_filter_by_source_missing_source_id_column_is_graceful_passthrough`, all passing.
-
-All 6 Acceptance Criteria verified against the test file and passing run:
-- AC #1 (`get_source_options` → `["All"]` for None/empty/missing-column) — 3 dedicated
-  tests, all passing.
-- AC #2 (mixed sources → `["All", "Google Timeline", "Swarm"]`, alphabetical after
-  `"All"`) — `test_get_source_options_mixed_sources_sorted_after_all`, passing.
-- AC #3 (`filter_by_source(df, "All")` row-count-unchanged, with and without
-  `source_id`) — 2 dedicated tests, passing.
-- AC #4 (`"Swarm"` filter on 4-row mixed fixture → exactly the 2 swarm rows,
-  row-for-row) — `test_filter_by_source_swarm_label_returns_only_swarm_rows_row_for_row`,
-  passing (checks specific lat/lng per city, not just counts).
-- AC #5 (nonexistent label → empty-but-correctly-shaped, not raising/unfiltered) —
-  `test_filter_by_source_nonexistent_label_returns_empty_but_correctly_shaped`, passing.
-- AC #6 (`source_label` known + 2 unknown-fallback examples) — 4 dedicated tests
-  (`swarm`, `google_timeline`, and two differently-shaped unknown inputs), passing.
-
-No issues found that require reversal to RED.
-
-Owner Review: APPROVED — Independently re-verified, not just re-reading the code-review notes:
-
-- Read `core/source_filter.py` and `tests/test_source_filter.py` in full. Traced all three
-  functions by hand: `source_label()` is a one-line dict lookup with a humanized fallback;
-  `get_source_options()`'s single guard (`None`/empty/missing-column) correctly short-circuits
-  to `["All"]` before touching `swarm_df["source_id"]`, and the non-guard path builds a
-  `set`-deduped, `sorted()` label list prepended with `"All"` — matches AC #1/#2 exactly.
-  `filter_by_source()`'s two guards (`None`/empty first, then `"All"`/missing-column) both
-  return the original object by reference (never touching `.map()`), and the remaining path
-  builds a boolean mask via `.map(source_label)` and returns `swarm_df[mask].reset_index(drop=True)`
-  — boolean-mask fancy indexing always allocates a new frame in pandas, so the input is never
-  mutated, confirmed against `test_filter_by_source_does_not_mutate_input_in_place`.
-- Re-ran all checks myself rather than trusting the notes above: `python -m pytest
-  tests/test_source_filter.py tests/test_localizer_frames.py tests/test_sidebar.py -v --no-cov`
-  → 42 passed, 0 failed. `python -m ruff check core/source_filter.py tests/test_source_filter.py`
-  → all checks passed. `python -m ruff format --check core/source_filter.py
-  tests/test_source_filter.py` → 2 files already formatted. `python -m mypy core/source_filter.py`
-  → no issues found (confirmed `core` is in `[tool.mypy] files` in `pyproject.toml`, so this file
-  is actually type-checked, not silently skipped).
-- Steelmanned the one candidate concern (passthrough branches return the same object reference
-  rather than a defensive copy): the spec's literal wording is "returns `swarm_df` unchanged,"
-  no AC or Test Guidance item requires a copy, and no consuming subtask (4/5) is documented to
-  mutate a passthrough result — retracting this as a non-issue, matching the code reviewer's
-  same conclusion.
-- Test Guidance coverage checked item-by-item against the test file: all three functions covered
-  independently with hand-built fixtures (no `LocalizerBroker`/Streamlit involvement) — confirmed.
-  Graceful-passthrough edge cases (`None`, empty DataFrame, missing `source_id` column,
-  single-distinct-value column) — all four present as dedicated tests. Unknown-label fallback
-  tested with two differently-shaped inputs (`some_future_plugin`, `custom_data_source`) —
-  present. No-mutation-in-place test — present and passing. No gaps found.
-- All 6 Acceptance Criteria independently re-verified against the passing test run: AC #1 (3
-  dedicated `get_source_options` tests), AC #2 (`test_get_source_options_mixed_sources_sorted_after_all`),
-  AC #3 (2 dedicated `filter_by_source(df, "All")` tests), AC #4
-  (`test_filter_by_source_swarm_label_returns_only_swarm_rows_row_for_row`, which checks specific
-  lat/lng per city, not just counts), AC #5
-  (`test_filter_by_source_nonexistent_label_returns_empty_but_correctly_shaped`), AC #6 (4
-  `source_label` tests covering both known values and two unknown-fallback examples).
-- Simplicity/naming/style: no dead code, no premature abstraction, three small pure functions
-  exactly matching the plan's spec; naming (`source_label`, `get_source_options`,
-  `filter_by_source`) is clear and mirrors `core/localizer_frames.py`'s existing pure-adapter
-  convention. No domain-specific risk patterns apply (no concurrency, network I/O, LLM parsing,
-  background jobs, or DB writes in this module).
-
-Note for the orchestrator: this subtask's approval unblocks Subtask 4, whose tester HALTed
-earlier specifically because `core/source_filter.py` did not exist yet (see Subtask 4's
-`Test Files` entry). Subtask 4's tester should now be re-run to write its RED tests against
-this now-real module before the coder proceeds on Subtask 4.
-
-This does not close the `geo-source-filter-ui` PR group — Subtask 4 is still `NEW`/blocked and
-Subtask 5 is still `RED`. Advancing `current` per the standard single-subtask owner workflow.
-
----
-
-### Subtask 4 — Wire the source filter into Geo Explorer
-
-**Status**: APPROVED
-
-**PR Group**: geo-source-filter-ui
-
-**Depends On**: 3
-
-**Description**:
-Add a `st.selectbox("Source", get_source_options(swarm_df), key="geo_source_filter")` call inside
-`pages/geo_explorer.py::render_geo_explorer()`'s existing "⚡ Filter" popover (`with filt_col: with
-st.popover("⚡ Filter"):`), shown only when `has_swarm` is true (mirroring how the Artist selectbox
-is already gated on `has_music`). After the popover block — at the same point `music_df` is
-already filtered by date range and artist (immediately before the "Share button" section) — apply
-`swarm_df = filter_by_source(swarm_df, selected_source)` so every downstream consumer
-(`_render_3d_globe`, `_render_2d_map`) sees only the filtered places, exactly once, with no
-per-view-mode duplication of filtering logic. Note that the "By City" breakdown table and city
-detail card (`_build_city_stats()` / `_render_city_breakdown()` / `_render_atlas_city_detail()`,
-lines ~793-1037) operate exclusively on `music_df` (they require `artist`/`track`/`date_text`
-columns that `swarm_df` doesn't have) and are out of scope for this subtask — check-ins only ever
-appear, in every view mode including "By City", as a single "Check-ins"-labeled dot layer on the
-map itself (the `ci` groupby in `_render_2d_map`, and the equivalent `checkin_geo` groupby in
-`_render_3d_globe`). This subtask's job is to make that dot layer (in both `_render_2d_map` and
-`_render_3d_globe`) reflect the filtered `swarm_df`, not to invent a check-in breakdown table that
-doesn't exist today.
+- **`fetch_records(self, since=None, progress_cb=None, checkins_csv: str | None = None)`**:
+  when `checkins_csv` is `None`, resolve via
+  `LocalizerSettings().get_setting("checkins_csv")` (same `try/except ImportError: pass`
+  guard as Letterboxd); if still `None` after that, yield nothing (not configured is
+  not an error). Otherwise delegate to a `_parse_csv(checkins_csv, since)` helper.
+- **`_parse_csv()`**: raise `FileNotFoundError` (with a message naming the path and
+  pointing at `untappd.com` → Settings → Export Data) if the configured path does not
+  exist — mirrors Letterboxd's exact behavior for a configured-but-missing file. Parse
+  with `csv.DictReader`. For each row:
+  - Parse `created_at` to a Unix timestamp using the same forgiving
+    space-to-`"T"`-then-`datetime.fromisoformat` approach used by `swarm/loader.py`'s
+    fallback parser; on failure, fall back to this batch's `fetched_at`.
+  - `label = row.get("brewery_name", "") or ""`, `sublabel = row.get("beer_name", "") or ""`,
+    `category = row.get("beer_type", "") or ""` — per issue #20's explicit mapping.
+  - Parse `rating_score` to a Python `float`, or `None` if blank/unparseable (never a
+    raw string, never `NaN` — same "`raw_json` must stay valid JSON" reasoning as
+    Subtask 1's rating fix).
+  - Parse `venue_lat`/`venue_lng` to Python `float`s, or `None` each if blank/
+    unparseable (this is the "check-in without a venue" case — represented as JSON
+    `null`, not `NaN`, since these live only inside `raw_json` and `events` has no
+    lat/lng columns at all per `store/schema.py`).
+  - Build `raw_json` as the full raw CSV row (`dict(row)`, preserving `comment`,
+    `flavor_profiles`, `serving_type`, `photo_url` verbatim) plus overridden/added
+    typed keys: `"rating"`, `"venue_name"` (`row.get("venue_name", "") or ""`),
+    `"venue_lat"`, `"venue_lng"` — then `json.dumps()`'d.
+  - Honor `since`: skip rows whose parsed timestamp is `<= since`.
+- **`get_config_fields()`**: one `file_path` field, `key="checkins_csv"`.
+- **`get_manual_download_instructions()`**: multi-line string mentioning
+  `untappd.com` and `csv`.
+- Register in `packages/localizer/src/localizer/plugins/__init__.py`: add
+  `from localizer.plugins.untappd.loader import UntappdPlugin` to the import block and
+  `REGISTRY[UntappdPlugin.PLUGIN_ID] = UntappdPlugin` — additive only, same caution as
+  Subtask 2 about not disturbing Flickr's lines in this shared function.
 
 **Acceptance Criteria**:
-- [ ] With `swarm_df` seeded with mixed `source_id` values and `st.selectbox` mocked to return
-  `"Swarm"`, the 2D Map view's check-in dot layer (`_render_2d_map`'s internal `ci` groupby, lines
-  ~559-576) only reflects rows whose `source_id == "swarm"` — verified via a specific lat/lng value
-  present only in the Swarm-tagged rows appearing, and one present only in Google-Timeline-tagged
-  rows being absent. This holds in both "By Artist" and "By City" breakdown modes, since the "By
-  City" mode only changes the check-in dots' displayed label (to "Check-ins"), not their filtering.
-- [ ] With the selectbox mocked to return `"All"`, behavior is unchanged from pre-filter output
-  (same row count reaching `_render_2d_map`/`_render_3d_globe` as the unfiltered `swarm_df`).
-- [ ] When `has_swarm` is `False` (i.e. `swarm_df` is `None` or empty — the state every existing
-  test in this file already uses), the new selectbox is never called — verified by asserting
-  `st.selectbox` was not invoked with a `"Source"` label argument, so `Depends On` Subtask 3's
-  helper never even runs the "All"-only path in those cases.
-- [ ] All pre-existing tests in `tests/test_geo_explorer.py` continue to pass with zero
-  modification to their assertions (only mock setups may gain a new default `st.selectbox`
-  side effect entry if required for a shared mock across labels — verify this is not needed since
-  none currently populate `swarm_df`).
-- [ ] `_build_city_stats()` / `_render_city_breakdown()` / `_render_atlas_city_detail()` remain
-  untouched by this subtask and continue to operate solely on `music_df` — no `swarm_df` argument
-  is introduced into that call path (regression guard against accidentally wiring `swarm_df` into
-  the scrobble-only breakdown table, which would require columns it doesn't have).
+- [ ] `UntappdPlugin` is present in `REGISTRY` after `REGISTRY.clear(); load_builtin_plugins()`.
+- [ ] `created_at` values in both a space-separated (`"2023-06-15 18:30:00"`) and a
+  `T`-separated ISO form (`"2023-06-15T18:30:00"`) both parse to the same correct Unix
+  timestamp for equivalent inputs — proving the parser isn't accidentally coupled to
+  only one literal format.
+- [ ] A check-in row with blank `venue_lat`/`venue_lng`/`venue_name` produces
+  `json.loads(record["raw_json"])["venue_lat"] is None` and
+  `[...]["venue_lng"] is None` (checked with `is None`, not falsiness) — while a
+  check-in row *with* a venue produces the exact float values from the CSV, matching
+  row-for-row (not just "some rows have venues").
+  - **AC caution**: this must be checked via `json.loads`, not by inspecting a
+    top-level `record["venue_lat"]` key — the schema has no such DB column, so any
+    top-level key beyond the seven `EVENTS`-schema keys is silently dropped by
+    `store.upsert_events()` and is not part of this plugin's real contract.
+- [ ] An unrated check-in (`rating_score` blank) produces
+  `json.loads(record["raw_json"])["rating"] is None`.
+- [ ] An empty CSV (header row only, zero data rows) yields an empty list, no
+  exception.
+- [ ] `label`/`sublabel`/`category` on a known fixture row match `brewery_name`/
+  `beer_name`/`beer_type` exactly (row-for-row, by a specific known value — e.g.
+  brewery `"Test Brewery Co."` / beer `"Hazy IPA"` / style `"IPA"` — not just "three
+  distinct strings exist").
+- [ ] `packages/localizer/src/localizer/plugins/untappd/loader.py` contains no
+  `import requests`, `urllib`, `httpx`, or `socket`.
 
 **Files to Touch**:
-- `pages/geo_explorer.py` (edit: `render_geo_explorer()` — add gated `st.selectbox("Source", ...)`
-  inside the filter popover; apply `filter_by_source()` to `swarm_df` before view dispatch; import
-  `get_source_options`, `filter_by_source` from `core.source_filter`)
-- `tests/test_geo_explorer.py` (edit: add a new test class exercising the filter with a seeded,
-  mixed-source `swarm_df`; zero edits to existing test classes' assertions)
+- `packages/localizer/src/localizer/plugins/untappd/__init__.py` (new, empty package
+  marker)
+- `packages/localizer/src/localizer/plugins/untappd/loader.py` (new)
+- `packages/localizer/src/localizer/plugins/__init__.py` (edit: additive import +
+  registry entry only)
+- `packages/localizer/tests/test_untappd_plugin.py` (new)
 
 **Test Guidance**:
-- This is the second-riskiest subtask in the plan (large file, four view-dispatch branches). After
-  writing the new filter-specific tests, re-run the entire `tests/test_geo_explorer.py` file and
-  confirm the exact same pass count as before this change — this is the load-bearing regression
-  check, since none of the four existing view-dispatch tests populate `swarm_df` today and must
-  keep passing completely unmodified.
-- Build a mixed-source `swarm_df` fixture with at least one row's `lat`/`lng`/`city` unique to
-  `"swarm"` and one unique to `"google_timeline"`, so filtering-by-source assertions can check for
-  presence/absence of specific values, not just row counts.
-- Test the check-in dot layer in both `_render_2d_map` (via its `ci` groupby, lines ~559-576) and
-  `_render_3d_globe` (via its `checkin_geo` groupby, lines ~275-438) — these are the two independent
-  consumption points of the same filtered `swarm_df` and both must reflect the filter. Do **not**
-  test `_build_city_stats()`/the "By City" breakdown table against `swarm_df` — that path only ever
-  consumes `music_df` and is explicitly out of scope (see Acceptance Criterion #5's regression
-  guard); a test asserting swarm data appears there would be testing for a regression, not a
-  feature.
-- Verify the selectbox is only rendered when `has_swarm` — mock `st.selectbox` with a side-effect
-  function keyed by label (like the existing `test_us_states_view_dispatches`'s `_sel_side_effect`
-  pattern) so adding the new call doesn't silently break the Artist-selectbox's expected return
-  value in tests that do populate `swarm_df`.
-- No concurrency, network I/O, or database-write risk domains apply to this subtask (pure
-  Streamlit widget wiring over in-memory DataFrames) — standard Streamlit-mock test technique
-  already used throughout this file suffices.
+- Cover every edge case issue #20 names explicitly: basic load, unrated check-in,
+  check-in without a venue, empty CSV — each its own test.
+- Also cover: `created_at` parsed correctly (both date-format variants above), a
+  configured-but-nonexistent `checkins_csv` path raising `FileNotFoundError`, an
+  unconfigured plugin (`checkins_csv=None`, no `LocalizerSettings` override) yielding
+  nothing rather than raising, and the `since` cursor excluding an older row.
+- Verify `raw_json` round-trips through `json.loads` cleanly on every row, including
+  rows with `None` values inside it (proves no stray `NaN`/non-serializable value
+  leaks in from the float-parsing logic).
+- Test `get_config_fields()` and `get_manual_download_instructions()` shape/wording
+  the same way the other two subtasks do.
+- Do not route any test through `LocalizerStore`/DuckDB — isolate `fetch_records()`
+  with `tmp_path`-based CSV fixtures, matching every sibling plugin test file.
 
 **Test Files**:
-`tests/test_geo_explorer.py` (edit — appended new test classes; zero modification to any
-pre-existing test method) — RED-confirmed (`python -m pytest tests/test_geo_explorer.py -v
---no-cov`: 40 collected, 35 passed / 5 failed; baseline before this change was 30 passed, 0
-failed, confirming all 30 pre-existing tests still pass unmodified and exactly 10 new tests
-were added). `core/source_filter.py` now exists (Subtask 3 is `APPROVED`), but per the task's
-instruction, `pages.geo_explorer.get_source_options`/`filter_by_source` are mocked with
-`create=True` at the consuming module's namespace (the import doesn't exist in
-`pages/geo_explorer.py` yet) — this tests the page's *wiring* to the helper, independent of
-`core/source_filter.py`'s own implementation (already covered by `tests/test_source_filter.py`).
+**Recovery note**: this subtask's original test file was lost to the same collision
+documented in Subtask 2's Test Files section, before any coder had touched Untappd —
+so this was simply re-run as a normal test-ahead pass, entirely inside the isolated
+worktree (`C:\Users\johns\Code\autobiographer\.claude\worktrees\
+localizer-plugins-flickr-untappd`), with no recovery/reconstruction needed.
 
-New test classes:
-- `TestGeoExplorerSourceFilterGating` (2 tests, both pass today by design — regression/gating
-  guards, per the same "passes today" pattern already established in Subtask 5):
-  - `test_source_selectbox_not_called_when_swarm_df_none`
-  - `test_source_selectbox_not_called_when_swarm_df_empty`
-- `TestGeoExplorer2DMapSourceFilterWiring` (4 tests, all RED):
-  - `test_swarm_selection_filters_checkin_dots_by_artist_mode` — RED: `filter_by_source`
-    never called (0 times)
-  - `test_swarm_selection_filters_checkin_dots_by_city_mode` — RED: unfiltered swarm_df (2
-    rows) reaches `_render_2d_map` instead of the filtered 1 row (`2 != 1`)
-  - `test_all_selection_keeps_full_checkin_dataset` — RED: `filter_by_source` never called
-    (strengthened from an initially-vacuous pass so it's a genuine pre-implementation failure,
-    not just a coincidental row-count match)
-  - `test_selectbox_populated_from_get_source_options` — RED: `get_source_options` never
-    called (0 times)
-- `TestGeoExplorer3DGlobeSourceFilterWiring` (1 test, RED):
-  - `test_swarm_selection_filters_checkin_dots_in_3d_view` — RED: `filter_by_source` never
-    called (0 times); proves the same filtered swarm_df must reach `_render_3d_globe`, the
-    second independent consumption point
-- `TestCityStatsRemainMusicDfOnly` (3 tests, all pass today by design — AC #5 regression
-  guards against a future coder wiring `swarm_df` into the scrobble-only city-breakdown path):
-  - `test_build_city_stats_takes_single_positional_df_argument`
-  - `test_render_city_breakdown_takes_single_music_df_argument`
-  - `test_render_atlas_city_detail_has_no_swarm_df_argument`
+`packages/localizer/tests/test_untappd_plugin.py` (new — 29 test functions: 28
+exercise the plugin, 1 is a `csv.DictReader` fixture sanity check with no plugin
+import, expected to pass immediately and stay passing after implementation).
+Confirmed RED: `cd packages/localizer && ../../venv/Scripts/python.exe -m pytest
+tests/test_untappd_plugin.py -v --no-cov` → **28 failed, 1 passed** (the 1 pass is
+the fixture sanity check, not a plugin test). All 28 plugin-test failures are either
+`ModuleNotFoundError: No module named 'localizer.plugins.untappd'` or, for
+`test_untappd_is_registered`, an `AssertionError` on `REGISTRY` membership — no
+vacuous passes.
 
-`ruff check tests/test_geo_explorer.py` — all checks passed.
+Test names: `test_untappd_plugin_id`, `test_untappd_fetch_mode_manual`,
+`test_untappd_output_tables_events`, `test_untappd_is_registered`,
+`test_untappd_get_config_fields_shape`, `test_untappd_manual_download_instructions`,
+`test_untappd_fetch_records_from_csv_count`, `test_untappd_required_keys_present`,
+`test_untappd_source_id_is_untappd`, `test_untappd_fetched_at_is_recent`,
+`test_untappd_label_sublabel_category_mapping`,
+`test_untappd_created_at_space_separated_parses`,
+`test_untappd_created_at_t_separated_parses`,
+`test_untappd_created_at_formats_are_equivalent`,
+`test_untappd_unparseable_created_at_falls_back_to_fetched_at`,
+`test_untappd_rated_checkin_rating_is_float`,
+`test_untappd_unrated_checkin_rating_is_none`,
+`test_untappd_checkin_with_venue_has_float_lat_lng_in_raw_json`,
+`test_untappd_checkin_without_venue_has_none_lat_lng_in_raw_json`,
+`test_untappd_no_top_level_venue_lat_lng_keys` (guards AC caution: venue lat/lng must
+only be checked via `json.loads(raw_json)`, never a top-level `record` key, since
+`events` has no such DB column),
+`test_untappd_raw_json_round_trips_and_preserves_fields`,
+`test_untappd_raw_json_none_values_round_trip`,
+`test_untappd_empty_csv_yields_empty_list`, `test_untappd_missing_csv_raises_file_not_found`,
+`test_untappd_missing_csv_error_mentions_untappd`,
+`test_untappd_unconfigured_yields_nothing`, `test_untappd_since_cursor_excludes_older_row`,
+`test_untappd_loader_has_no_network_imports`, `test_untappd_parses_header_columns_via_dictreader`
+(the fixture sanity check).
 
-Prior HALT (test-ahead batch, 2026-07-07) resolved: was blocked on `Depends On: 3` because
-`core/source_filter.py` did not exist yet. Subtask 3 is now `APPROVED` and this re-run tester
-pass wrote the RED tests above.
-
-**Implementation Notes**:
-In `pages/geo_explorer.py`, added `from core.source_filter import filter_by_source,
-get_source_options` to the module-level imports (alphabetically placed between the
-`components.theme` and `pages.artist_geography` imports, mirroring the existing import
-ordering convention).
-
-Inside `render_geo_explorer()`'s existing "⚡ Filter" popover, added:
-```python
-if has_swarm and swarm_df is not None:
-    selected_source = st.selectbox(
-        "Source", get_source_options(swarm_df), key="geo_source_filter"
-    )
-```
-placed immediately after the existing `has_music`-gated Artist selectbox, mirroring its
-gating pattern exactly. A `selected_source = "All"` default was added alongside the
-existing `selected_artist = "All"` default (used when `has_swarm` is False, so the later
-unconditional filter call still has a defined value).
-
-Immediately after the existing `music_df` date/artist filtering block (right before the
-"Share button" section), added a single unconditional line:
-```python
-swarm_df = filter_by_source(swarm_df, selected_source)
-```
-This is safe to call unconditionally (even when `has_swarm` is False, i.e. `swarm_df` is
-`None`/empty) because `filter_by_source()` (Subtask 3) gracefully passes through
-`None`/empty/`"All"`/missing-`source_id` inputs without raising — confirmed by
-`core/source_filter.py`'s own test suite (`tests/test_source_filter.py`, all passing).
-Both `_render_3d_globe` and `_render_2d_map` are called further down with this same
-(possibly-filtered) `swarm_df` local variable, so both view-dispatch branches
-automatically see the filtered frame — no per-view-mode duplication of filtering logic,
-as required by the plan.
-
-`_build_city_stats()`, `_render_city_breakdown()`, and `_render_atlas_city_detail()` were
-not touched at all — confirmed no lines in this diff fall within their function bodies;
-they continue to receive only `music_df` and remain untouched, matching AC #5's
-regression guard (`TestCityStatsRemainMusicDfOnly`'s three signature-inspection tests all
-pass unmodified).
-
-The test file (`tests/test_geo_explorer.py`) was already written by the tester agent in
-the RED phase (`TestGeoExplorerSourceFilterGating`,
-`TestGeoExplorer2DMapSourceFilterWiring`, `TestGeoExplorer3DGlobeSourceFilterWiring`,
-`TestCityStatsRemainMusicDfOnly`); no test-file edits were made in this GREEN phase.
-
-No deviations from the plan; no files touched beyond `pages/geo_explorer.py` (the test
-file was already written by the tester).
-
-Ran `python -m pytest tests/test_geo_explorer.py -v --no-cov`: 40 passed, 0 failed (30
-pre-existing tests unmodified and passing + all 10 new tests from this subtask, zero
-regressions — exactly the pass count the tester reported as the target).
-
-Ran the scoped set including Subtasks 1, 2, and 3's GREEN/APPROVED tests: `python -m
-pytest tests/test_geo_explorer.py tests/test_localizer_frames.py tests/test_sidebar.py
-tests/test_source_filter.py -v --no-cov`: 82 passed, 0 failed.
-
-Ran `python -m ruff check pages/geo_explorer.py`: all checks passed. Ran `python -m ruff
-format --check pages/geo_explorer.py`: 1 file already formatted, no changes needed. Ran
-`python -m mypy pages/geo_explorer.py`: no issues found.
-
-**Review Notes**:
-Code Review: APPROVED — checks clean
-
-Automated checks (scoped to the current subtask's Test Files entry
-(`tests/test_geo_explorer.py`) plus Subtasks 1, 2, and 3's GREEN/APPROVED test files
-(`tests/test_localizer_frames.py`, `tests/test_sidebar.py`, `tests/test_source_filter.py`);
-Subtask 5's `tests/test_places.py` is excluded since Subtask 5 is still `RED`):
-- `python -m ruff check pages/geo_explorer.py tests/test_geo_explorer.py` — All checks passed!
-- `python -m ruff format --check pages/geo_explorer.py tests/test_geo_explorer.py` — 2 files already formatted
-- `python -m mypy pages/geo_explorer.py` — no issues found
-- `python -m pytest tests/test_geo_explorer.py tests/test_localizer_frames.py tests/test_sidebar.py tests/test_source_filter.py -v --no-cov` — 82 passed, 0 failed
-
-Diff review (`git diff HEAD -- pages/geo_explorer.py`, +9/-0, read in full alongside
-surrounding context lines 1100-1240): matches the plan exactly. One new import
-(`from core.source_filter import filter_by_source, get_source_options`, alphabetically
-placed), a `selected_source = "All"` default alongside the existing `selected_artist`
-default, the gated `if has_swarm and swarm_df is not None:` selectbox block placed
-directly after the `has_music`-gated Artist selectbox (mirroring its pattern exactly),
-and a single unconditional `swarm_df = filter_by_source(swarm_df, selected_source)` line
-placed after the `music_df` date/artist filtering block and before the Share button
-section. No dead code, no commented-out blocks, no secrets/tokens, no N+1 or hot-path
-synchronous-call concerns (pure in-memory Streamlit widget wiring over DataFrames).
-
-Focused check on the two flagged risk areas:
-- **AC #5 (city-stats regression guard)**: grepped every `swarm_df` reference in the
-  file — all occurrences fall in `_render_3d_globe` (lines 253-281),
-  `_render_2d_map` (lines 512-564), and `render_geo_explorer` itself (lines 1049-1236).
-  None fall within `_build_city_stats` (794-869), `_render_atlas_city_detail` (871-946),
-  or `_render_city_breakdown` (992-1036) — confirmed via `git diff`, which shows zero
-  changed lines in that range, and via `inspect.signature` checks
-  (`test_build_city_stats_takes_single_positional_df_argument`,
-  `test_render_city_breakdown_takes_single_music_df_argument`,
-  `test_render_atlas_city_detail_has_no_swarm_df_argument`), all passing. This is the
-  exact defect the plan-review round flagged and it is fully closed — zero diff in that
-  code path.
-- **AC #3 (selectbox never called when `has_swarm` is False)**: the implementation's
-  gate is `if has_swarm and swarm_df is not None:` (line 1132), matching
-  `TestGeoExplorerSourceFilterGating`'s two tests
-  (`test_source_selectbox_not_called_when_swarm_df_none`,
-  `test_source_selectbox_not_called_when_swarm_df_empty`), both of which assert — via
-  `_assert_source_selectbox_never_called` — that no `st.selectbox` call in the entire
-  render was made with `"Source"` as its first positional arg (not merely that a shared
-  mock wasn't called at all, which would be a weaker/vacuous check since the same
-  `st.selectbox` mock also serves the Artist selectbox). Both tests pass.
-
-Reviewed the remaining three Acceptance Criteria against non-vacuous, specific
-assertions (not just row counts):
-- AC #1/#2 (Swarm-only filter reaches `_render_2d_map`/`_render_3d_globe`'s dot layers
-  in both "By Artist" and "By City" modes; "All" is a true passthrough) —
-  `test_swarm_selection_filters_checkin_dots_by_artist_mode`,
-  `..._by_city_mode`, and `test_swarm_selection_filters_checkin_dots_in_3d_view` each
-  assert a specific Swarm-only lat value (64.13) is present and the
-  Google-Timeline-only lat value (52.52) is absent from what reaches the render
-  function — not just a row-count match. `test_all_selection_keeps_full_checkin_dataset`
-  explicitly asserts `filter_by_source` was still called (not vacuously skipped) even
-  though "All" leaves the row count unchanged, avoiding a coincidental-pass trap.
-- AC #4 (pre-existing tests unmodified) — confirmed via the pytest run: 30 pre-existing
-  + 10 new = 40 tests in this file, all passing, matching the coder's reported count
-  exactly.
-
-No issues found that require reversal to RED. Ready for the owner agent.
-
-Owner Review: APPROVED — Independently re-verified, not just re-reading the code-review notes:
-
-- Read `pages/geo_explorer.py`'s diff in full (`git diff HEAD -- pages/geo_explorer.py`, +9/-0,
-  purely additive) and traced the actual data flow by hand: `selected_source` defaults to
-  `"All"`; the gated `if has_swarm and swarm_df is not None:` selectbox block (lines 1132-1135)
-  mirrors the existing `has_music`-gated Artist selectbox exactly; the unconditional
-  `swarm_df = filter_by_source(swarm_df, selected_source)` (line 1208) runs once, right before
-  view dispatch (lines 1224-1240), and both `_render_3d_globe` and `_render_2d_map` receive this
-  same filtered local variable positionally — confirmed by reading the dispatch call sites
-  directly, not inferring from the coder's notes.
-- Read `_build_city_stats(df)` (single param `df`), `_render_city_breakdown(music_df)` (single
-  param `music_df`), and `_render_atlas_city_detail(city, city_stats, full_df)` (no `swarm_df`
-  param) directly via their function definitions — all three match
-  `TestCityStatsRemainMusicDfOnly`'s signature-inspection assertions exactly, closing AC #5's
-  regression guard with zero diff in that code range.
-- Re-ran the scoped test suite independently: `python -m pytest tests/test_geo_explorer.py
-  tests/test_localizer_frames.py tests/test_sidebar.py tests/test_source_filter.py -v --no-cov`
-  → 82 passed, 0 failed. `python -m ruff check pages/geo_explorer.py tests/test_geo_explorer.py`
-  → all checks passed. `python -m ruff format --check pages/geo_explorer.py
-  tests/test_geo_explorer.py` → 2 files already formatted. `python -m mypy pages/geo_explorer.py`
-  → no issues found.
-- Confirmed via `git diff HEAD -- tests/test_geo_explorer.py` that the 495-line test-file diff is
-  purely additive (0 deleted lines; the file's line count went from 482 to 977) — AC #4's "zero
-  modification to existing assertions" claim holds exactly, not just by count-matching.
-- Read the new test classes (`TestGeoExplorerSourceFilterGating`,
-  `TestGeoExplorer2DMapSourceFilterWiring`, `TestGeoExplorer3DGlobeSourceFilterWiring`,
-  `TestCityStatsRemainMusicDfOnly`) in full: assertions check specific lat values (64.13 present,
-  52.52 absent) and exact row counts reaching `_render_2d_map`/`_render_3d_globe`, not just
-  "something changed" — non-vacuous per Test Guidance. `test_all_selection_keeps_full_checkin_dataset`
-  explicitly asserts `filter_by_source` was called even though "All" leaves row count unchanged,
-  avoiding a coincidental-pass trap.
-- All 5 Acceptance Criteria independently verified: AC #1/#2 (Swarm-only and "All" filtering
-  reaching both render functions, verified by specific lat presence/absence and row counts), AC #3
-  (`TestGeoExplorerSourceFilterGating`'s two gating tests), AC #4 (diff-confirmed zero
-  modification to pre-existing tests), AC #5 (signature-inspection tests matching the untouched
-  city-stats code path).
-- Simplicity/naming/style: the diff is minimal (+9 lines), no dead code, no premature
-  abstraction — `selected_source` mirrors the existing `selected_artist` naming and gating
-  convention exactly. No domain-specific risk patterns apply (pure Streamlit widget wiring over
-  in-memory DataFrames; no concurrency, network I/O, LLM parsing, background jobs, or DB writes).
-
-This subtask does not close the `geo-source-filter-ui` PR group — Subtask 5 is still `RED`.
-Advancing `current` to 5 per the standard owner workflow.
-
-**Housekeeping note**: Subtask 5's section below was missing its `### Subtask 5 — ...` heading
-(its fields ran on directly after this subtask's Review Notes with no section separator) — added
-the missing heading below as a structural fix; no content was changed.
-
----
-
-### Subtask 5 — Wire the source filter into Check-in Insights
-
-**Status**: APPROVED
-
-**PR Group**: geo-source-filter-ui
-
-**Depends On**: 3
-
-**Description**:
-Add the same filter pattern to `pages/places.py::render_checkin_insights()`. Immediately after the
-existing empty-state check (`if swarm_df is None or swarm_df.empty: ... return`), add
-`st.selectbox("Source", get_source_options(swarm_df), key="checkin_source_filter")` and apply
-`swarm_df = filter_by_source(swarm_df, selected_source)` before the shareable HTML export
-(`build_checkin_insights_html`) and the country/city `groupby` breakdowns — so the filter affects
-the exported HTML and both breakdown tables/charts consistently. If filtering narrows `swarm_df` to
-empty (e.g. a user selects a source with zero rows after some other future filter interacts with
-it), show an informative `st.info` message and return, rather than letting the country/city
-`groupby` calls run on an empty frame and render blank charts.
-
-**Acceptance Criteria**:
-- [ ] With a mixed-source `swarm_df` and the selectbox mocked to return `"Swarm"`, the "By Country"
-  and "Top Cities" breakdown tables only reflect rows whose `source_id == "swarm"` — verified via a
-  specific country/city value present only in Google-Timeline-tagged rows being absent from the
-  output tables.
-- [ ] `build_checkin_insights_html()` is called with the filtered `swarm_df`, not the original
-  (verified via a mock call-arg inspection asserting the argument's row count/content matches the
-  filtered set).
-- [ ] With the selectbox mocked to return `"All"`, output row counts match the unfiltered
-  `swarm_df` exactly (no regression from today's behavior).
-- [ ] When `swarm_df` is `None` or empty (today's existing empty-state test), the existing `st.info`
-  empty-state message still fires and the function returns before the new selectbox is ever
-  called — zero behavior change for the no-data case.
-- [ ] Filtering down to zero rows (a source with no matching rows) shows an `st.info` message and
-  does not raise inside the `groupby("country")`/`groupby(["city", "country"])` calls.
-
-**Files to Touch**:
-- `pages/places.py` (edit: `render_checkin_insights()` — add gated `st.selectbox("Source", ...)`
-  after the empty-state check; apply `filter_by_source()` before the HTML export and both
-  breakdowns; handle the post-filter-empty case; import `get_source_options`, `filter_by_source`
-  from `core.source_filter`)
-- `tests/test_places.py` (new — no test file exists yet for `pages/places.py`; create one scoped to
-  `render_checkin_insights()` following this repo's existing Streamlit-mock conventions from
-  `tests/test_geo_explorer.py`)
-
-**Test Guidance**:
-- No existing test file covers `pages/places.py` at all (confirmed via repo-wide search) — the new
-  `tests/test_places.py` must include, at minimum: the pre-existing-equivalent empty-state test
-  (swarm_df `None`/empty → `st.info` shown, no crash), the "All" passthrough case, the "Swarm"-only
-  filtered case (with specific country/city presence/absence assertions), the HTML-export
-  call-argument assertion, and the post-filter-empty-result case.
-- Build a mixed-source fixture with at least one row's `country`/`city` unique to `"swarm"` and one
-  unique to `"google_timeline"` (parallel to Subtask 4's fixture design) so presence/absence
-  assertions are meaningful.
-- Follow this repo's existing `MagicMock`-based Streamlit mocking convention (see
-  `tests/test_geo_explorer.py`'s `_make_col_mock`/`_cols_side_effect` helpers) rather than
-  introducing a new mocking style.
-- No concurrency, network I/O, or database-write risk domains apply — pure Streamlit widget wiring
-  over an in-memory DataFrame plus an HTML-export function call.
-
-**Test Files**:
-`tests/test_places.py` (new — no prior test file existed for `pages/places.py`) — RED-confirmed (`pytest tests/test_places.py -v --no-cov`: 5 of 7 fail for genuine reasons tied to absent implementation; 2 empty-state regression guards pass today by design, per AC #4).
-- `TestRenderCheckinInsightsEmptyState::test_none_swarm_df_shows_info_and_skips_selectbox` (passes today — regression guard)
-- `TestRenderCheckinInsightsEmptyState::test_empty_swarm_df_shows_info_and_skips_selectbox` (passes today — regression guard)
-- `TestRenderCheckinInsightsSourceFilter::test_selectbox_populated_from_get_source_options` (RED)
-- `TestRenderCheckinInsightsSourceFilter::test_swarm_only_filter_narrows_country_and_city_breakdowns` (RED, AC #1)
-- `TestRenderCheckinInsightsSourceFilter::test_html_export_receives_filtered_dataframe` (RED, AC #2)
-- `TestRenderCheckinInsightsSourceFilter::test_all_selection_keeps_full_dataset` (RED, AC #3)
-- `TestRenderCheckinInsightsSourceFilter::test_post_filter_empty_shows_info_and_skips_breakdowns` (RED, AC #5)
-- Note: `core/source_filter.py` (Subtask 3) doesn't exist yet either, but this tester did not halt — it mocked `pages.places.get_source_options`/`pages.places.filter_by_source` with `create=True`, testing the integration (does `render_checkin_insights` call and thread these correctly) independent of Subtask 3's actual implementation, which has its own separate test coverage.
+Tests expect `UntappdPlugin.fetch_records(self, since=None, progress_cb=None,
+checkins_csv=None)` with `checkins_csv` resolved from
+`LocalizerSettings().get_setting("checkins_csv")` when `None`, `raw_json` built as
+`dict(row)` plus overridden `rating`/`venue_name`/`venue_lat`/`venue_lng` keys (all
+`None` when blank, never `NaN`/string), and `label`/`sublabel`/`category` =
+`brewery_name`/`beer_name`/`beer_type` per the plan's explicit mapping (fixture row:
+brewery `"Test Brewery Co."` / beer `"Hazy IPA"` / style `"IPA"`). No
+`LocalizerStore`/DuckDB involved — `tmp_path`-based CSV fixtures only. No
+implementation files exist yet and `plugins/__init__.py` was not touched.
 
 **Implementation Notes**:
-In `pages/places.py`, added `from core.source_filter import filter_by_source,
-get_source_options` to the module imports (alphabetically placed between
-`components.theme` and `export_html`, mirroring the existing import ordering
-convention — `core.source_filter` sorts between them).
+Created `UntappdPlugin` under
+`packages/localizer/src/localizer/plugins/untappd/` mirroring
+`letterboxd/loader.py`'s structure almost exactly, per the subtask spec:
 
-Inside `render_checkin_insights()`, immediately after the existing empty-state
-check (`if swarm_df is None or swarm_df.empty: ... return`), added:
-```python
-selected_source = st.selectbox("Source", get_source_options(swarm_df))
-swarm_df = filter_by_source(swarm_df, selected_source)
+- `packages/localizer/src/localizer/plugins/untappd/__init__.py` — new,
+  empty package marker (matches the `letterboxd`/`swarm` convention).
+- `packages/localizer/src/localizer/plugins/untappd/loader.py` — new.
+  `UntappdPlugin` has no custom `__init__` (the CSV path is resolved
+  lazily inside `fetch_records()`, exactly like Letterboxd, not in the
+  constructor like Swarm/Flickr — the test suite instantiates
+  `UntappdPlugin()` with zero args and passes `checkins_csv` per-call).
+  `fetch_records(self, since=None, progress_cb=None, checkins_csv=None)`
+  resolves `checkins_csv` from `LocalizerSettings().get_setting("checkins_csv")`
+  inside a `try/except ImportError: pass` guard when not passed in; if still
+  `None`, yields nothing. `_parse_csv()` raises `FileNotFoundError` (message
+  names the path and points at `untappd.com` → Settings → Export Data) when
+  a configured path doesn't exist, then parses with `csv.DictReader`.
+  `created_at` is parsed via the same forgiving
+  `str.replace(" ", "T")` + `datetime.fromisoformat()` approach used by
+  `swarm/loader.py`'s fallback parser, falling back to this batch's
+  `fetched_at` on any `ValueError` (covers both the space-separated and
+  T-separated formats identically, and the fully-unparseable case).
+  `label`/`sublabel`/`category` map to `brewery_name`/`beer_name`/
+  `beer_type` per issue #20. A small private `_parse_optional_float()`
+  helper parses `rating_score`/`venue_lat`/`venue_lng` to a Python `float`
+  or `None` (never a raw string, never `NaN`) — used for all three fields.
+  `raw_json` is built as `dict(row)` (preserving `comment`,
+  `flavor_profiles`, `serving_type`, `photo_url`, and the original raw
+  `rating_score`/`venue_lat`/`venue_lng`/`venue_name` columns verbatim)
+  with `"rating"`, `"venue_name"`, `"venue_lat"`, `"venue_lng"` added/
+  overridden as typed values on top, then `json.dumps()`'d — matching
+  Subtask 1's letterboxd rating-fix reasoning (JSON `null`, not `NaN`, for
+  "missing" inside a JSON-embedded field). The `since` cursor is applied
+  before yielding (`timestamp <= since` is skipped), consistent with the
+  other plugins.
+- `packages/localizer/src/localizer/plugins/__init__.py` — edited
+  additively only inside `load_builtin_plugins()`: one import line
+  (`from localizer.plugins.untappd.loader import UntappdPlugin`) inserted
+  alphabetically after the `swarm` import, and one
+  `REGISTRY[UntappdPlugin.PLUGIN_ID] = UntappdPlugin` line appended after
+  the existing `FlickrPlugin` registration line. No existing line
+  (including Subtask 2's Flickr lines) was reordered, removed, or
+  otherwise touched.
 
-if swarm_df is None or swarm_df.empty:
-    st.info("No check-ins match the selected source filter.")
-    return
-```
-The reassigned (possibly-filtered) `swarm_df` local variable then flows
-unchanged into the existing `build_checkin_insights_html()` call, the "By
-Country" `groupby("country")`, and the "Top Cities"
-`groupby(["city", "country"])` — all three now see only the filtered rows, and
-in a single place, matching the plan's "filter once, before every consumer"
-requirement.
+No deviations from the plan; no files touched beyond the four listed in
+Subtask 3's "Files to Touch".
 
-**One deviation from the plan's literal wording, required to satisfy the
-pre-written test**: the Description said to call
-`st.selectbox("Source", get_source_options(swarm_df), key="checkin_source_filter")`.
-However, `tests/test_places.py::TestRenderCheckinInsightsSourceFilter::test_selectbox_populated_from_get_source_options`
-asserts `mock_sel.assert_any_call("Source", ["All", "Google Timeline", "Swarm"])` —
-`Mock.assert_any_call` performs strict equality on the full call signature
-(positional args *and* kwargs), so a call carrying an extra `key=...` kwarg
-would not match this assertion and the test would fail. Since I must not
-modify the test file, I omitted the `key` kwarg — `st.selectbox("Source",
-get_source_options(swarm_df))` — which is safe in practice because this is
-the only `st.selectbox` call in `render_checkin_insights()` (no risk of a
-duplicate-widget-ID collision that a `key` would otherwise guard against).
-Flagging this for the owner's awareness since it's a deliberate, test-driven
-departure from the Description's literal code sample, not an oversight.
+Test run: `cd packages/localizer && ../../venv/Scripts/python.exe -m pytest
+tests/test_untappd_plugin.py -v --no-cov` → **29 passed** (28 plugin tests +
+1 fixture sanity check).
 
-No other files were touched beyond `pages/places.py`; `tests/test_places.py`
-was already fully written by the tester agent in the RED phase and was not
-modified in this GREEN pass.
+Full sub-suite: `cd packages/localizer && ../../venv/Scripts/python.exe -m
+pytest -q --no-cov` → **278 passed**, 0 failures (up from the prior
+249-passed baseline noted in Subtask 2's Owner Review, +29 for this
+subtask's new test file — no regressions in Flickr, Letterboxd, or any
+other sibling plugin's tests).
 
-Ran `python -m pytest tests/test_places.py -v --no-cov`: 7 passed, 0 failed
-(2 pre-existing-equivalent empty-state regression guards + 5 new tests, all
-green).
-
-Ran the scoped set (this subtask's tests plus every `GREEN`/`APPROVED`
-subtask's tests — Subtasks 1-4): `python -m pytest tests/test_places.py
-tests/test_geo_explorer.py tests/test_localizer_frames.py tests/test_sidebar.py
-tests/test_source_filter.py -v --no-cov`: 89 passed, 0 failed.
-
-Ran `python -m ruff check pages/places.py tests/test_places.py`: all checks
-passed. Ran `python -m ruff format --check pages/places.py
-tests/test_places.py`: `pages/places.py` already formatted; `tests/test_places.py`
-flags one pre-existing long-line wrap (line 245,
-`pd.testing.assert_frame_equal(html_arg.reset_index(...), filtered.reset_index(...))`)
-that predates this coder pass — confirmed via `git status` that
-`tests/test_places.py` is untracked and was not edited by me in this pass, so
-this is not a new violation introduced by my work and, per this task's
-explicit instruction not to modify the test file, was left as-is. Ran
-`python -m mypy pages/places.py`: no issues found.
+Lint: `./venv/Scripts/python.exe -m ruff check --fix
+packages/localizer/src/localizer/plugins/untappd/
+packages/localizer/src/localizer/plugins/__init__.py` → "All checks
+passed!"; `./venv/Scripts/python.exe -m ruff format
+packages/localizer/src/localizer/plugins/untappd/
+packages/localizer/src/localizer/plugins/__init__.py` → "3 files left
+unchanged" (already correctly formatted, no auto-fix needed). `./venv/
+Scripts/python.exe -m mypy
+packages/localizer/src/localizer/plugins/untappd/loader.py` → "Success: no
+issues found in 1 source file" (ignoring the known pre-existing
+Python-3.9-not-supported config warning, per instructions).
 
 **Review Notes**:
-Code Review: NEEDS_REVISION — automated checks + two scrutiny items below; status reverted GREEN → RED.
+Code Review: skipped by orchestrator instruction — status went GREEN straight to
+owner review (mirrors Subtask 2's mid-task-collision shortcut), so this pass covers
+both code review and owner review.
 
-Automated checks (scoped to this subtask's `tests/test_places.py` plus Subtasks 1-4's
-GREEN/APPROVED test files):
-- `python -m ruff check pages/places.py tests/test_places.py` — All checks passed!
-- `python -m ruff format --check pages/places.py tests/test_places.py` — **FAILS**:
-  `pages/places.py` already formatted, but `tests/test_places.py` "would reformat" (1 file).
-  `ruff format --diff` shows the offending block is at line ~245 (the
-  `pd.testing.assert_frame_equal(html_arg.reset_index(...), filtered.reset_index(...))` call
-  in `test_html_export_receives_filtered_dataframe`), which ruff wants wrapped across lines.
-- `python -m mypy pages/places.py` — no issues found
-- `python -m pytest tests/test_places.py tests/test_geo_explorer.py tests/test_localizer_frames.py tests/test_sidebar.py tests/test_source_filter.py --no-cov -q` — 89 passed, 0 failed
+**Owner Review: APPROVED** — independently re-verified from scratch, not from prior
+notes:
 
-Finding 1 — ruff format gate is not clean, and the coder's rationale for leaving it doesn't
-hold. CLAUDE.md's Local Quality Gate (Section 7, Step 2) requires `ruff format --check .` to
-pass with **zero errors** before any commit — there is no carve-out for "pre-existing" or
-"not my file" formatting debt. The coder's notes call this "not their file to edit per task
-scope," but `tests/test_places.py` is explicitly listed as a **new** file under this
-subtask's own "Files to Touch" (no test file for `pages/places.py` existed before this
-subtask) — it was created by the tester agent in this same subtask's RED phase, not
-inherited from an earlier subtask. There is no other-subtask ownership conflict here; it is
-squarely in scope and must be reformatted (`python -m ruff format tests/test_places.py`)
-before this subtask can be approved. This is a mechanical, test-semantics-neutral fix (ruff
-only rewraps the `assert_frame_equal(...)` call across lines) — it does not require
-re-litigating any test's assertions, consistent with the task's instruction that a test-only
-formatting fix doesn't need to reopen test-semantics debate.
+- Read `untappd/loader.py`, `untappd/__init__.py` (confirmed 0-byte package marker,
+  matching sibling convention), the additive diff to `plugins/__init__.py`, and all
+  538 lines of `test_untappd_plugin.py`. Cross-referenced against `letterboxd/loader.py`
+  (the sibling it mirrors) and `base.py`'s `SourcePlugin` ABC.
+- Traced every AC line-by-line: `label`/`sublabel`/`category` = `brewery_name`/
+  `beer_name`/`beer_type` verified against the plan's named fixture values ("Test
+  Brewery Co."/"Hazy IPA"/"IPA"); `created_at` parsing (`.replace(" ", "T")` +
+  `datetime.fromisoformat()`) correctly unifies space- and T-separated forms and
+  falls back to `fetched_at` inside a `try/except ValueError` on any unparseable
+  value; the shared `_parse_optional_float()` helper returns a typed `float` or
+  `None` (never a raw string, never `NaN`) for `rating_score`/`venue_lat`/`venue_lng`,
+  used consistently for all three; `venue_lat`/`venue_lng` never leak as top-level
+  record keys (own dedicated test); `FileNotFoundError` is raised only for a
+  configured-but-missing path, naming both the path and `untappd.com`; an
+  unconfigured plugin (`checkins_csv=None`, no settings override) yields nothing
+  rather than raising; the `since` cursor correctly excludes rows with
+  `timestamp <= since`.
+- Re-ran independently (not trusting the coder's reported numbers):
+  `pytest tests/test_untappd_plugin.py -v --no-cov` → **29 passed**; `ruff check`
+  on all 4 touched files (`untappd/__init__.py`, `untappd/loader.py`,
+  `plugins/__init__.py`, `tests/test_untappd_plugin.py`) → All checks passed;
+  `ruff format --check` on all 4 → already formatted; `mypy` on `loader.py` →
+  no issues (ignoring the known pre-existing Python-3.9-config warning). Full
+  `packages/localizer` sub-suite → **278 passed, 0 failures** — fully green with
+  zero residual/expected failures, as required since this is the last subtask in
+  the plan.
+- Every Test Guidance item has a corresponding test (basic load, unrated check-in,
+  no-venue check-in, empty CSV, both `created_at` format variants plus their
+  equivalence, missing-path `FileNotFoundError` + message wording, unconfigured
+  yields nothing, `since` cursor, `raw_json` round-trip including `None` values,
+  `get_config_fields`/`get_manual_download_instructions` shape/wording, no
+  `LocalizerStore`/DuckDB usage) — several exceeded (top-level-key-leak guard,
+  unparseable-date fallback, no-network-import static scan, DictReader fixture
+  sanity check).
+- Scope check: `git diff --stat` on `plugins/__init__.py` shows exactly 4 additive
+  lines (2 for Flickr's import/registration from Subtask 2, 2 for Untappd's from
+  this subtask, against the pre-worktree base) — nothing reordered or removed,
+  matching the "both edits must be independently additive and non-conflicting"
+  requirement from both subtasks' specs. The 1-line `pyproject.toml` ruff-ignore
+  addition (`"packages/localizer/tests/*" = ["S", "B", "E501"]`) is the same
+  necessary, minimal, precedented line already vetted in Subtask 2's Owner Review
+  — not new scope creep introduced here.
+- No dead code, no premature abstraction, no secrets, no blocking/network calls
+  (`import requests`/`urllib`/`httpx`/`socket` absent, confirmed both by static
+  read and by the dedicated test). Naming, docstrings, and structure are
+  consistent with the `letterboxd` sibling this subtask mirrors almost exactly,
+  per the subtask's own design intent. Diff is simple and scoped exactly to the
+  subtask's Files to Touch.
 
-Finding 2 — the `key="checkin_source_filter"` omission is not an acceptable trade-off as
-implemented; the test itself has the gap, and the coder's own analogous sibling subtask
-(Subtask 4) already demonstrates the correct fix. Comparing the two subtasks' identically-named
-tests directly:
-- `tests/test_geo_explorer.py::TestGeoExplorer2DMapSourceFilterWiring::test_selectbox_populated_from_get_source_options`
-  (lines 835-865) asserts via `source_calls = [c for c in mock_sel.call_args_list if c.args and
-  c.args[0] == "Source"]` then checks `source_calls[0].args[1] == mock_get_opts.return_value` —
-  a positional-args-only check that tolerates an extra `key=...` kwarg on the same call. That
-  page's implementation *does* pass `key="geo_source_filter"` (confirmed in Subtask 4's already
-  `APPROVED` diff) and its test passes cleanly.
-- `tests/test_places.py::TestRenderCheckinInsightsSourceFilter::test_selectbox_populated_from_get_source_options`
-  (line 142) instead asserts `mock_sel.assert_any_call("Source", ["All", "Google Timeline",
-  "Swarm"])` — `assert_any_call` requires an **exact** match of the full call signature
-  (positional args and kwargs together), so it is strictly weaker/more brittle than the
-  pattern already established one subtask earlier for the identical scenario, not an
-  unavoidable constraint of Mock's API.
-- CLAUDE.md's Streamlit Conventions section calls for "explicit `session_state` keys" for
-  widget state; the subtask's own Description explicitly specified
-  `key="checkin_source_filter"` in its code sample, matching Subtask 4's already-approved
-  `key="geo_source_filter"` precedent. Dropping the key is a real, if currently low-risk,
-  inconsistency between the two sibling pages implementing the same feature — today there's
-  no second `st.selectbox` call in `render_checkin_insights()` to collide with, but that's an
-  accident of the current function body, not a designed guarantee, and it leaves this page
-  unable to participate in any future explicit-`session_state`-keyed rerun/refresh logic
-  without a follow-up patch.
-- Per the task's own framing: this is a "silently accept the weaker test as the reason to
-  drop a documented convention" situation, not a legitimate, agreed-upon deviation.
-  **Required fix**: rewrite `test_selectbox_populated_from_get_source_options`'s final
-  assertion in `tests/test_places.py` to use the same positional-args-tolerant pattern already
-  used in `tests/test_geo_explorer.py` (filter `mock_sel.call_args_list` for the `"Source"`
-  call and check its `args[1]`, ignoring `kwargs`), then add
-  `key="checkin_source_filter"` to the `st.selectbox(...)` call in
-  `pages/places.py::render_checkin_insights()` to match the plan's literal Description and
-  Subtask 4's precedent.
-
-Diff review otherwise (`git diff HEAD -- pages/places.py`, +11/-1): no dead code, no
-commented-out blocks, no secrets/tokens, no N+1 or hot-path synchronous-call concerns (pure
-in-memory Streamlit widget wiring plus one DataFrame filter call). The post-filter-empty
-guard (`if swarm_df is None or swarm_df.empty: st.info(...); return`) correctly precedes the
-HTML export and both groupby breakdowns, satisfying AC #5's "must not raise inside groupby"
-requirement. AC #1-#4 are otherwise well covered by non-vacuous assertions (specific
-country/city presence/absence, `assert_frame_equal` on the HTML-export call arg, "All"
-passthrough row-count check, and the pre-existing empty-state regression guard) — these do
-not need rework, only the two findings above.
-
-Status reverted RED so the coder can: (1) run `ruff format tests/test_places.py` to close
-the formatting gate, and (2) loosen the selectbox-call assertion to the established
-tolerant pattern and add the `key=` kwarg back to the implementation. Both are small,
-mechanical changes; nothing else in this subtask needs to change.
-
-**Implementation Notes (revision pass)**: Applied both required fixes exactly as
-diagnosed by the reviewer, with no other changes:
-
-1. **Ruff format**: Ran `python -m ruff format tests/test_places.py pages/places.py` —
-   reformatted `tests/test_places.py` (the long `assert_frame_equal(...)` call around
-   line 245 was rewrapped across lines by ruff mechanically); `pages/places.py` was
-   already formatted, left unchanged. Re-ran `python -m pytest tests/test_places.py -v
-   --no-cov` afterward to confirm the reformat didn't alter test semantics: still 7
-   passed, 0 failed.
-
-2. **`key=` kwarg restoration**: In `tests/test_places.py::TestRenderCheckinInsightsSourceFilter::test_selectbox_populated_from_get_source_options`,
-   replaced the strict `mock_sel.assert_any_call("Source", ["All", "Google Timeline",
-   "Swarm"])` with the same positional-args-tolerant pattern already used in
-   `tests/test_geo_explorer.py::TestGeoExplorer2DMapSourceFilterWiring::test_selectbox_populated_from_get_source_options`
-   (lines 835-865 there): filter `mock_sel.call_args_list` for the call whose
-   `c.args[0] == "Source"`, assert exactly one such call exists, then assert only on
-   `args[1]` (the options list), tolerant of any kwargs on that call. Then restored
-   `key="checkin_source_filter"` to the `st.selectbox(...)` call in
-   `pages/places.py::render_checkin_insights()`, matching the subtask's original
-   Description and Subtask 4's already-approved `key="geo_source_filter"` precedent.
-
-No other files or tests were touched; both fixes are exactly the mechanical/test-only
-changes the reviewer specified, with zero re-litigation of any other assertion.
-
-Verification run after both fixes:
-- `python -m pytest tests/test_places.py -v --no-cov` — 7 passed, 0 failed.
-- `python -m ruff check pages/places.py tests/test_places.py` — All checks passed!
-- `python -m ruff format --check pages/places.py tests/test_places.py` — 2 files already formatted.
-- `python -m mypy pages/places.py` — no issues found.
-- Scoped set: `python -m pytest tests/test_places.py tests/test_geo_explorer.py
-  tests/test_localizer_frames.py tests/test_sidebar.py tests/test_source_filter.py -v
-  --no-cov` — 89 passed, 0 failed (no regressions in any sibling subtask's tests).
-
-Code Review: APPROVED (re-review) — Both fixes from the prior NEEDS_REVISION round were
-independently re-verified directly against the files on disk, not just re-read from the
-coder's notes, and the full subtask was re-reviewed end to end, not just the two flagged
-points:
-
-- **Fix 1 (ruff format)**: `python -m ruff format --check pages/places.py
-  tests/test_places.py` — "2 files already formatted." The previously-offending
-  `assert_frame_equal(...)` wrap at the old line ~245 is resolved.
-- **Fix 2 (`key=` kwarg + tolerant assertion)**: confirmed via `Grep` that
-  `pages/places.py` lines 499-501 read
-  `st.selectbox("Source", get_source_options(swarm_df), key="checkin_source_filter")` —
-  the key is restored, matching the subtask's Description and Subtask 4's
-  `key="geo_source_filter"` precedent. Confirmed via `Read` that
-  `tests/test_places.py::TestRenderCheckinInsightsSourceFilter::test_selectbox_populated_from_get_source_options`
-  (lines 142-144) now filters `mock_sel.call_args_list` for the call whose
-  `c.args[0] == "Source"` and asserts only on `args[1]`, tolerant of the `key=` kwarg —
-  the same pattern used in `tests/test_geo_explorer.py`.
-
-Automated checks, re-run directly rather than trusting prior output:
-- `python -m ruff check pages/places.py tests/test_places.py` — All checks passed!
-- `python -m ruff format --check pages/places.py tests/test_places.py` — 2 files already formatted
-- `python -m mypy pages/places.py` — no issues found
-- `python -m pytest tests/test_places.py tests/test_geo_explorer.py
-  tests/test_localizer_frames.py tests/test_sidebar.py tests/test_source_filter.py -v
-  --no-cov` — 89 passed, 0 failed
-
-Full-subtask diff re-review (`git diff HEAD -- pages/places.py`, +13/-1, read in full):
-one new import (`from core.source_filter import filter_by_source, get_source_options`,
-alphabetically placed), a docstring update describing the new filter behavior, the gated
-`st.selectbox(...)`/`filter_by_source(...)` pair immediately after the existing
-empty-state check, and a post-filter-empty guard (`if swarm_df is None or
-swarm_df.empty: st.info(...); return`) placed before `build_checkin_insights_html()` and
-both `groupby` breakdowns — satisfying AC #5. No dead code, no commented-out blocks, no
-secrets/tokens, no N+1 or hot-path synchronous-call concerns (pure in-memory Streamlit
-widget wiring plus one DataFrame filter call). All 5 Acceptance Criteria remain covered by
-non-vacuous assertions in `tests/test_places.py` (specific country/city presence/absence
-for AC #1, `assert_frame_equal` on the HTML-export call arg for AC #2, "All" passthrough
-row-count check for AC #3, the pre-existing empty-state regression guard for AC #4, and
-the post-filter-empty guard test for AC #5) — nothing regressed elsewhere in this pass.
-
-No issues found. Ready for the owner agent.
-
-Owner Review: APPROVED — Independently re-verified, not just re-reading the code-review notes:
-
-- Read `pages/places.py` in full and `git diff HEAD -- pages/places.py` (+13/-1, purely
-  additive): one new import (`from core.source_filter import filter_by_source,
-  get_source_options`, alphabetically placed), a docstring update, the gated
-  `st.selectbox("Source", get_source_options(swarm_df), key="checkin_source_filter")` /
-  `filter_by_source(swarm_df, selected_source)` pair immediately after the existing
-  empty-state check, and a post-filter-empty guard (`if swarm_df is None or
-  swarm_df.empty: st.info(...); return`) placed before `build_checkin_insights_html()` and
-  both `groupby` breakdowns. The `key=` kwarg matches Subtask 4's `key="geo_source_filter"`
-  precedent, closing the finding from the earlier NEEDS_REVISION round.
-- Read `tests/test_places.py` in full (brand-new file, not just the two areas the last
-  review round touched). Traced each of the 7 tests against the implementation by hand:
-  - `TestRenderCheckinInsightsEmptyState`'s two tests confirm the new selectbox is never
-    reached when `swarm_df` is `None`/empty — matches AC #4, and the early-return happens
-    before line 499 in the source, confirmed by reading the code.
-  - `test_selectbox_populated_from_get_source_options` asserts `get_source_options` was
-    called with the original (unfiltered) `swarm_df` and that exactly one `st.selectbox`
-    call used `"Source"` as its first arg with the mocked options list as its second —
-    tolerant of the `key=` kwarg, avoiding the brittleness the prior review round flagged.
-  - `test_swarm_only_filter_narrows_country_and_city_breakdowns` traces that
-    `filter_by_source` is called with the *original* `swarm_df` and label `"Swarm"`, and
-    that both `px.bar` calls (country, city) only see the two swarm-tagged rows — verified
-    via presence of Iceland/Germany/Reykjavik/Berlin and absence of UK/France/London/Paris,
-    not just row counts. This is a non-vacuous check of AC #1.
-  - `test_html_export_receives_filtered_dataframe` confirms `build_checkin_insights_html`
-    receives the filtered (2-row) frame via `assert_frame_equal`, satisfying AC #2.
-  - `test_all_selection_keeps_full_dataset` confirms `filter_by_source` is still called
-    (with `"All"`) even though the row count is unchanged — avoiding a coincidental-pass
-    trap — satisfying AC #3.
-  - `test_post_filter_empty_shows_info_and_skips_breakdowns` confirms an `st.info` fires
-    and neither `px.bar` nor `build_checkin_insights_html` are called when the filtered
-    frame is empty, satisfying AC #5 without any groupby exception occurring (the test
-    would fail with an uncaught error otherwise).
-- Re-ran every check myself rather than trusting the notes above:
-  `python -m pytest tests/test_places.py tests/test_geo_explorer.py
-  tests/test_localizer_frames.py tests/test_sidebar.py tests/test_source_filter.py -v
-  --no-cov` → 89 passed, 0 failed. `python -m ruff check pages/places.py
-  tests/test_places.py` → all checks passed. `python -m ruff format --check
-  pages/places.py tests/test_places.py` → 2 files already formatted. `python -m mypy
-  pages/places.py` → no issues found (noting, as with Subtask 4, that `pages/` is not in
-  `pyproject.toml`'s `[tool.mypy] files` list, so the project's bare `mypy` gate does not
-  actually check this file — a pre-existing repo-wide gap unrelated to this diff, already
-  accepted at Subtask 4's approval).
-- Test Guidance coverage checked item-by-item: pre-existing-equivalent empty-state test,
-  "All" passthrough, "Swarm"-only filtered case with presence/absence assertions, HTML-export
-  call-argument assertion, and post-filter-empty case are all present. Mixed-source fixture
-  has country/city values unique to each source (Reykjavik/Iceland, Berlin/Germany vs.
-  London/UK, Paris/France). The existing `_make_col_mock`/`_cols_side_effect` mocking
-  convention from `tests/test_geo_explorer.py` is followed, not a new style. No gaps found.
-- Simplicity/naming/style: diff is minimal (+13/-1), no dead code, no premature
-  abstraction — `selected_source` mirrors `pages/geo_explorer.py`'s naming exactly. No
-  domain-specific risk patterns apply (pure Streamlit widget wiring over an in-memory
-  DataFrame plus one HTML-export call; no concurrency, network I/O, LLM parsing,
-  background jobs, or DB writes).
-- All 5 Acceptance Criteria independently verified against the passing test run and the
-  traced code paths above.
-
-This is the last subtask in the plan and the second/final subtask in the
-`geo-source-filter-ui` PR group. Both subtasks in that group (4 and 5) are now
-`APPROVED`, closing the group. Per AGENTS.md "After each subtask is APPROVED" §4, ran the
-full-suite integration gate before proceeding: `python -m pytest` (no path filter) → 905
-passed, 0 failed, exit code 0. `python -m ruff check .` → all checks passed. `python -m
-ruff format --check .` → 135 files already formatted. Proceeding to branch/commit/PR.
+Subtask 3 is complete and APPROVED. This was the last subtask in the plan — all
+three subtasks (Letterboxd field-mapping fix, Flickr, Untappd) now show
+`Status: APPROVED`. Each subtask has its own `PR Group` (`letterboxd-field-mapping-fix`,
+`flickr-plugin`, `untappd-plugin`), so per `AGENTS.md`'s "After each subtask is
+APPROVED" section, PR group `untappd-plugin` (containing only this subtask) is now
+ready to close: full-suite integration gate, branch/commit, and `gh pr create` are
+the orchestrator's responsibility, not performed here. `Plan Status` is set to
+`COMPLETE` below since no subtasks remain.
 
 ---

--- a/packages/localizer/src/localizer/plugins/__init__.py
+++ b/packages/localizer/src/localizer/plugins/__init__.py
@@ -44,6 +44,7 @@ def load_builtin_plugins() -> None:
     re-registers, because @register only fires on first module import.
     """
     from localizer.plugins.feedly.loader import FeedlyPlugin
+    from localizer.plugins.flickr.loader import FlickrPlugin
     from localizer.plugins.github.loader import GitHubPlugin
     from localizer.plugins.google_timeline.loader import GoogleTimelinePlugin
     from localizer.plugins.lastfm.loader import LastFmPlugin
@@ -58,3 +59,4 @@ def load_builtin_plugins() -> None:
     REGISTRY[RssPlugin.PLUGIN_ID] = RssPlugin
     REGISTRY[LetterboxdPlugin.PLUGIN_ID] = LetterboxdPlugin
     REGISTRY[GoogleTimelinePlugin.PLUGIN_ID] = GoogleTimelinePlugin
+    REGISTRY[FlickrPlugin.PLUGIN_ID] = FlickrPlugin

--- a/packages/localizer/src/localizer/plugins/flickr/loader.py
+++ b/packages/localizer/src/localizer/plugins/flickr/loader.py
@@ -1,0 +1,192 @@
+"""Flickr source plugin for localizer.
+
+FetchMode.MANUAL — the user must export their data from Flickr and point the
+plugin at the resulting directory of ``photo_*.json`` files.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from localizer.plugins import register
+from localizer.plugins.base import FetchMode, OutputTable, SourcePlugin
+
+_FALSY_STRINGS = {"false", "0", "", "no"}
+
+
+def _coerce_bool(value: Any) -> bool:
+    """Coerce a settings-layer value (bool or string) to a real bool.
+
+    Args:
+        value: Either an actual ``bool`` or a string round-tripped through
+            the settings layer (e.g. ``"false"``, ``"0"``, ``"no"``).
+
+    Returns:
+        ``False`` when ``value`` is a string matching (case-insensitively)
+        one of ``"false"``/``"0"``/``""``/``"no"``; ``True`` otherwise.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() not in _FALSY_STRINGS
+    return bool(value)
+
+
+@register
+class FlickrPlugin(SourcePlugin):
+    """Load Flickr photo history from a local JSON export directory.
+
+    Args:
+        export_dir: Path to the directory containing ``photo_*.json`` export
+            files. If None, resolved from ``LocalizerSettings``.
+        geotagged_only: When True (the default), photos without valid
+            latitude/longitude are skipped. When False, they are yielded
+            with NaN lat/lng. If None, resolved from ``LocalizerSettings``.
+    """
+
+    PLUGIN_ID = "flickr"
+    DISPLAY_NAME = "Flickr Photos"
+    FETCH_MODE = FetchMode.MANUAL
+    OUTPUT_TABLES = [OutputTable.PLACES]
+    ICON = ":material/photo_camera:"
+
+    def __init__(
+        self,
+        export_dir: str | None = None,
+        geotagged_only: bool | None = None,
+    ) -> None:
+        if export_dir is None:
+            try:
+                from localizer.settings import LocalizerSettings  # noqa: PLC0415
+
+                export_dir = LocalizerSettings().get_setting("export_dir") or None
+            except ImportError:
+                pass
+        self._export_dir = export_dir
+
+        if geotagged_only is None:
+            try:
+                from localizer.settings import LocalizerSettings  # noqa: PLC0415
+
+                geotagged_only = LocalizerSettings().get_setting("geotagged_only", True)
+            except ImportError:
+                geotagged_only = True
+        self._geotagged_only = _coerce_bool(geotagged_only)
+
+    def get_config_fields(self) -> list[dict[str, Any]]:
+        """Declare sidebar config fields for the Flickr plugin.
+
+        Returns:
+            List with the export directory path field and the
+            geotagged-only boolean toggle field.
+        """
+        return [
+            {
+                "key": "export_dir",
+                "label": "Flickr export directory",
+                "type": "dir_path",
+            },
+            {
+                "key": "geotagged_only",
+                "label": "Only include geotagged photos",
+                "type": "bool",
+                "default": True,
+            },
+        ]
+
+    def get_manual_download_instructions(self) -> str:
+        """Return instructions for exporting photo data from Flickr.
+
+        Returns:
+            Multi-line instruction string with export steps.
+        """
+        return (
+            "To export your Flickr photo data:\n"
+            "1. Log in at https://www.flickr.com\n"
+            "2. Go to Account Settings → Your Flickr Data\n"
+            "3. Request a full data export and wait for the download email.\n"
+            "4. Download and unzip the archive.\n"
+            "5. Point the 'Flickr export directory' setting at the unzipped\n"
+            "   folder containing the 'photo_*.json' files.\n"
+        )
+
+    def fetch_records(
+        self,
+        since: int | None = None,
+        progress_cb: Any | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Yield normalized place dicts from Flickr JSON export files.
+
+        Reads all ``photo_*.json`` files in ``export_dir`` and yields one
+        record per photo. Missing or non-existent directories yield nothing
+        gracefully; a malformed file is skipped without aborting the rest.
+
+        Args:
+            since: Optional Unix timestamp; yield only photos newer than this.
+            progress_cb: Optional progress callback (unused for manual plugins).
+
+        Yields:
+            Dicts with keys: source_id, timestamp, lat, lng, place_name,
+            place_type, raw_json, fetched_at.
+        """
+        if not self._export_dir:
+            return
+
+        export_path = Path(self._export_dir)
+        if not export_path.exists() or not export_path.is_dir():
+            return
+
+        fetched_at = int(time.time())
+
+        for json_file in sorted(export_path.glob("photo_*.json")):
+            try:
+                data = json.loads(json_file.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+
+            if not isinstance(data, dict):
+                continue
+
+            date_taken = data.get("date_taken")
+            timestamp = fetched_at
+            if date_taken:
+                try:
+                    timestamp = int(
+                        datetime.fromisoformat(str(date_taken).replace(" ", "T")).timestamp()
+                    )
+                except (ValueError, AttributeError):
+                    timestamp = fetched_at
+
+            if since is not None and timestamp <= since:
+                continue
+
+            geo = data.get("geo")
+            geotagged = False
+            lat = float("nan")
+            lng = float("nan")
+            if isinstance(geo, dict) and geo:
+                try:
+                    lat = float(geo["latitude"])
+                    lng = float(geo["longitude"])
+                    geotagged = True
+                except (KeyError, TypeError, ValueError):
+                    geotagged = False
+
+            if not geotagged and self._geotagged_only:
+                continue
+
+            yield {
+                "source_id": "flickr",
+                "timestamp": timestamp,
+                "lat": lat,
+                "lng": lng,
+                "place_name": data.get("name") or "",
+                "place_type": "photo",
+                "raw_json": data,
+                "fetched_at": fetched_at,
+            }

--- a/packages/localizer/tests/test_flickr_plugin.py
+++ b/packages/localizer/tests/test_flickr_plugin.py
@@ -1,0 +1,578 @@
+"""Failing tests for Subtask 2: FlickrPlugin in the localizer package (issue #19).
+
+All tests here are expected to FAIL until the coder implements:
+  - packages/localizer/src/localizer/plugins/flickr/__init__.py
+  - packages/localizer/src/localizer/plugins/flickr/loader.py
+  - Updated packages/localizer/src/localizer/plugins/__init__.py (load_builtin_plugins)
+
+FlickrPlugin is FetchMode.MANUAL, OutputTable.PLACES — it reads a directory of
+``photo_*.json`` export files (mirroring swarm/loader.py's directory-glob,
+graceful-empty-on-missing-directory, per-file try/except shape) and never makes
+any network call itself.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal Flickr photo export JSON
+# ---------------------------------------------------------------------------
+
+GEOTAGGED = {"latitude": 51.5074, "longitude": -0.1278}
+
+
+def _make_photo_data(
+    name: str | None = "Test Photo",
+    date_taken: str = "2023-06-15 18:30:00",
+    geo: dict[str, float] | None = None,
+    tags: list[str] | None = None,
+    albums: list[str] | None = None,
+    description: str = "A test photo.",
+    photopage: str = "https://www.flickr.com/photos/testuser/1/",
+) -> dict[str, Any]:
+    """Return a single photo dict matching the Flickr JSON export shape."""
+    data: dict[str, Any] = {
+        "date_taken": date_taken,
+        "geo": geo,
+        "tags": tags if tags is not None else ["travel", "sunset"],
+        "albums": albums if albums is not None else ["Summer Trip"],
+        "description": description,
+        "photopage": photopage,
+    }
+    if name is not None:
+        data["name"] = name
+    return data
+
+
+def _write_photo(dir_path: Path, filename: str, data: dict[str, Any]) -> Path:
+    """Write a photo JSON dict to *dir_path/filename* and return the path."""
+    file_path = dir_path / filename
+    file_path.write_text(json.dumps(data), encoding="utf-8")
+    return file_path
+
+
+def _raw_json(record: dict[str, Any]) -> dict[str, Any]:
+    """Return record['raw_json'] as a dict, parsing it if it is a JSON string."""
+    raw = record["raw_json"]
+    if isinstance(raw, str):
+        parsed: dict[str, Any] = json.loads(raw)
+        return parsed
+    return raw  # type: ignore[no-any-return]
+
+
+def _no_settings_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch LocalizerSettings.get_setting to always return its default.
+
+    Simulates a machine with no config.toml/env overrides, so fallback tests
+    are deterministic regardless of the developer's local ~/.localizer state.
+    """
+    from localizer.settings import LocalizerSettings
+
+    monkeypatch.setattr(
+        LocalizerSettings,
+        "get_setting",
+        lambda self, key, default=None: default,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ABC / class attribute / registration tests
+# ---------------------------------------------------------------------------
+
+
+def test_flickr_plugin_is_registered() -> None:
+    """After load_builtin_plugins(), REGISTRY['flickr'] must exist."""
+    from localizer.plugins import REGISTRY, load_builtin_plugins
+
+    REGISTRY.clear()
+    load_builtin_plugins()
+    assert "flickr" in REGISTRY, f"'flickr' not in REGISTRY; keys: {list(REGISTRY)}"
+
+
+def test_flickr_plugin_plugin_id() -> None:
+    """FlickrPlugin.PLUGIN_ID must equal 'flickr'."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    assert FlickrPlugin.PLUGIN_ID == "flickr"
+
+
+def test_flickr_plugin_fetch_mode_manual() -> None:
+    """FlickrPlugin.FETCH_MODE must be FetchMode.MANUAL."""
+    from localizer.plugins.base import FetchMode
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    assert FlickrPlugin.FETCH_MODE == FetchMode.MANUAL
+
+
+def test_flickr_plugin_output_tables_places() -> None:
+    """OutputTable.PLACES must be in FlickrPlugin.OUTPUT_TABLES."""
+    from localizer.plugins.base import OutputTable
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    assert OutputTable.PLACES in FlickrPlugin.OUTPUT_TABLES
+
+
+def test_flickr_plugin_get_config_fields() -> None:
+    """get_config_fields() must return the export_dir and geotagged_only fields."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    plugin = FlickrPlugin()
+    fields = plugin.get_config_fields()
+    assert isinstance(fields, list)
+    assert len(fields) == 2, f"Expected exactly 2 config fields, got {len(fields)}: {fields}"
+
+    by_key = {field["key"]: field for field in fields}
+    assert "export_dir" in by_key, f"'export_dir' field missing: {fields}"
+    assert "geotagged_only" in by_key, f"'geotagged_only' field missing: {fields}"
+    for field in fields:
+        assert "key" in field, f"Config field missing 'key': {field}"
+        assert "label" in field, f"Config field missing 'label': {field}"
+
+    assert by_key["export_dir"]["type"] == "dir_path", (
+        f"export_dir field type {by_key['export_dir'].get('type')!r} != 'dir_path'"
+    )
+
+
+def test_flickr_plugin_geotagged_only_field_is_bool_type_default_true() -> None:
+    """The geotagged_only field must be type='bool' with a default of True."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    plugin = FlickrPlugin()
+    fields = plugin.get_config_fields()
+    by_key = {field["key"]: field for field in fields}
+
+    geotagged_field = by_key["geotagged_only"]
+    assert geotagged_field["type"] == "bool", (
+        f"geotagged_only field type {geotagged_field.get('type')!r} != 'bool'"
+    )
+    assert geotagged_field.get("default") is True, (
+        f"geotagged_only field default {geotagged_field.get('default')!r} is not True"
+    )
+
+
+def test_flickr_plugin_manual_download_instructions() -> None:
+    """get_manual_download_instructions() must be a non-empty string mentioning flickr.com."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    plugin = FlickrPlugin()
+    instructions = plugin.get_manual_download_instructions()
+
+    assert isinstance(instructions, str)
+    assert len(instructions.strip()) > 0, "Expected non-empty manual download instructions"
+
+    instructions_lower = instructions.lower()
+    assert "flickr.com" in instructions_lower, (
+        f"'flickr.com' not found in instructions: {instructions!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# fetch_records normalization tests
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_records_geotagged_photo_yields_float_lat_lng(tmp_path: Path) -> None:
+    """A geotagged photo must yield exactly one record with float lat/lng and place_type=='photo'."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(geo=GEOTAGGED))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_records())
+
+    assert len(records) == 1, f"Expected 1 record, got {len(records)}"
+    record = records[0]
+    assert isinstance(record["lat"], float), f"Expected float lat, got {type(record['lat'])}"
+    assert isinstance(record["lng"], float), f"Expected float lng, got {type(record['lng'])}"
+    assert record["lat"] == pytest.approx(GEOTAGGED["latitude"])
+    assert record["lng"] == pytest.approx(GEOTAGGED["longitude"])
+    assert record["place_type"] == "photo"
+
+
+def test_fetch_records_non_geotagged_geotagged_only_true_yields_zero(tmp_path: Path) -> None:
+    """A non-geotagged photo with geotagged_only=True must yield zero records."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(geo=None))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path), geotagged_only=True)
+    records = list(plugin.fetch_records())
+
+    assert records == [], f"Expected 0 records with geotagged_only=True, got {len(records)}"
+
+
+def test_fetch_records_non_geotagged_geotagged_only_false_yields_nan(tmp_path: Path) -> None:
+    """A non-geotagged photo with geotagged_only=False must yield 1 record with NaN lat/lng."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(geo=None))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path), geotagged_only=False)
+    records = list(plugin.fetch_records())
+
+    assert len(records) == 1, (
+        f"Expected exactly 1 record with geotagged_only=False, got {len(records)}"
+    )
+    record = records[0]
+    assert math.isnan(record["lat"]), f"Expected NaN lat, got {record['lat']!r}"
+    assert math.isnan(record["lng"]), f"Expected NaN lng, got {record['lng']!r}"
+
+
+def test_fetch_records_geotagged_only_default_is_true(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When geotagged_only is not passed, it must default to True (excluding un-geotagged photos)."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _no_settings_override(monkeypatch)
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(geo=None))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_records())
+
+    assert records == [], "geotagged_only should default to True, excluding non-geotagged photos"
+
+
+@pytest.mark.parametrize("geotagged_only", [True, False])
+def test_fetch_records_geotagged_photo_always_included_regardless_of_toggle(
+    tmp_path: Path, geotagged_only: bool
+) -> None:
+    """A geotagged photo must always be yielded, regardless of the geotagged_only toggle."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(geo=GEOTAGGED))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path), geotagged_only=geotagged_only)
+    records = list(plugin.fetch_records())
+
+    assert len(records) == 1, (
+        f"Geotagged photo excluded with geotagged_only={geotagged_only}: got {len(records)} records"
+    )
+    assert records[0]["lat"] == pytest.approx(GEOTAGGED["latitude"])
+    assert records[0]["lng"] == pytest.approx(GEOTAGGED["longitude"])
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected"),
+    [
+        ("false", False),
+        ("False", False),
+        ("0", False),
+        ("", False),
+        ("no", False),
+        ("No", False),
+        ("true", True),
+        ("1", True),
+        ("yes", True),
+    ],
+)
+def test_geotagged_only_string_coercion_from_settings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    raw_value: str,
+    expected: bool,
+) -> None:
+    """A string value from LocalizerSettings must coerce to the correct bool.
+
+    Verified indirectly (black-box) via fetch_records() behavior against a
+    non-geotagged photo fixture, rather than by inspecting a private attribute.
+    """
+    from localizer.plugins.flickr.loader import FlickrPlugin
+    from localizer.settings import LocalizerSettings
+
+    def fake_get_setting(self: Any, key: str, default: Any = None) -> Any:
+        if key == "geotagged_only":
+            return raw_value
+        return default
+
+    monkeypatch.setattr(LocalizerSettings, "get_setting", fake_get_setting)
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(geo=None))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_records())
+
+    if expected is True:
+        assert records == [], (
+            f"raw settings value {raw_value!r} should coerce to True (exclude), "
+            f"got {len(records)} records"
+        )
+    else:
+        assert len(records) == 1, (
+            f"raw settings value {raw_value!r} should coerce to False (include as NaN), "
+            f"got {len(records)} records"
+        )
+        assert math.isnan(records[0]["lat"])
+        assert math.isnan(records[0]["lng"])
+
+
+def test_fetch_records_missing_title_yields_empty_place_name(tmp_path: Path) -> None:
+    """A photo JSON with no 'name' key must yield place_name == '' (not KeyError/None)."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(name=None, geo=GEOTAGGED))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_records())
+
+    assert len(records) == 1
+    assert records[0]["place_name"] == "", f"Expected '', got {records[0]['place_name']!r}"
+
+
+def test_fetch_records_raw_json_preserves_tags_albums_description_photopage(
+    tmp_path: Path,
+) -> None:
+    """raw_json must preserve tags/albums/description/photopage verbatim, and be JSON-serializable."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    data = _make_photo_data(
+        geo=GEOTAGGED,
+        tags=["mountains", "hiking", "summer"],
+        albums=["Alps 2023"],
+        description="A hike in the Alps.",
+        photopage="https://www.flickr.com/photos/testuser/42/",
+    )
+    _write_photo(tmp_path, "photo_1.json", data)
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_records())
+    assert len(records) == 1
+
+    raw = _raw_json(records[0])
+    assert raw["tags"] == ["mountains", "hiking", "summer"]
+    assert raw["albums"] == ["Alps 2023"]
+    assert raw["description"] == "A hike in the Alps."
+    assert raw["photopage"] == "https://www.flickr.com/photos/testuser/42/"
+
+
+def test_fetch_records_empty_export_dir_yields_empty_list(tmp_path: Path) -> None:
+    """An empty export directory (exists, zero matching files) must yield []."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_records())
+
+    assert records == [], f"Expected empty list from empty dir, got {records}"
+
+
+def test_fetch_records_nonexistent_export_dir_yields_empty_list(tmp_path: Path) -> None:
+    """A nonexistent export directory path must yield [] without raising."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    nonexistent = tmp_path / "does_not_exist"
+
+    plugin = FlickrPlugin(export_dir=str(nonexistent))
+    try:
+        records = list(plugin.fetch_records())
+        assert records == [], f"Expected empty list for missing dir, got {records}"
+    except Exception as exc:  # noqa: BLE001
+        pytest.fail(f"fetch_records() raised {type(exc).__name__} on missing dir: {exc}")
+
+
+def test_fetch_records_unconfigured_export_dir_yields_empty_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FlickrPlugin() with no export_dir and no settings override must yield [] without raising."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _no_settings_override(monkeypatch)
+
+    plugin = FlickrPlugin()
+    records = list(plugin.fetch_records())
+
+    assert records == [], f"Expected empty list when unconfigured, got {records}"
+
+
+def test_fetch_records_multiple_files_all_parsed(tmp_path: Path) -> None:
+    """Multiple photo_*.json files in the directory must all be read."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(geo=GEOTAGGED))
+    _write_photo(
+        tmp_path,
+        "photo_2.json",
+        _make_photo_data(geo={"latitude": 40.0, "longitude": -74.0}),
+    )
+    _write_photo(
+        tmp_path,
+        "photo_3.json",
+        _make_photo_data(geo={"latitude": 35.0, "longitude": 139.0}),
+    )
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_records())
+
+    assert len(records) == 3, f"Expected 3 records across 3 files, got {len(records)}"
+
+
+def test_fetch_records_ignores_non_matching_files(tmp_path: Path) -> None:
+    """Files not matching the photo_*.json glob pattern must be ignored."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(geo=GEOTAGGED))
+    (tmp_path / "notes.txt").write_text("not a photo", encoding="utf-8")
+    (tmp_path / "other_1.json").write_text(
+        json.dumps(_make_photo_data(geo=GEOTAGGED)), encoding="utf-8"
+    )
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_records())
+
+    assert len(records) == 1, (
+        f"Expected only the photo_*.json file to be parsed, got {len(records)} records"
+    )
+
+
+def test_fetch_records_malformed_json_file_skipped_valid_still_yielded(tmp_path: Path) -> None:
+    """A malformed photo_*.json file must be skipped; the valid file must still be yielded."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    (tmp_path / "photo_bad.json").write_text("{not valid json", encoding="utf-8")
+    _write_photo(tmp_path, "photo_good.json", _make_photo_data(geo=GEOTAGGED))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_records())
+
+    assert len(records) == 1, (
+        f"Expected the malformed file to be skipped and the valid one yielded, got {len(records)}"
+    )
+
+
+def test_fetch_records_date_taken_parses_to_expected_timestamp(tmp_path: Path) -> None:
+    """A space-separated date_taken must parse to the correct Unix timestamp."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    date_taken = "2023-06-15 18:30:00"
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(date_taken=date_taken, geo=GEOTAGGED))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_records())
+    assert len(records) == 1
+
+    expected_ts = int(datetime.fromisoformat(date_taken.replace(" ", "T")).timestamp())
+    assert records[0]["timestamp"] == expected_ts
+
+
+def test_fetch_records_unparseable_date_taken_falls_back_to_fetched_at(tmp_path: Path) -> None:
+    """An unparseable date_taken must fall back to this batch's fetched_at, not raise."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(
+        tmp_path,
+        "photo_1.json",
+        _make_photo_data(date_taken="not-a-real-date", geo=GEOTAGGED),
+    )
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_records())
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["timestamp"] == record["fetched_at"], (
+        f"Expected fallback to fetched_at ({record['fetched_at']}), got {record['timestamp']}"
+    )
+
+
+def test_fetch_records_since_cursor_excludes_older_photo(tmp_path: Path) -> None:
+    """A photo older than 'since' must be excluded; a newer one must be included."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    older_date = "2023-01-01 00:00:00"
+    newer_date = "2023-06-15 18:30:00"
+    _write_photo(tmp_path, "photo_old.json", _make_photo_data(date_taken=older_date, geo=GEOTAGGED))
+    _write_photo(tmp_path, "photo_new.json", _make_photo_data(date_taken=newer_date, geo=GEOTAGGED))
+
+    older_ts = int(datetime.fromisoformat(older_date.replace(" ", "T")).timestamp())
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_records(since=older_ts))
+
+    assert len(records) == 1, f"Expected only the newer photo, got {len(records)} records"
+    newer_ts = int(datetime.fromisoformat(newer_date.replace(" ", "T")).timestamp())
+    assert records[0]["timestamp"] == newer_ts
+
+
+def test_fetch_records_dict_has_required_keys(tmp_path: Path) -> None:
+    """Each yielded dict must have the required place record keys."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(geo=GEOTAGGED))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_records())
+    assert len(records) == 1
+
+    required_keys = {
+        "source_id",
+        "timestamp",
+        "lat",
+        "lng",
+        "place_name",
+        "place_type",
+        "raw_json",
+        "fetched_at",
+    }
+    missing = required_keys - set(records[0].keys())
+    assert not missing, f"Record missing required keys: {missing}"
+
+
+def test_fetch_records_source_id_is_flickr(tmp_path: Path) -> None:
+    """Each record's source_id must equal 'flickr'."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(geo=GEOTAGGED))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_records())
+    assert records[0]["source_id"] == "flickr"
+
+
+def test_fetch_records_fetched_at_is_recent(tmp_path: Path) -> None:
+    """fetched_at must be a Unix timestamp close to now."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(geo=GEOTAGGED))
+
+    before = int(time.time())
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_records())
+    after = int(time.time())
+
+    fetched_at = records[0]["fetched_at"]
+    assert isinstance(fetched_at, int)
+    assert before - 5 <= fetched_at <= after + 5, (
+        f"fetched_at {fetched_at} not close to now ({before}-{after})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Network-isolation test
+# ---------------------------------------------------------------------------
+
+
+def test_flickr_loader_has_no_network_imports() -> None:
+    """loader.py must contain no network-related imports (issue #19's zero-network requirement)."""
+    import localizer.plugins.flickr.loader as loader_module
+
+    source = Path(loader_module.__file__).read_text(encoding="utf-8")
+    forbidden_patterns = [
+        "import requests",
+        "import urllib",
+        "from urllib",
+        "import httpx",
+        "from httpx",
+        "import socket",
+        "from socket",
+    ]
+    for pattern in forbidden_patterns:
+        assert pattern not in source, (
+            f"Found forbidden network-related import pattern {pattern!r} in loader.py"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S", "B", "E501"]
+"packages/localizer/tests/*" = ["S", "B", "E501"]
 "record_flythrough.py" = ["E501"]  # long lines are embedded JS inside f-strings
 "export_html.py" = ["E501"]  # long lines are embedded JS/CSS inside f-strings
 


### PR DESCRIPTION
## Summary
- Adds `FlickrPlugin` (`OutputTable.PLACES`, `FetchMode.MANUAL`) that parses Flickr export JSON files, mirroring the existing `SwarmPlugin` loader pattern.
- Non-geotagged photos are preserved with `NaN` lat/lng (the `places` schema's `lat`/`lng` columns are `DOUBLE NOT NULL`, so `NaN` is legal but SQL `NULL` is not) when `geotagged_only=False`.
- Registers the plugin in `localizer.plugins.REGISTRY` via `load_builtin_plugins()`.
- Extends `pyproject.toml`'s ruff `per-file-ignores` to cover `packages/localizer/tests/*`, closing a gap where the pre-push gate's repo-wide ruff check didn't apply the same `S`/`B`/`E501` exemptions given to the root `tests/*`.

Closes #19

## Test plan
- [x] `pytest packages/localizer/tests` passes (249 tests, including new Flickr plugin coverage)
- [x] `pytest` (root suite) passes (905 tests)
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `mypy` clean