### PR TITLE
feat: unified places layer with apply_location_context() and Google Location History plugin

### DIFF
--- a/analysis_utils.py
+++ b/analysis_utils.py
@@ -535,15 +535,18 @@ def get_assumption_location(ts: int, assumptions: dict[str, Any]) -> Optional[di
     return None
 
 
-def apply_swarm_offsets(
+def apply_location_context(
     lastfm_df: pd.DataFrame,
     swarm_df: pd.DataFrame,
     assumptions: dict[str, Any],
     max_age_days: int = 30,
 ) -> pd.DataFrame:
     """
-    Adjust Last.fm track timestamps and locations based on Swarm checkins or runtime assumptions.
-    Highly optimized vectorized implementation (Issue #39 optimization).
+    Adjust Last.fm track timestamps and locations based on location-source checkins
+    (Swarm, Google Location History, Google Timeline, etc. — any ``places``-shaped
+    frame, regardless of ``source_id``) or runtime assumptions.
+    Highly optimized vectorized implementation (Issue #39 optimization; renamed
+    from ``apply_swarm_offsets`` in Issue #110 once it became source-agnostic).
     """
     if lastfm_df.empty:
         return lastfm_df
@@ -1173,7 +1176,7 @@ def build_life_chapters(
     Each chapter represents a distinct geographic period (residency segment or
     trip) with aggregated listening statistics.  Overlapping periods are
     resolved by giving trips priority over residency (matching the same
-    precedence used in ``apply_swarm_offsets``).
+    precedence used in ``apply_location_context``).
 
     Args:
         df: Listening history DataFrame with ``date_text`` (datetime) and

--- a/components/sidebar.py
+++ b/components/sidebar.py
@@ -33,7 +33,7 @@ When ``~/.localizer/store.duckdb`` (or ``LocalizerStore.default_path()``) exists
 ``render_sidebar()`` loads data via ``LocalizerBroker`` instead of the legacy
 CSV/JSON file paths: it fetches raw events/places frames, adapts them into the
 legacy column shapes via ``core.localizer_frames``, and runs the same
-``apply_swarm_offsets()`` used by the legacy path. ``_current_config`` is still
+``apply_location_context()`` used by the legacy path. ``_current_config`` is still
 written as a 4-tuple (``("", "", assumptions_path, "")``) so index-based readers
 elsewhere never see a shape change; the richer reload identity lives in
 ``_loaded_store_identity`` instead. The legacy file-hash cache
@@ -54,7 +54,7 @@ import pandas as pd
 import streamlit as st
 
 from analysis_utils import (
-    apply_swarm_offsets,
+    apply_location_context,
     get_cache_key,
     get_cached_data,
     load_assumptions,
@@ -131,7 +131,7 @@ def _load_data_from_broker(assumptions_path: str) -> None:
 
     Fetches raw events/places frames from ``LocalizerBroker``, adapts them into
     the legacy ``lastfm_df``/``swarm_df`` shapes via ``core.localizer_frames``,
-    and runs the existing ``apply_swarm_offsets()`` logic on top — mirroring the
+    and runs the existing ``apply_location_context()`` logic on top — mirroring the
     legacy path's computation but sourced from the localizer DuckDB store
     instead of flat CSV/JSON files. The file-hash cache is intentionally not
     used here (see the module docstring's "Broker mode" section); instead
@@ -169,7 +169,7 @@ def _load_data_from_broker(assumptions_path: str) -> None:
             swarm_df = places_to_swarm_frame(broker.get_places_frame())
 
             st.write("Applying timezone offsets…")
-            merged_df = apply_swarm_offsets(lastfm_df, swarm_df, assumptions)
+            merged_df = apply_location_context(lastfm_df, swarm_df, assumptions)
 
             status.update(label="Data ready.", state="complete", expanded=False)
 
@@ -226,7 +226,7 @@ def _load_data_with_progress(
     """Load all data sources with a visible progress widget; store in session state.
 
     Reads the Last.fm CSV, optionally reads Swarm JSONs and a Google Timeline
-    export, checks the file cache, and runs ``apply_swarm_offsets`` on a cache
+    export, checks the file cache, and runs ``apply_location_context`` on a cache
     miss.  Swarm and Timeline location records are concatenated into a single
     ``swarm_df`` (sorted by timestamp) so every geo view and the offset join
     consume them uniformly.  Results are stored in ``st.session_state`` keys
@@ -271,7 +271,7 @@ def _load_data_with_progress(
                 if not timeline_df.empty:
                     timeline_df["source_id"] = "google_timeline"
                     swarm_df = pd.concat([swarm_df, timeline_df], ignore_index=True)
-                    # Re-sort: apply_swarm_offsets relies on ascending timestamps.
+                    # Re-sort: apply_location_context relies on ascending timestamps.
                     swarm_df = swarm_df.sort_values("timestamp").reset_index(drop=True)
 
             cache_key = get_cache_key(file_path, swarm_dir, assumptions_path, timeline_path)
@@ -284,7 +284,7 @@ def _load_data_with_progress(
             else:
                 st.session_state["_cache_status"] = "miss"
                 st.write("Applying timezone offsets — first-time setup, may take a minute…")
-                merged_df = apply_swarm_offsets(raw_df, swarm_df, assumptions)
+                merged_df = apply_location_context(raw_df, swarm_df, assumptions)
                 save_to_cache(merged_df, cache_key)
 
             status.update(label="Data ready.", state="complete", expanded=False)

--- a/core/broker.py
+++ b/core/broker.py
@@ -3,7 +3,7 @@
 The DataBroker is the central data coordinator. It holds loaded DataFrames
 from each plugin, tracks which source types are available, and provides a
 merged DataFrame that combines what-when and where-when sources via temporal
-join (powered by apply_swarm_offsets for the Swarm/Last.fm case).
+join (powered by apply_location_context for the where-when/Last.fm case).
 
 Typical usage::
 
@@ -49,6 +49,10 @@ class DataBroker:
         )
         self._sources: dict[str, pd.DataFrame] = {}
         self._available_types: list[str] = []
+        # Tracks PLUGIN_TYPE per loaded source_id so get_merged_frame() can union
+        # *every* where-when source (Swarm, Google Timeline, etc.) rather than
+        # hardcoding a single plugin id (Issue #110).
+        self._plugin_types: dict[str, str] = {}
 
     @property
     def available_types(self) -> list[str]:
@@ -71,6 +75,7 @@ class DataBroker:
         """
         df = plugin.load(config)
         self._sources[plugin.PLUGIN_ID] = df
+        self._plugin_types[plugin.PLUGIN_ID] = plugin.PLUGIN_TYPE
         if plugin.PLUGIN_TYPE not in self._available_types:
             self._available_types.append(plugin.PLUGIN_TYPE)
         return df
@@ -97,16 +102,20 @@ class DataBroker:
     def get_merged_frame(self, assumptions: dict[str, Any] | None = None) -> pd.DataFrame:
         """Return a merged DataFrame combining what-when and where-when sources.
 
-        If both a what-when source (Last.fm) and a where-when source (Swarm)
-        are loaded, applies temporal merging via apply_swarm_offsets() to
-        annotate what-when records with location and timezone data.
+        If both a what-when source (Last.fm) and at least one where-when
+        source (Swarm, Google Timeline, or any other loaded plugin whose
+        ``PLUGIN_TYPE`` is ``"where-when"``) are loaded, applies temporal
+        merging via apply_location_context() to annotate what-when records
+        with location and timezone data. All loaded where-when sources are
+        unioned (concatenated) before the join, so enrichment is not tied to
+        any single source_id.
 
         If only a what-when source is loaded, returns it unmodified.
         If no what-when source is loaded, returns an empty DataFrame.
 
         Args:
             assumptions: Location assumptions dict from load_assumptions().
-                         Required for the Swarm temporal join; pass None to
+                         Required for the location temporal join; pass None to
                          skip location enrichment.
 
         Returns:
@@ -118,14 +127,31 @@ class DataBroker:
         if lastfm_df.empty:
             return lastfm_df
 
-        swarm_df = self._sources.get("swarm", pd.DataFrame())
+        where_when_frames = []
+        for source_id, plugin_type in self._plugin_types.items():
+            if plugin_type != "where-when":
+                continue
+            source_df = self._sources.get(source_id, pd.DataFrame())
+            if not source_df.empty:
+                where_when_frames.append(source_df)
 
-        if swarm_df.empty or assumptions is None:
+        if not where_when_frames or assumptions is None:
             return lastfm_df
 
-        from analysis_utils import apply_swarm_offsets
+        if len(where_when_frames) > 1:
+            # apply_location_context() binary-searches swarm_df["timestamp"], so a
+            # union of multiple sources must be re-sorted ascending.
+            swarm_df = (
+                pd.concat(where_when_frames, ignore_index=True)
+                .sort_values("timestamp")
+                .reset_index(drop=True)
+            )
+        else:
+            swarm_df = where_when_frames[0]
 
-        return apply_swarm_offsets(lastfm_df, swarm_df, assumptions)
+        from analysis_utils import apply_location_context
+
+        return apply_location_context(lastfm_df, swarm_df, assumptions)
 
     def is_type_available(self, plugin_type: str) -> bool:
         """Check whether any loaded source provides the given plugin type.

--- a/core/localizer_frames.py
+++ b/core/localizer_frames.py
@@ -3,7 +3,7 @@
 `LocalizerBroker.get_events_frame()` / `get_places_frame()` (see core/broker.py) return
 generic columns (`timestamp, label, sublabel, category, source_id` and `timestamp, lat,
 lng, place_name, place_type, source_id` respectively). The rest of the app —
-`apply_swarm_offsets()`, `pages/geo_explorer.py`, `pages/places.py` — expects the legacy
+`apply_location_context()`, `pages/geo_explorer.py`, `pages/places.py` — expects the legacy
 Last.fm/Swarm column shapes instead. These two functions bridge that gap.
 
 This module is intentionally Streamlit- and DuckDB-free: it is pure DataFrame-in/
@@ -64,7 +64,7 @@ def places_to_swarm_frame(places_df: pd.DataFrame) -> pd.DataFrame:
     Returns:
         DataFrame with columns `timestamp, offset, city, state, country, venue,
         venue_category, lat, lng, event_category, shout, source_id`, sorted ascending
-        by `timestamp` (required by `apply_swarm_offsets`'s binary search over
+        by `timestamp` (required by `apply_location_context`'s binary search over
         `swarm_df["timestamp"]`). `place_name` is copied into both `city` and `venue`;
         `place_type` is renamed to `venue_category`. `state`, `country`,
         `event_category`, `shout` default to `""` and `offset` defaults to `0`, since

--- a/packages/localizer/README.md
+++ b/packages/localizer/README.md
@@ -29,7 +29,7 @@ Autobiographer uses localizer as its data layer, but localizer is a standalone p
 │  DISPLAY PHASE  (streamlit run visualize.py)                    │
 │                                                                 │
 │  LocalizerBroker reads DataFrames from DuckDB                   │
-│  apply_swarm_offsets() enriches Last.fm events with location    │
+│  apply_location_context() enriches Last.fm events with location │
 │    — reads default_assumptions.json at runtime (not in DuckDB)  │
 │                                                                 │
 │  Zero outbound network calls at render time                     │
@@ -38,9 +38,9 @@ Autobiographer uses localizer as its data layer, but localizer is a standalone p
 
 ### The places layer and location assumptions
 
-The `places` table stores timestamped GPS check-ins from sources like Foursquare/Swarm. These are used to infer where you were when you listened to music, watched a film, etc.
+The `places` table stores timestamped GPS check-ins from any registered where-when source — Foursquare/Swarm, Google Maps Timeline, Google Location History, etc. `apply_location_context()` unions all `source_id` values in `places` (it is not tied to any single source) when inferring where you were when you listened to music, watched a film, etc.
 
-**`default_assumptions.json` is not stored in DuckDB.** It is a runtime configuration file that describes where you were during periods *not covered* by check-ins — home residency rules, recurring holidays, long trips. The dashboard reads it from disk at render time via `LocalizerSettings.get_assumptions_path()` and passes it to `apply_swarm_offsets()`, which joins it against Last.fm events to assign locations.
+**`default_assumptions.json` is not stored in DuckDB.** It is a runtime configuration file that describes where you were during periods *not covered* by check-ins — home residency rules, recurring holidays, long trips. The dashboard reads it from disk at render time via `LocalizerSettings.get_assumptions_path()` and passes it to `apply_location_context()`, which joins it against Last.fm events to assign locations.
 
 This means:
 - Editing `default_assumptions.json` takes effect the next time you open the dashboard — no sync needed.

--- a/packages/localizer/src/localizer/plugins/__init__.py
+++ b/packages/localizer/src/localizer/plugins/__init__.py
@@ -46,6 +46,7 @@ def load_builtin_plugins() -> None:
     from localizer.plugins.feedly.loader import FeedlyPlugin
     from localizer.plugins.flickr.loader import FlickrPlugin
     from localizer.plugins.github.loader import GitHubPlugin
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
     from localizer.plugins.google_timeline.loader import GoogleTimelinePlugin
     from localizer.plugins.lastfm.loader import LastFmPlugin
     from localizer.plugins.letterboxd.loader import LetterboxdPlugin
@@ -60,5 +61,6 @@ def load_builtin_plugins() -> None:
     REGISTRY[RssPlugin.PLUGIN_ID] = RssPlugin
     REGISTRY[LetterboxdPlugin.PLUGIN_ID] = LetterboxdPlugin
     REGISTRY[GoogleTimelinePlugin.PLUGIN_ID] = GoogleTimelinePlugin
+    REGISTRY[GoogleLocationPlugin.PLUGIN_ID] = GoogleLocationPlugin
     REGISTRY[FlickrPlugin.PLUGIN_ID] = FlickrPlugin
     REGISTRY[UntappdPlugin.PLUGIN_ID] = UntappdPlugin

--- a/packages/localizer/src/localizer/plugins/google_location/loader.py
+++ b/packages/localizer/src/localizer/plugins/google_location/loader.py
@@ -1,0 +1,152 @@
+"""Google Location History (Takeout) source plugin for localizer.
+
+FetchMode.MANUAL — the user must export their data from Google Takeout and
+point the plugin at the unzipped "Location History" directory. Handles both
+legacy Takeout formats via ``localizer.plugins.google_location.parser``:
+``Records.json`` (raw GPS pings) and ``Semantic Location History/<Year>/
+<Year>_<MONTH>.json`` (place visits and activity segments).
+
+Distinct from ``localizer.plugins.google_timeline``, which handles the
+current on-device single-file ``Timeline.json`` export.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+from localizer.plugins import register
+from localizer.plugins.base import FetchMode, OutputTable, SourcePlugin
+
+
+@register
+class GoogleLocationPlugin(SourcePlugin):
+    """Load Google Location History from a local Google Takeout export directory.
+
+    Args:
+        google_location_dir: Path to the exported "Location History"
+            directory. If None, falls back to
+            ``LocalizerSettings().get_setting("google_location_dir")``. The
+            plugin yields nothing until a valid directory is available.
+    """
+
+    PLUGIN_ID = "google_location"
+    DISPLAY_NAME = "Google Location History"
+    FETCH_MODE = FetchMode.MANUAL
+    OUTPUT_TABLES = [OutputTable.PLACES]
+    ICON = ":material/my_location:"
+
+    def __init__(self, google_location_dir: str | None = None) -> None:
+        if google_location_dir is None:
+            try:
+                from localizer.settings import LocalizerSettings  # noqa: PLC0415
+
+                google_location_dir = LocalizerSettings().get_setting("google_location_dir") or None
+            except ImportError:
+                pass
+        self._dir = google_location_dir
+
+    def get_config_fields(self) -> list[dict[str, Any]]:
+        """Declare sidebar config fields for the Google Location History plugin.
+
+        Returns:
+            List with one field descriptor for the Takeout export directory.
+        """
+        return [
+            {
+                "key": "google_location_dir",
+                "label": "Google Location History export directory",
+                "type": "dir_path",
+            }
+        ]
+
+    def get_manual_download_instructions(self) -> str:
+        """Return instructions for exporting Google Location History via Takeout.
+
+        Returns:
+            Multi-line instruction string covering the Takeout export.
+        """
+        return (
+            "Google Location History (legacy formats) is exported via Google Takeout:\n\n"
+            "  1. Visit https://takeout.google.com\n"
+            "  2. Deselect all, then select only 'Location History (Timeline)'\n"
+            "  3. Create the export and download the archive\n"
+            "  4. Unzip it and locate the 'Location History' folder — it may contain\n"
+            "     a 'Records.json' file and/or a 'Semantic Location History' subfolder\n"
+            "     of yearly folders with monthly JSON files\n\n"
+            "Then point the 'Google Location History export directory' setting at that "
+            "'Location History' folder (not an individual file).\n\n"
+            "Note: if your export instead contains a single 'Timeline.json' file, use "
+            "the 'Google Maps Timeline' source instead — that is the newer on-device "
+            "export format."
+        )
+
+    def fetch_records(
+        self,
+        since: int | None = None,
+        progress_cb: Any | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Yield normalized place dicts from a Google Takeout Location History export.
+
+        Streams ``Records.json`` (if present) and every
+        ``Semantic Location History/<Year>/<Year>_<MONTH>.json`` file (if
+        present) one record at a time, so memory use stays bounded even for
+        multi-year exports with millions of GPS pings — each source file is
+        read and parsed in turn, and this generator is consumed by the
+        localizer CLI in fixed-size batches (see ``cli.py``'s ``_BATCH_SIZE``
+        write loop), rather than materializing the whole export in memory.
+        Missing configuration, a nonexistent directory, or a directory with
+        neither expected format yields nothing gracefully. Malformed
+        individual files are skipped rather than aborting the whole fetch.
+
+        Args:
+            since: Optional Unix timestamp; yield only records newer than this.
+            progress_cb: Optional progress callback (unused for manual plugins).
+
+        Yields:
+            Dicts with keys: source_id, timestamp, lat, lng, place_name,
+            place_type, raw_json, fetched_at.
+        """
+        if not self._dir:
+            return
+
+        base_dir = Path(self._dir)
+        if not base_dir.exists() or not base_dir.is_dir():
+            return
+
+        from localizer.plugins.google_location.parser import (  # noqa: PLC0415
+            parse_records_json,
+            parse_semantic_location_history,
+        )
+
+        fetched_at = int(time.time())
+
+        def _to_output(record: dict[str, Any]) -> dict[str, Any]:
+            return {
+                "source_id": self.PLUGIN_ID,
+                "timestamp": record["timestamp"],
+                "lat": float(record["lat"]),
+                "lng": float(record["lng"]),
+                "place_name": record["place_name"],
+                "place_type": record["place_type"],
+                "raw_json": record["raw"],
+                "fetched_at": fetched_at,
+            }
+
+        records_json = base_dir / "Records.json"
+        if records_json.exists():
+            for record in parse_records_json(records_json):
+                if since is not None and record["timestamp"] <= since:
+                    continue
+                yield _to_output(record)
+
+        semantic_dir = base_dir / "Semantic Location History"
+        if semantic_dir.exists() and semantic_dir.is_dir():
+            for year_dir in sorted(p for p in semantic_dir.iterdir() if p.is_dir()):
+                for month_file in sorted(year_dir.glob("*.json")):
+                    for record in parse_semantic_location_history(month_file):
+                        if since is not None and record["timestamp"] <= since:
+                            continue
+                        yield _to_output(record)

--- a/packages/localizer/src/localizer/plugins/google_location/parser.py
+++ b/packages/localizer/src/localizer/plugins/google_location/parser.py
@@ -1,0 +1,253 @@
+"""Parsers for legacy Google Location History (Google Takeout) exports.
+
+Google Takeout has offered location history in two now-superseded formats,
+both distinct from the newer on-device ``Timeline.json`` export handled by
+``localizer.plugins.google_timeline.parser`` (see that module for the modern
+format):
+
+  - **Records.json** (older format): a single file at the top level of the
+    "Location History" export directory, shaped
+    ``{"locations": [{"latitudeE7": ..., "longitudeE7": ..., "timestamp": ...}, ...]}``.
+    Each entry is a raw GPS ping (no place name/semantic info).
+  - **Semantic Location History** (newer legacy format): one JSON file per
+    month, at ``Semantic Location History/<Year>/<Year>_<MONTH>.json``,
+    shaped
+    ``{"timelineObjects": [{"placeVisit": {...}} | {"activitySegment": {...}}, ...]}``.
+    Each entry is either a place visit (with a place name/semantic type) or
+    a movement between two locations (an activity segment).
+
+Both parsers are pure functions: given a file path, they yield normalized
+dicts with ``timestamp`` (Unix seconds), ``lat``/``lng`` (floats),
+``place_name``, ``place_type``, and ``raw`` (the original JSON entry, kept
+for full-fidelity storage). Malformed files/entries are skipped rather than
+raising, mirroring ``localizer.plugins.swarm.loader``'s per-file resilience.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+
+def _parse_iso_or_ms_timestamp(entry: dict[str, Any], iso_key: str, ms_key: str) -> int | None:
+    """Return a Unix-seconds timestamp from an entry with an ISO or millisecond field.
+
+    Args:
+        entry: Dict potentially containing `iso_key` (RFC3339 string) and/or
+            `ms_key` (string or int of Unix milliseconds).
+        iso_key: Key for the ISO 8601 timestamp string (preferred).
+        ms_key: Key for the millisecond-epoch fallback.
+
+    Returns:
+        Unix timestamp in seconds, or None if neither field parses.
+    """
+    iso_value = entry.get(iso_key)
+    if iso_value:
+        try:
+            import pandas as pd  # noqa: PLC0415
+
+            return int(pd.Timestamp(iso_value).timestamp())
+        except (ValueError, TypeError):
+            pass
+
+    ms_value = entry.get(ms_key)
+    if ms_value is not None:
+        try:
+            return int(ms_value) // 1000
+        except (ValueError, TypeError):
+            pass
+
+    return None
+
+
+def parse_records_json(path: str | Path) -> Iterator[dict[str, Any]]:
+    """Parse a legacy Google Takeout ``Records.json`` export.
+
+    Args:
+        path: Path to the `Records.json` file.
+
+    Yields:
+        Dicts with keys `timestamp`, `lat`, `lng`, `place_name`, `place_type`,
+        `raw`. Entries missing coordinates or a parseable timestamp are
+        skipped. `place_name` is always `""` and `place_type` is always
+        `"location_ping"` — Records.json entries are raw GPS pings with no
+        semantic place information (unlike Semantic Location History).
+
+    Notes:
+        Yields nothing (rather than raising) if the file is missing, is not
+        valid JSON, or has no top-level `locations` list.
+    """
+    file_path = Path(path)
+    if not file_path.exists():
+        return
+
+    try:
+        data = json.loads(file_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+
+    if not isinstance(data, dict):
+        return
+    locations = data.get("locations")
+    if not isinstance(locations, list):
+        return
+
+    for entry in locations:
+        if not isinstance(entry, dict):
+            continue
+
+        lat_e7 = entry.get("latitudeE7")
+        lng_e7 = entry.get("longitudeE7")
+        if lat_e7 is None or lng_e7 is None:
+            continue
+
+        timestamp = _parse_iso_or_ms_timestamp(entry, "timestamp", "timestampMs")
+        if timestamp is None:
+            continue
+
+        try:
+            lat = float(lat_e7) / 1e7
+            lng = float(lng_e7) / 1e7
+        except (TypeError, ValueError):
+            continue
+
+        yield {
+            "timestamp": timestamp,
+            "lat": lat,
+            "lng": lng,
+            "place_name": "",
+            "place_type": "location_ping",
+            "raw": entry,
+        }
+
+
+def parse_semantic_location_history(path: str | Path) -> Iterator[dict[str, Any]]:
+    """Parse a single Semantic Location History month file.
+
+    Args:
+        path: Path to a `<Year>_<MONTH>.json` file under
+            `Semantic Location History/<Year>/`.
+
+    Yields:
+        Dicts with keys `timestamp`, `lat`, `lng`, `place_name`, `place_type`,
+        `raw`. Place visits yield the visited place's name (or "Unknown
+        place") and its semantic type, lowercased, as `place_type`. Activity
+        segments (movement between places) yield the activity type as
+        `place_name` and `"activity:<type>"` (lowercased) as `place_type`,
+        matching the convention used by
+        `localizer.plugins.google_timeline.parser`.
+
+    Notes:
+        Yields nothing (rather than raising) if the file is missing, is not
+        valid JSON, or has no top-level `timelineObjects` list. Entries
+        missing coordinates or a parseable timestamp are skipped.
+    """
+    file_path = Path(path)
+    if not file_path.exists():
+        return
+
+    try:
+        data = json.loads(file_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+
+    if not isinstance(data, dict):
+        return
+    objects = data.get("timelineObjects")
+    if not isinstance(objects, list):
+        return
+
+    for obj in objects:
+        if not isinstance(obj, dict):
+            continue
+
+        if "placeVisit" in obj:
+            record = _parse_place_visit(obj)
+        elif "activitySegment" in obj:
+            record = _parse_activity_segment(obj)
+        else:
+            continue
+
+        if record is not None:
+            yield record
+
+
+def _parse_place_visit(obj: dict[str, Any]) -> dict[str, Any] | None:
+    """Normalize a single `placeVisit` timeline object.
+
+    Args:
+        obj: A `timelineObjects` entry containing a `placeVisit` key.
+
+    Returns:
+        Normalized dict, or None if coordinates/timestamp cannot be parsed.
+    """
+    visit = obj.get("placeVisit") or {}
+    location = visit.get("location") or {}
+    lat_e7 = location.get("latitudeE7")
+    lng_e7 = location.get("longitudeE7")
+    if lat_e7 is None or lng_e7 is None:
+        return None
+
+    duration = visit.get("duration") or {}
+    timestamp = _parse_iso_or_ms_timestamp(duration, "startTimestamp", "startTimestampMs")
+    if timestamp is None:
+        return None
+
+    try:
+        lat = float(lat_e7) / 1e7
+        lng = float(lng_e7) / 1e7
+    except (TypeError, ValueError):
+        return None
+
+    place_name = location.get("name") or "Unknown place"
+    semantic_type = visit.get("semanticType") or location.get("semanticType") or "visit"
+
+    return {
+        "timestamp": timestamp,
+        "lat": lat,
+        "lng": lng,
+        "place_name": place_name,
+        "place_type": str(semantic_type).lower(),
+        "raw": obj,
+    }
+
+
+def _parse_activity_segment(obj: dict[str, Any]) -> dict[str, Any] | None:
+    """Normalize a single `activitySegment` timeline object.
+
+    Args:
+        obj: A `timelineObjects` entry containing an `activitySegment` key.
+
+    Returns:
+        Normalized dict, or None if coordinates/timestamp cannot be parsed.
+    """
+    segment = obj.get("activitySegment") or {}
+    start_location = segment.get("startLocation") or {}
+    lat_e7 = start_location.get("latitudeE7")
+    lng_e7 = start_location.get("longitudeE7")
+    if lat_e7 is None or lng_e7 is None:
+        return None
+
+    duration = segment.get("duration") or {}
+    timestamp = _parse_iso_or_ms_timestamp(duration, "startTimestamp", "startTimestampMs")
+    if timestamp is None:
+        return None
+
+    try:
+        lat = float(lat_e7) / 1e7
+        lng = float(lng_e7) / 1e7
+    except (TypeError, ValueError):
+        return None
+
+    activity_type = segment.get("activityType") or "UNKNOWN"
+
+    return {
+        "timestamp": timestamp,
+        "lat": lat,
+        "lng": lng,
+        "place_name": str(activity_type).replace("_", " ").capitalize(),
+        "place_type": "activity:" + str(activity_type).lower(),
+        "raw": obj,
+    }

--- a/packages/localizer/tests/test_google_location_plugin.py
+++ b/packages/localizer/tests/test_google_location_plugin.py
@@ -1,0 +1,547 @@
+"""Tests for GoogleLocationPlugin (issue #110): legacy Google Takeout Location History.
+
+Covers both legacy Takeout formats, distinct from `google_timeline`'s modern
+single-file `Timeline.json` export:
+  - packages/localizer/src/localizer/plugins/google_location/parser.py
+  - packages/localizer/src/localizer/plugins/google_location/loader.py
+  - Registration in packages/localizer/src/localizer/plugins/__init__.py
+
+Format 1 — Records.json (top level of the export directory): raw GPS pings,
+``{"locations": [{"latitudeE7": ..., "longitudeE7": ..., "timestamp"|"timestampMs": ...}]}``.
+
+Format 2 — Semantic Location History/<Year>/<Year>_<MONTH>.json: place visits
+and activity segments, ``{"timelineObjects": [{"placeVisit": {...}} | {"activitySegment": {...}}]}``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    """Write *data* as JSON to *path*, creating parent directories as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _records_json_payload() -> dict[str, Any]:
+    """Return a Records.json payload with an ISO-timestamp entry and an ms-timestamp entry."""
+    return {
+        "locations": [
+            {
+                "latitudeE7": 407128000,
+                "longitudeE7": -740060000,
+                "timestamp": "2020-01-01T12:00:00.000Z",
+            },
+            {
+                "latitudeE7": 340522000,
+                "longitudeE7": -1182437000,
+                "timestampMs": "1580000000000",
+            },
+        ]
+    }
+
+
+def _semantic_month_payload() -> dict[str, Any]:
+    """Return a Semantic Location History month file with one visit + one activity."""
+    return {
+        "timelineObjects": [
+            {
+                "placeVisit": {
+                    "location": {
+                        "latitudeE7": 407128000,
+                        "longitudeE7": -740060000,
+                        "name": "Home",
+                    },
+                    "semanticType": "HOME",
+                    "duration": {
+                        "startTimestamp": "2020-01-01T08:00:00.000Z",
+                        "endTimestamp": "2020-01-01T09:00:00.000Z",
+                    },
+                }
+            },
+            {
+                "activitySegment": {
+                    "startLocation": {"latitudeE7": 407128000, "longitudeE7": -740060000},
+                    "endLocation": {"latitudeE7": 407500000, "longitudeE7": -740500000},
+                    "activityType": "WALKING",
+                    "duration": {
+                        "startTimestamp": "2020-01-04T11:00:00.000Z",
+                        "endTimestamp": "2020-01-04T12:00:00.000Z",
+                    },
+                }
+            },
+        ]
+    }
+
+
+def _no_settings_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch LocalizerSettings.get_setting to always return its default."""
+    from localizer.settings import LocalizerSettings
+
+    monkeypatch.setattr(
+        LocalizerSettings,
+        "get_setting",
+        lambda self, key, default=None: default,
+    )
+
+
+REQUIRED_KEYS = {
+    "source_id",
+    "timestamp",
+    "lat",
+    "lng",
+    "place_name",
+    "place_type",
+    "raw_json",
+    "fetched_at",
+}
+
+
+# ---------------------------------------------------------------------------
+# Registration / class-attribute tests
+# ---------------------------------------------------------------------------
+
+
+def test_google_location_plugin_is_registered() -> None:
+    """After load_builtin_plugins(), REGISTRY['google_location'] must exist."""
+    from localizer.plugins import REGISTRY, load_builtin_plugins
+
+    REGISTRY.clear()
+    load_builtin_plugins()
+    assert "google_location" in REGISTRY, (
+        f"'google_location' not in REGISTRY; keys: {list(REGISTRY)}"
+    )
+
+
+def test_google_location_plugin_plugin_id() -> None:
+    """GoogleLocationPlugin.PLUGIN_ID must equal 'google_location'."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    assert GoogleLocationPlugin.PLUGIN_ID == "google_location"
+
+
+def test_google_location_plugin_display_name_is_set() -> None:
+    """GoogleLocationPlugin.DISPLAY_NAME must be a non-empty string."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    assert isinstance(GoogleLocationPlugin.DISPLAY_NAME, str)
+    assert len(GoogleLocationPlugin.DISPLAY_NAME.strip()) > 0
+
+
+def test_google_location_plugin_fetch_mode_manual() -> None:
+    """GoogleLocationPlugin.FETCH_MODE must be FetchMode.MANUAL."""
+    from localizer.plugins.base import FetchMode
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    assert GoogleLocationPlugin.FETCH_MODE == FetchMode.MANUAL
+
+
+def test_google_location_plugin_output_tables_places() -> None:
+    """OutputTable.PLACES must be in GoogleLocationPlugin.OUTPUT_TABLES."""
+    from localizer.plugins.base import OutputTable
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    assert OutputTable.PLACES in GoogleLocationPlugin.OUTPUT_TABLES
+
+
+def test_google_location_plugin_icon_is_set() -> None:
+    """GoogleLocationPlugin.ICON must be a non-empty string."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    assert isinstance(GoogleLocationPlugin.ICON, str)
+    assert len(GoogleLocationPlugin.ICON.strip()) > 0
+
+
+def test_google_location_plugin_get_config_fields() -> None:
+    """get_config_fields() must return a field with key 'google_location_dir'."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    plugin = GoogleLocationPlugin()
+    fields = plugin.get_config_fields()
+    assert isinstance(fields, list)
+    assert len(fields) >= 1
+    for field in fields:
+        assert "key" in field
+        assert "label" in field
+
+    keys = [field["key"] for field in fields]
+    assert "google_location_dir" in keys, (
+        "Expected the settings key 'google_location_dir' so `localizer config set "
+        "google_location_dir ...` and `--set-dir` (which derives '{source}_dir') work"
+    )
+    dir_field = next(f for f in fields if f["key"] == "google_location_dir")
+    assert dir_field["type"] == "dir_path"
+
+
+def test_google_location_plugin_manual_download_instructions() -> None:
+    """get_manual_download_instructions() must return a non-empty string."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    plugin = GoogleLocationPlugin()
+    instructions = plugin.get_manual_download_instructions()
+    assert isinstance(instructions, str)
+    assert len(instructions.strip()) > 0
+
+
+# ---------------------------------------------------------------------------
+# Records.json (legacy raw GPS ping format)
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_records_parses_records_json(tmp_path: Path) -> None:
+    """A Records.json with 2 entries yields exactly 2 dicts with required keys."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    export_dir = tmp_path / "Location History"
+    _write_json(export_dir / "Records.json", _records_json_payload())
+
+    plugin = GoogleLocationPlugin(google_location_dir=str(export_dir))
+    records = list(plugin.fetch_records())
+    assert len(records) == 2
+    for record in records:
+        assert set(record.keys()) == REQUIRED_KEYS
+        assert record["source_id"] == "google_location"
+        assert isinstance(record["lat"], float)
+        assert isinstance(record["lng"], float)
+        assert isinstance(record["timestamp"], int)
+        assert record["place_type"] == "location_ping"
+        assert record["place_name"] == ""
+
+
+def test_fetch_records_records_json_latitude_e7_conversion(tmp_path: Path) -> None:
+    """latitudeE7/longitudeE7 must be divided by 1e7 to produce decimal degrees."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    export_dir = tmp_path / "Location History"
+    _write_json(export_dir / "Records.json", _records_json_payload())
+
+    plugin = GoogleLocationPlugin(google_location_dir=str(export_dir))
+    records = sorted(list(plugin.fetch_records()), key=lambda r: r["timestamp"])
+    assert records[0]["lat"] == pytest.approx(40.7128, abs=1e-4)
+    assert records[0]["lng"] == pytest.approx(-74.0060, abs=1e-4)
+    assert records[1]["lat"] == pytest.approx(34.0522, abs=1e-4)
+    assert records[1]["lng"] == pytest.approx(-118.2437, abs=1e-4)
+
+
+def test_fetch_records_records_json_ms_timestamp_fallback(tmp_path: Path) -> None:
+    """The 'timestampMs' field must be honored when 'timestamp' is absent."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    export_dir = tmp_path / "Location History"
+    _write_json(export_dir / "Records.json", _records_json_payload())
+
+    plugin = GoogleLocationPlugin(google_location_dir=str(export_dir))
+    records = list(plugin.fetch_records())
+    timestamps = {r["timestamp"] for r in records}
+    assert 1580000000 in timestamps
+
+
+def test_fetch_records_records_json_raw_json_is_serializable(tmp_path: Path) -> None:
+    """raw_json on each yielded record must be JSON-serializable."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    export_dir = tmp_path / "Location History"
+    _write_json(export_dir / "Records.json", _records_json_payload())
+
+    plugin = GoogleLocationPlugin(google_location_dir=str(export_dir))
+    for record in plugin.fetch_records():
+        raw = record["raw_json"]
+        if isinstance(raw, str):
+            json.loads(raw)
+        else:
+            json.dumps(raw)
+
+
+# ---------------------------------------------------------------------------
+# Semantic Location History (legacy placeVisit/activitySegment format)
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_records_parses_semantic_location_history(tmp_path: Path) -> None:
+    """A month file with 1 visit + 1 activity yields exactly 2 dicts."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    export_dir = tmp_path / "Location History"
+    _write_json(
+        export_dir / "Semantic Location History" / "2020" / "2020_JANUARY.json",
+        _semantic_month_payload(),
+    )
+
+    plugin = GoogleLocationPlugin(google_location_dir=str(export_dir))
+    records = list(plugin.fetch_records())
+    assert len(records) == 2
+    for record in records:
+        assert set(record.keys()) == REQUIRED_KEYS
+        assert record["source_id"] == "google_location"
+
+
+def test_fetch_records_place_visit_name_and_type(tmp_path: Path) -> None:
+    """A placeVisit yields the place's name and lowercased semantic type."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    export_dir = tmp_path / "Location History"
+    _write_json(
+        export_dir / "Semantic Location History" / "2020" / "2020_JANUARY.json",
+        _semantic_month_payload(),
+    )
+
+    plugin = GoogleLocationPlugin(google_location_dir=str(export_dir))
+    records = list(plugin.fetch_records())
+    visits = [r for r in records if not str(r["place_type"]).startswith("activity:")]
+    assert len(visits) == 1
+    assert visits[0]["place_name"] == "Home"
+    assert visits[0]["place_type"] == "home"
+
+
+def test_fetch_records_activity_segment_prefix(tmp_path: Path) -> None:
+    """An activitySegment yields a place_type prefixed with 'activity:'."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    export_dir = tmp_path / "Location History"
+    _write_json(
+        export_dir / "Semantic Location History" / "2020" / "2020_JANUARY.json",
+        _semantic_month_payload(),
+    )
+
+    plugin = GoogleLocationPlugin(google_location_dir=str(export_dir))
+    records = list(plugin.fetch_records())
+    activities = [r for r in records if str(r["place_type"]).startswith("activity:")]
+    assert len(activities) == 1
+    assert activities[0]["place_type"] == "activity:walking"
+    assert activities[0]["place_name"] == "Walking"
+
+
+def test_fetch_records_semantic_ms_timestamp_fallback(tmp_path: Path) -> None:
+    """duration.startTimestampMs must be honored when startTimestamp is absent."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    payload = {
+        "timelineObjects": [
+            {
+                "placeVisit": {
+                    "location": {
+                        "latitudeE7": 407128000,
+                        "longitudeE7": -740060000,
+                        "name": "Old Format Place",
+                    },
+                    "semanticType": "WORK",
+                    "duration": {"startTimestampMs": "1577880000000"},
+                }
+            }
+        ]
+    }
+    export_dir = tmp_path / "Location History"
+    _write_json(export_dir / "Semantic Location History" / "2020" / "2020_JANUARY.json", payload)
+
+    plugin = GoogleLocationPlugin(google_location_dir=str(export_dir))
+    records = list(plugin.fetch_records())
+    assert len(records) == 1
+    assert records[0]["timestamp"] == 1577880000
+    assert records[0]["place_name"] == "Old Format Place"
+
+
+def test_fetch_records_scans_multiple_year_and_month_files(tmp_path: Path) -> None:
+    """Multiple year directories and month files are all scanned."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    export_dir = tmp_path / "Location History"
+    _write_json(
+        export_dir / "Semantic Location History" / "2020" / "2020_JANUARY.json",
+        _semantic_month_payload(),
+    )
+    _write_json(
+        export_dir / "Semantic Location History" / "2021" / "2021_FEBRUARY.json",
+        _semantic_month_payload(),
+    )
+
+    plugin = GoogleLocationPlugin(google_location_dir=str(export_dir))
+    records = list(plugin.fetch_records())
+    assert len(records) == 4
+
+
+# ---------------------------------------------------------------------------
+# Combined formats + since filtering
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_records_combines_both_formats(tmp_path: Path) -> None:
+    """When both Records.json and Semantic Location History are present, both are yielded."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    export_dir = tmp_path / "Location History"
+    _write_json(export_dir / "Records.json", _records_json_payload())
+    _write_json(
+        export_dir / "Semantic Location History" / "2020" / "2020_JANUARY.json",
+        _semantic_month_payload(),
+    )
+
+    plugin = GoogleLocationPlugin(google_location_dir=str(export_dir))
+    records = list(plugin.fetch_records())
+    assert len(records) == 4  # 2 from Records.json + 2 from Semantic Location History
+
+
+def test_fetch_records_since_filtering_excludes_older_record(tmp_path: Path) -> None:
+    """A record with timestamp <= since must be excluded."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    export_dir = tmp_path / "Location History"
+    _write_json(export_dir / "Records.json", _records_json_payload())
+
+    plugin = GoogleLocationPlugin(google_location_dir=str(export_dir))
+    all_records = list(plugin.fetch_records())
+    assert len(all_records) == 2
+    timestamps = sorted(r["timestamp"] for r in all_records)
+    older_timestamp = timestamps[0]
+
+    filtered = list(plugin.fetch_records(since=older_timestamp))
+    assert len(filtered) == 1
+    assert all(r["timestamp"] > older_timestamp for r in filtered)
+
+
+def test_fetch_records_fetched_at_is_recent(tmp_path: Path) -> None:
+    """fetched_at must be a Unix timestamp close to now."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    export_dir = tmp_path / "Location History"
+    _write_json(export_dir / "Records.json", _records_json_payload())
+
+    before = int(time.time())
+    plugin = GoogleLocationPlugin(google_location_dir=str(export_dir))
+    records = list(plugin.fetch_records())
+    after = int(time.time())
+
+    assert len(records) == 2
+    for record in records:
+        assert before - 5 <= record["fetched_at"] <= after + 5
+
+
+# ---------------------------------------------------------------------------
+# No-config / missing-directory / malformed-file edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_records_no_dir_configured_yields_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No explicit dir and no settings entry -> fetch_records() yields [], no exception."""
+    monkeypatch.setenv("LOCALIZER_CONFIG_PATH", str(tmp_path / "empty_config.toml"))
+
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    plugin = GoogleLocationPlugin()
+    records = list(plugin.fetch_records())
+    assert records == []
+
+
+def test_fetch_records_missing_dir_yields_nothing(tmp_path: Path) -> None:
+    """A configured directory that does not exist -> fetch_records() yields [], no exception."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    plugin = GoogleLocationPlugin(google_location_dir=str(tmp_path / "does_not_exist"))
+    try:
+        records = list(plugin.fetch_records())
+    except Exception as exc:  # noqa: BLE001
+        pytest.fail(f"fetch_records() raised {type(exc).__name__} on missing dir: {exc}")
+    assert records == []
+
+
+def test_fetch_records_empty_dir_yields_nothing(tmp_path: Path) -> None:
+    """An existing but empty directory (neither format present) yields nothing."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    export_dir = tmp_path / "Location History"
+    export_dir.mkdir()
+
+    plugin = GoogleLocationPlugin(google_location_dir=str(export_dir))
+    records = list(plugin.fetch_records())
+    assert records == []
+
+
+def test_fetch_records_malformed_records_json_skipped_gracefully(tmp_path: Path) -> None:
+    """A Records.json that is not valid JSON must not raise, and yields nothing from it."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    export_dir = tmp_path / "Location History"
+    export_dir.mkdir(parents=True)
+    (export_dir / "Records.json").write_text("{not valid json", encoding="utf-8")
+
+    plugin = GoogleLocationPlugin(google_location_dir=str(export_dir))
+    try:
+        records = list(plugin.fetch_records())
+    except Exception as exc:  # noqa: BLE001
+        pytest.fail(f"fetch_records() raised {type(exc).__name__} on malformed JSON: {exc}")
+    assert records == []
+
+
+def test_fetch_records_malformed_month_file_skipped_other_files_still_processed(
+    tmp_path: Path,
+) -> None:
+    """A malformed month file is skipped; other valid month files are still parsed."""
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    export_dir = tmp_path / "Location History"
+    semantic_dir = export_dir / "Semantic Location History" / "2020"
+    semantic_dir.mkdir(parents=True)
+    (semantic_dir / "2020_JANUARY.json").write_text("not valid json {{{", encoding="utf-8")
+    _write_json(semantic_dir / "2020_FEBRUARY.json", _semantic_month_payload())
+
+    plugin = GoogleLocationPlugin(google_location_dir=str(export_dir))
+    records = list(plugin.fetch_records())
+    assert len(records) == 2, "Expected the valid month file's 2 records despite the bad one"
+
+
+# ---------------------------------------------------------------------------
+# Settings integration
+# ---------------------------------------------------------------------------
+
+
+def test_init_reads_dir_from_localizer_settings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no explicit dir, __init__ must resolve it via LocalizerSettings."""
+    config_path = tmp_path / "config.toml"
+    monkeypatch.setenv("LOCALIZER_CONFIG_PATH", str(config_path))
+
+    export_dir = tmp_path / "Location History"
+    _write_json(export_dir / "Records.json", _records_json_payload())
+
+    from localizer.settings import LocalizerSettings
+
+    LocalizerSettings().set_setting("google_location_dir", str(export_dir))
+
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    plugin = GoogleLocationPlugin()
+    records = list(plugin.fetch_records())
+    assert len(records) == 2
+
+
+def test_explicit_dir_overrides_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit google_location_dir argument must take precedence over settings."""
+    config_path = tmp_path / "config.toml"
+    monkeypatch.setenv("LOCALIZER_CONFIG_PATH", str(config_path))
+
+    from localizer.settings import LocalizerSettings
+
+    LocalizerSettings().set_setting(
+        "google_location_dir", str(tmp_path / "settings_does_not_exist")
+    )
+
+    export_dir = tmp_path / "Location History"
+    _write_json(export_dir / "Records.json", _records_json_payload())
+
+    from localizer.plugins.google_location.loader import GoogleLocationPlugin
+
+    plugin = GoogleLocationPlugin(google_location_dir=str(export_dir))
+    records = list(plugin.fetch_records())
+    assert len(records) == 2

--- a/plugins/sources/assumptions/loader.py
+++ b/plugins/sources/assumptions/loader.py
@@ -2,7 +2,7 @@
 
 Loads a user-authored JSON file that describes where the user was during
 periods not covered by Swarm check-ins — trips, recurring holidays, and
-home residency rules. This data is consumed by apply_swarm_offsets() to
+home residency rules. This data is consumed by apply_location_context() to
 assign locations and timezone offsets to Last.fm listens.
 """
 
@@ -24,7 +24,7 @@ class AssumptionsPlugin(_LegacyAutoPlugin):
     The JSON file describes where the user was during periods not recorded
     by Swarm: long trips, annually recurring holidays, and home/work
     residency rules. The sidebar passes the file path to load_assumptions()
-    so apply_swarm_offsets() can fill in locations for Last.fm listens.
+    so apply_location_context() can fill in locations for Last.fm listens.
     """
 
     PLUGIN_TYPE = "location-context"

--- a/record_flythrough.py
+++ b/record_flythrough.py
@@ -215,7 +215,7 @@ def create_recording_assets(
             return None, None
 
     from analysis_utils import (
-        apply_swarm_offsets,
+        apply_location_context,
         load_assumptions,
         load_listening_data,
         load_swarm_data,
@@ -236,7 +236,7 @@ def create_recording_assets(
             else pd.DataFrame()
         )
         assumptions = load_assumptions(assumptions_path)
-        df = apply_swarm_offsets(df, swarm_df, assumptions)
+        df = apply_location_context(df, swarm_df, assumptions)
 
     df = filter_data(df, artist, start_date, end_date)
     if df.empty:

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -140,7 +140,7 @@ class TestDataBrokerGetMergedFrame(unittest.TestCase):
         result = broker.get_merged_frame(assumptions=None)
         pd.testing.assert_frame_equal(result, lastfm_df)
 
-    def test_calls_apply_swarm_offsets_when_both_sources_loaded(self):
+    def test_calls_apply_location_context_when_both_sources_loaded(self):
         broker = DataBroker()
         lastfm_plugin = LastFmPlugin()
         swarm_plugin = SwarmPlugin()
@@ -155,11 +155,58 @@ class TestDataBrokerGetMergedFrame(unittest.TestCase):
         with patch.object(swarm_plugin, "load", return_value=swarm_df):
             broker.load(swarm_plugin, {"swarm_dir": "fake/"})
 
-        with patch("analysis_utils.apply_swarm_offsets", return_value=merged_df) as mock_merge:
+        with patch("analysis_utils.apply_location_context", return_value=merged_df) as mock_merge:
             result = broker.get_merged_frame(assumptions=assumptions)
 
         mock_merge.assert_called_once()
         self.assertIn("city", result.columns)
+
+    def test_unions_all_where_when_sources_when_multiple_loaded(self):
+        """get_merged_frame() must union every loaded where-when source (Issue #110).
+
+        Previously this hardcoded ``self._sources.get("swarm")``, silently
+        dropping any other where-when plugin (e.g. Google Timeline) loaded
+        alongside Swarm. It must now concatenate every source whose
+        PLUGIN_TYPE is "where-when" before the temporal join.
+        """
+        from plugins.sources.google_timeline.loader import GoogleTimelinePlugin
+
+        broker = DataBroker()
+        lastfm_plugin = LastFmPlugin()
+        swarm_plugin = SwarmPlugin()
+        timeline_plugin = GoogleTimelinePlugin()
+
+        lastfm_df = _make_lastfm_df()
+        swarm_df = _make_swarm_df()
+        timeline_df = pd.DataFrame(
+            {
+                "timestamp": [1620000000],
+                "lat": [51.5],
+                "lng": [-0.12],
+                "place_name": ["London"],
+                "place_type": ["visit"],
+                "source_id": ["google_timeline"],
+            }
+        )
+        assumptions = {"defaults": {}, "holidays": [], "trips": [], "residency": []}
+
+        with patch.object(lastfm_plugin, "load", return_value=lastfm_df):
+            broker.load(lastfm_plugin, {"data_path": "fake.csv"})
+        with patch.object(swarm_plugin, "load", return_value=swarm_df):
+            broker.load(swarm_plugin, {"swarm_dir": "fake/"})
+        with patch.object(timeline_plugin, "load", return_value=timeline_df):
+            broker.load(timeline_plugin, {"timeline_path": "fake.json"})
+
+        with patch("analysis_utils.apply_location_context", return_value=lastfm_df) as mock_merge:
+            broker.get_merged_frame(assumptions=assumptions)
+
+        mock_merge.assert_called_once()
+        combined_swarm_df = mock_merge.call_args[0][1]
+        self.assertEqual(
+            set(combined_swarm_df["source_id"]),
+            {"swarm", "google_timeline"},
+            "Expected get_merged_frame() to union all where-when sources' source_ids",
+        )
 
 
 class TestDataBrokerIsTypeAvailable(unittest.TestCase):

--- a/tests/test_location_fallbacks.py
+++ b/tests/test_location_fallbacks.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 
 import pandas as pd
 
-from analysis_utils import apply_swarm_offsets, get_assumption_location, load_assumptions
+from analysis_utils import apply_location_context, get_assumption_location, load_assumptions
 
 
 class TestLocationFallbacks(unittest.TestCase):
@@ -67,7 +67,7 @@ class TestLocationFallbacks(unittest.TestCase):
         self.assertIsNotNone(location)
         self.assertEqual(location["city"], "Co-working Space")
 
-    def test_apply_swarm_offsets_comprehensive(self):
+    def test_apply_location_context_comprehensive(self):
         # Create a Last.fm df covering many cases
         test_cases = [
             # 1. Holiday: Midsummer
@@ -97,7 +97,7 @@ class TestLocationFallbacks(unittest.TestCase):
         )
 
         swarm_df = pd.DataFrame(columns=["timestamp", "offset", "city", "venue", "lat", "lng"])
-        result_df = apply_swarm_offsets(df, swarm_df, self.assumptions)
+        result_df = apply_location_context(df, swarm_df, self.assumptions)
 
         for i, tc in enumerate(test_cases):
             self.assertEqual(

--- a/tests/test_music_map_america.py
+++ b/tests/test_music_map_america.py
@@ -72,7 +72,7 @@ US_STATES = [
 
 
 def _make_df() -> pd.DataFrame:
-    """Return a minimal DataFrame with the columns produced by apply_swarm_offsets."""
+    """Return a minimal DataFrame with the columns produced by apply_location_context."""
     return pd.DataFrame(
         {
             "artist": ["Artist A", "Artist A", "Artist B", "Artist C", "Artist A"],

--- a/tests/test_record_flythrough.py
+++ b/tests/test_record_flythrough.py
@@ -55,7 +55,7 @@ class TestRecordFlythrough(unittest.TestCase):
         self.assertTrue(len(keyframes) >= 2)
 
     @patch("analysis_utils.load_swarm_data")
-    @patch("analysis_utils.apply_swarm_offsets")
+    @patch("analysis_utils.apply_location_context")
     @patch("os.path.exists")
     def test_create_recording_assets_geocoding_trigger(
         self, mock_exists, mock_apply, mock_load_swarm

--- a/tests/test_sidebar.py
+++ b/tests/test_sidebar.py
@@ -46,7 +46,7 @@ class TestLoadDataCombination(unittest.TestCase):
             patch.object(sidebar, "load_google_timeline", return_value=self.timeline_df),
             patch.object(sidebar, "get_cache_key", return_value="k"),
             patch.object(sidebar, "get_cached_data", return_value=None),
-            patch.object(sidebar, "apply_swarm_offsets", return_value=self.raw_df),
+            patch.object(sidebar, "apply_location_context", return_value=self.raw_df),
             patch.object(sidebar, "save_to_cache"),
         ):
             sidebar._load_data_with_progress(

--- a/tests/test_swarm_integration.py
+++ b/tests/test_swarm_integration.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pandas as pd
 
-from analysis_utils import apply_swarm_offsets, load_swarm_data
+from analysis_utils import apply_location_context, load_swarm_data
 
 
 class TestSwarmIntegration(unittest.TestCase):
@@ -58,7 +58,7 @@ class TestSwarmIntegration(unittest.TestCase):
         self.assertEqual(df.iloc[1]["city"], "Sydney")
         self.assertEqual(df.iloc[0]["offset"], 540)
 
-    def test_apply_swarm_offsets(self):
+    def test_apply_location_context(self):
         swarm_df = load_swarm_data(self.test_dir)
 
         # Last.fm tracks in UTC
@@ -77,7 +77,7 @@ class TestSwarmIntegration(unittest.TestCase):
         lastfm_df = pd.DataFrame(tracks)
         lastfm_df["date_text"] = pd.to_datetime(lastfm_df["date_text"])
 
-        adjusted_df = apply_swarm_offsets(lastfm_df, swarm_df, self.assumptions)
+        adjusted_df = apply_location_context(lastfm_df, swarm_df, self.assumptions)
 
         # Check first track: 13:00 UTC + 9 hours (JST) = 22:00
         self.assertEqual(adjusted_df.iloc[0]["date_text"].hour, 22)


### PR DESCRIPTION
## Summary

- Renamed `apply_swarm_offsets()` to `apply_location_context()` (in `analysis_utils.py`) and updated every call site (`components/sidebar.py`, `core/broker.py`, `record_flythrough.py`) plus docstrings/comments in `core/localizer_frames.py`, `plugins/sources/assumptions/loader.py`, and `packages/localizer/README.md`. The function's own logic was already source-agnostic (it just consumes a "places"-shaped frame); the rename reflects that it's no longer Swarm-specific.
- Fixed `DataBroker.get_merged_frame()` (the legacy, deprecated broker path) to union **every** loaded where-when plugin's frame before the temporal join, instead of hardcoding `self._sources.get("swarm")`. Previously a second where-when source (e.g. Google Timeline) loaded alongside Swarm was silently dropped. `LocalizerBroker.get_merged_frame()` already queried `places` unfiltered by `source_id`, so no change was needed there.
- Added a new `google_location` plugin under `packages/localizer/src/localizer/plugins/google_location/` that reads Google Takeout's two legacy Location History export formats:
  - `Records.json` (raw GPS pings, top level of the export directory)
  - `Semantic Location History/<Year>/<Year>_<MONTH>.json` (place visits and activity segments)
  
  Both ISO-8601 and millisecond-epoch timestamp variants are handled. The plugin is `FetchMode.MANUAL`, `OutputTable.PLACES`, registered in `load_builtin_plugins()`, so `localizer config set google_location_dir "..."`, `localizer fetch google_location --full`, and `localizer status` all work end-to-end without further wiring.
- Per the issue, importing `default_assumptions.json` into DuckDB was explicitly out of scope and was not touched.

## Test plan

- [x] `packages/localizer/tests/test_google_location_plugin.py` — 27 new tests covering registration, class attributes, both export formats (including ms-timestamp fallback), combined-format fetch, `since` filtering, missing/empty/malformed-directory edge cases, and `LocalizerSettings` integration.
- [x] `tests/test_broker.py` — added `test_unions_all_where_when_sources_when_multiple_loaded`, asserting `DataBroker.get_merged_frame()` unions all where-when `source_id`s (Swarm + Google Timeline) rather than just Swarm.
- [x] Renamed the function references in `tests/test_location_fallbacks.py`, `tests/test_swarm_integration.py`, `tests/test_record_flythrough.py`, `tests/test_sidebar.py`, `tests/test_music_map_america.py` to `apply_location_context`; no behavior changes.
- [x] Full localizer suite: `cd packages/localizer && pytest -n auto` → 308 passed.
- [x] Full root suite: `pytest -n auto` → 913 passed, 71.72% coverage.
- [x] `ruff check .`, `ruff format --check .`, `mypy` all clean.
- [x] Manually verified `localizer fetch google_location --full` and `localizer status --json` end-to-end against an isolated DuckDB store.

Closes #110