### PR TITLE
feat: add Drinking History exploration view for Untappd check-ins

### DIFF
--- a/core/drinking_history.py
+++ b/core/drinking_history.py
@@ -1,0 +1,232 @@
+"""Pure Untappd check-in shaping helpers for the Drinking History page (issue #124).
+
+``UntappdPlugin`` (packages/localizer/src/localizer/plugins/untappd/loader.py) emits
+beer check-ins as ``OutputTable.EVENTS`` rows: ``label``/``sublabel``/``category`` hold
+``brewery_name``/``beer_name``/``beer_type``, while ``rating_score``/``venue_name``/
+``venue_lat``/``venue_lng`` live only inside ``raw_json`` (the events table has no
+lat/lng columns of its own). ``pages/beer.py`` needs those ``raw_json`` fields, which
+``LocalizerBroker.get_events_frame()`` does not expose — so this module works from a
+raw events frame (``timestamp, label, sublabel, category, raw_json, source_id``)
+fetched directly via ``LocalizerStore.query_events(include_raw_json=True)``.
+
+This module is intentionally Streamlit- and DuckDB-free: it is pure DataFrame-in/
+DataFrame-out logic, independently testable with hand-built fixtures, mirroring the
+convention already established by ``core/localizer_frames.py`` and
+``core/source_filter.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pandas as pd
+
+UNTAPPD_SOURCE_ID = "untappd"
+
+CHECKIN_COLUMNS = [
+    "timestamp",
+    "date",
+    "brewery",
+    "beer",
+    "style",
+    "rating",
+    "venue_name",
+    "venue_lat",
+    "venue_lng",
+]
+
+
+def _parse_raw_json(raw: Any) -> dict[str, Any]:
+    """Parse a raw_json cell into a dict, tolerating dicts, JSON strings, or None.
+
+    Args:
+        raw: The raw_json value as stored/queried — may already be a dict (e.g. in
+            hand-built test fixtures), a JSON string (as returned by DuckDB), or
+            None/NaN.
+
+    Returns:
+        A dict. Unparseable or missing values return an empty dict rather than
+        raising, so a single malformed row never crashes the page.
+    """
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str) and raw.strip():
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def build_checkins_frame(events_df: pd.DataFrame) -> pd.DataFrame:
+    """Shape a raw events frame into an Untappd check-ins frame.
+
+    Args:
+        events_df: DataFrame with columns ``timestamp, label, sublabel, category,
+            raw_json`` and, optionally, ``source_id``. When ``source_id`` is
+            present, rows are filtered to ``source_id == "untappd"``; when absent,
+            every row is treated as already-filtered Untappd data.
+
+    Returns:
+        DataFrame with columns ``timestamp, date, brewery, beer, style, rating,
+        venue_name, venue_lat, venue_lng``, sorted ascending by ``timestamp``.
+        ``rating``/``venue_lat``/``venue_lng`` are floats (``NaN`` when absent from
+        ``raw_json``). Empty/missing input returns an empty frame with exactly
+        these columns.
+    """
+    if events_df is None or events_df.empty:
+        return pd.DataFrame(columns=CHECKIN_COLUMNS)
+
+    subset = events_df
+    if "source_id" in subset.columns:
+        subset = subset[subset["source_id"] == UNTAPPD_SOURCE_ID]
+
+    if subset.empty:
+        return pd.DataFrame(columns=CHECKIN_COLUMNS)
+
+    if "raw_json" in subset.columns:
+        raw_dicts = [_parse_raw_json(raw) for raw in subset["raw_json"]]
+    else:
+        raw_dicts = [{} for _ in range(len(subset))]
+
+    result = pd.DataFrame(
+        {
+            "timestamp": subset["timestamp"].astype(int).to_numpy(),
+            "brewery": subset["label"].fillna("").to_numpy(),
+            "beer": subset["sublabel"].fillna("").to_numpy(),
+            "style": subset["category"].fillna("").to_numpy(),
+            "rating": [d.get("rating") for d in raw_dicts],
+            "venue_name": [d.get("venue_name") or "" for d in raw_dicts],
+            "venue_lat": [d.get("venue_lat") for d in raw_dicts],
+            "venue_lng": [d.get("venue_lng") for d in raw_dicts],
+        }
+    )
+    result["rating"] = pd.to_numeric(result["rating"], errors="coerce")
+    result["venue_lat"] = pd.to_numeric(result["venue_lat"], errors="coerce")
+    result["venue_lng"] = pd.to_numeric(result["venue_lng"], errors="coerce")
+    result["date"] = pd.to_datetime(result["timestamp"], unit="s")
+
+    return result.sort_values("timestamp").reset_index(drop=True)[CHECKIN_COLUMNS]
+
+
+def top_breweries(checkins_df: pd.DataFrame, top_n: int = 10) -> pd.DataFrame:
+    """Return the most-visited breweries by check-in count.
+
+    Args:
+        checkins_df: A checkins frame as returned by ``build_checkins_frame``.
+        top_n: Maximum number of breweries to return.
+
+    Returns:
+        DataFrame with columns ``[brewery, checkins]``, sorted descending by
+        ``checkins``. Empty input (or a frame missing the ``brewery`` column)
+        returns an empty frame with these columns.
+    """
+    if checkins_df is None or checkins_df.empty or "brewery" not in checkins_df.columns:
+        return pd.DataFrame(columns=["brewery", "checkins"])
+
+    named = checkins_df[checkins_df["brewery"] != ""]
+    if named.empty:
+        return pd.DataFrame(columns=["brewery", "checkins"])
+
+    counts = named.groupby("brewery").size().reset_index(name="checkins")
+    return counts.sort_values("checkins", ascending=False).head(top_n).reset_index(drop=True)
+
+
+def top_styles(checkins_df: pd.DataFrame, top_n: int = 10) -> pd.DataFrame:
+    """Return the most-checked-in beer styles by check-in count.
+
+    Args:
+        checkins_df: A checkins frame as returned by ``build_checkins_frame``.
+        top_n: Maximum number of styles to return.
+
+    Returns:
+        DataFrame with columns ``[style, checkins]``, sorted descending by
+        ``checkins``. Empty input (or a frame missing the ``style`` column)
+        returns an empty frame with these columns.
+    """
+    if checkins_df is None or checkins_df.empty or "style" not in checkins_df.columns:
+        return pd.DataFrame(columns=["style", "checkins"])
+
+    named = checkins_df[checkins_df["style"] != ""]
+    if named.empty:
+        return pd.DataFrame(columns=["style", "checkins"])
+
+    counts = named.groupby("style").size().reset_index(name="checkins")
+    return counts.sort_values("checkins", ascending=False).head(top_n).reset_index(drop=True)
+
+
+def rating_trend(checkins_df: pd.DataFrame) -> pd.DataFrame:
+    """Compute the monthly average rating trend from rated check-ins.
+
+    Args:
+        checkins_df: A checkins frame as returned by ``build_checkins_frame``.
+
+    Returns:
+        DataFrame with columns ``[month, avg_rating, rated_checkins]``, one row
+        per calendar month that has at least one rated check-in, sorted
+        ascending by ``month``. Unrated check-ins (``rating`` is ``NaN``) are
+        excluded from both the average and the count. Empty input, a frame
+        missing the ``rating``/``date`` columns, or a frame with no rated
+        check-ins at all returns an empty frame with these columns.
+    """
+    columns = ["month", "avg_rating", "rated_checkins"]
+    if checkins_df is None or checkins_df.empty:
+        return pd.DataFrame(columns=columns)
+    if "rating" not in checkins_df.columns or "date" not in checkins_df.columns:
+        return pd.DataFrame(columns=columns)
+
+    rated = checkins_df.dropna(subset=["rating"])
+    if rated.empty:
+        return pd.DataFrame(columns=columns)
+
+    rated = rated.assign(month=rated["date"].dt.to_period("M").dt.to_timestamp())
+    trend = rated.groupby("month")["rating"].agg(["mean", "count"]).reset_index()
+    trend.columns = columns
+    return trend.sort_values("month").reset_index(drop=True)
+
+
+def rating_distribution(checkins_df: pd.DataFrame) -> pd.DataFrame:
+    """Compute the count of check-ins at each distinct rating value.
+
+    Args:
+        checkins_df: A checkins frame as returned by ``build_checkins_frame``.
+
+    Returns:
+        DataFrame with columns ``[rating, checkins]``, one row per distinct
+        rating value present, sorted ascending by ``rating``. Unrated check-ins
+        are excluded. Empty input, or a frame with no rated check-ins, returns
+        an empty frame with these columns.
+    """
+    columns = ["rating", "checkins"]
+    if checkins_df is None or checkins_df.empty or "rating" not in checkins_df.columns:
+        return pd.DataFrame(columns=columns)
+
+    rated = checkins_df.dropna(subset=["rating"])
+    if rated.empty:
+        return pd.DataFrame(columns=columns)
+
+    counts = rated["rating"].value_counts().sort_index().reset_index()
+    counts.columns = columns
+    return counts
+
+
+def checkins_with_venue(checkins_df: pd.DataFrame) -> pd.DataFrame:
+    """Filter check-ins down to those with known venue coordinates, for map display.
+
+    Args:
+        checkins_df: A checkins frame as returned by ``build_checkins_frame``.
+
+    Returns:
+        The subset of rows where both ``venue_lat`` and ``venue_lng`` are
+        present, with a reset index. Empty input, or a frame missing either
+        column, returns an empty frame (preserving ``checkins_df``'s columns
+        when present).
+    """
+    if checkins_df is None or checkins_df.empty:
+        return pd.DataFrame(columns=CHECKIN_COLUMNS)
+    if "venue_lat" not in checkins_df.columns or "venue_lng" not in checkins_df.columns:
+        return pd.DataFrame(columns=checkins_df.columns)
+
+    return checkins_df.dropna(subset=["venue_lat", "venue_lng"]).reset_index(drop=True)

--- a/packages/localizer/src/localizer/store/db.py
+++ b/packages/localizer/src/localizer/store/db.py
@@ -263,15 +263,24 @@ class LocalizerStore:
         self,
         source_id: str | None = None,
         since: int | None = None,
+        include_raw_json: bool = False,
     ) -> pd.DataFrame:
         """Query events, returning the backwards-compat what-when schema.
 
         Args:
             source_id: Filter to this source only; None returns all sources.
             since: Return only rows with timestamp >= since; None returns all.
+            include_raw_json: When True, also select the raw_json column. Some
+                plugins (e.g. Untappd — issue #124) stash fields with no
+                dedicated events column (rating, venue lat/lng) inside
+                raw_json; callers that need those must opt in here rather than
+                via LocalizerBroker.get_events_frame(), which intentionally
+                keeps the generic lastfm-shaped column set stable for the
+                broader merge pipeline.
 
         Returns:
-            DataFrame with columns [timestamp, label, sublabel, category, source_id].
+            DataFrame with columns [timestamp, label, sublabel, category,
+            source_id], plus raw_json when include_raw_json is True.
         """
         assert self._conn is not None
         clauses: list[str] = []
@@ -284,7 +293,10 @@ class LocalizerStore:
             params.append(since)
 
         where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
-        sql = f"SELECT timestamp, label, sublabel, category, source_id FROM events{where}"  # noqa: S608
+        select_cols = "timestamp, label, sublabel, category, source_id"
+        if include_raw_json:
+            select_cols += ", raw_json"
+        sql = f"SELECT {select_cols} FROM events{where}"  # noqa: S608
         return self._conn.execute(sql, params).df()
 
     def query_places(

--- a/packages/localizer/tests/test_store.py
+++ b/packages/localizer/tests/test_store.py
@@ -165,6 +165,72 @@ def test_query_events_filters_by_since(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# 1b. query_events(include_raw_json=True) — issue #124, Drinking History view.
+#
+# pages/beer.py needs rating_score/venue_name/venue_lat/venue_lng, which the
+# UntappdPlugin only ever writes into raw_json (events has no lat/lng columns).
+# LocalizerBroker.get_events_frame() intentionally never exposes raw_json (it
+# feeds the generic lastfm-shaped merge), so this opt-in flag is the only way
+# to get raw_json back out of the events table without changing that default
+# shape or touching core/broker.py.
+# ---------------------------------------------------------------------------
+
+
+def test_query_events_default_excludes_raw_json_column(tmp_path):
+    """By default (include_raw_json unset), raw_json must not be in the result columns."""
+    db_path = tmp_path / "store.duckdb"
+    with LocalizerStore(db_path) as store:
+        store.upsert_events(_make_events(2))
+        df = store.query_events()
+
+    assert "raw_json" not in df.columns
+
+
+def test_query_events_include_raw_json_adds_column(tmp_path):
+    """include_raw_json=True must add a raw_json column alongside the usual ones."""
+    db_path = tmp_path / "store.duckdb"
+    records = _make_events(1)
+    records[0]["raw_json"] = '{"rating": 4.5, "venue_lat": 40.7128}'
+    with LocalizerStore(db_path) as store:
+        store.upsert_events(records)
+        df = store.query_events(include_raw_json=True)
+
+    assert "raw_json" in df.columns
+    expected_cols = {"timestamp", "label", "sublabel", "category", "source_id", "raw_json"}
+    assert expected_cols.issubset(set(df.columns))
+
+
+def test_query_events_include_raw_json_round_trips_content(tmp_path):
+    """The raw_json column returned must contain the exact JSON that was upserted."""
+    import json
+
+    db_path = tmp_path / "store.duckdb"
+    records = _make_events(1)
+    records[0]["raw_json"] = json.dumps({"rating": 4.5, "venue_name": "The Tasting Room"})
+    with LocalizerStore(db_path) as store:
+        store.upsert_events(records)
+        df = store.query_events(include_raw_json=True)
+
+    parsed = json.loads(df.iloc[0]["raw_json"])
+    assert parsed["rating"] == 4.5
+    assert parsed["venue_name"] == "The Tasting Room"
+
+
+def test_query_events_include_raw_json_still_filters_by_source_id(tmp_path):
+    """include_raw_json must not interfere with the existing source_id filter."""
+    db_path = tmp_path / "store.duckdb"
+    lastfm_events = _make_events(2, source_id="lastfm")
+    untappd_events = _make_events(3, source_id="untappd")
+    with LocalizerStore(db_path) as store:
+        store.upsert_events(lastfm_events + untappd_events)
+        df = store.query_events(source_id="untappd", include_raw_json=True)
+
+    assert len(df) == 3
+    assert (df["source_id"] == "untappd").all()
+    assert "raw_json" in df.columns
+
+
+# ---------------------------------------------------------------------------
 # 2. Re-open safety
 # ---------------------------------------------------------------------------
 

--- a/pages/beer.py
+++ b/pages/beer.py
@@ -1,16 +1,174 @@
-"""Beer page — check-in history from Untappd."""
+"""Drinking History page — Untappd check-in exploration (issue #124).
+
+Surfaces the beer check-in history emitted by ``UntappdPlugin``
+(``packages/localizer/src/localizer/plugins/untappd/loader.py``) as
+``OutputTable.EVENTS`` rows: a chronological timeline, brewery/style
+breakdowns, a rating distribution/trend, and a secondary map of check-ins that
+have venue coordinates.
+
+Data loading bypasses ``LocalizerBroker``/``components.sidebar``'s merged
+``df``/``swarm_df`` session state on purpose: rating/venue_name/venue_lat/
+venue_lng live only inside each event's ``raw_json`` (the events table has no
+lat/lng columns of its own), and ``LocalizerBroker.get_events_frame()``
+intentionally never exposes ``raw_json`` — it feeds the generic lastfm-shaped
+merge used elsewhere. This page instead opens ``LocalizerStore`` directly with
+``query_events(include_raw_json=True)`` and shapes the result via
+``core.drinking_history``.
+"""
 
 from __future__ import annotations
 
+import pandas as pd
+import plotly.express as px
 import streamlit as st
+
+from components.theme import COLORWAY, apply_dark_theme
+from core.drinking_history import (
+    build_checkins_frame,
+    checkins_with_venue,
+    rating_distribution,
+    rating_trend,
+    top_breweries,
+    top_styles,
+)
+
+_TOP_N = 10
+
+
+def _load_untappd_checkins() -> pd.DataFrame:
+    """Load and shape Untappd check-in history from the local DuckDB store.
+
+    Returns:
+        A checkins frame (see ``core.drinking_history.build_checkins_frame``),
+        or an empty frame if the store/plugin has no data yet or the query
+        fails for any reason (e.g. localizer not installed, store unreadable).
+    """
+    try:
+        from localizer.store.db import LocalizerStore  # noqa: PLC0415
+
+        with LocalizerStore() as store:
+            events_df = store.query_events(source_id="untappd", include_raw_json=True)
+    except Exception:  # noqa: BLE001
+        return build_checkins_frame(pd.DataFrame())
+
+    return build_checkins_frame(events_df)
+
+
+def _render_timeline(checkins: pd.DataFrame) -> None:
+    """Render a chronological list of check-ins, most recent first."""
+    st.subheader("Check-in Timeline")
+    timeline = checkins.sort_values("timestamp", ascending=False)
+    display = timeline[["date", "brewery", "beer", "style", "rating", "venue_name"]].copy()
+    display["date"] = display["date"].dt.strftime("%Y-%m-%d")
+    display["rating"] = display["rating"].map(lambda r: "" if pd.isna(r) else f"{r:.2f}")
+    display["venue_name"] = display["venue_name"].replace("", "—")
+    display.columns = ["Date", "Brewery", "Beer", "Style", "Rating", "Venue"]
+    st.dataframe(display, width="stretch", hide_index=True)
+
+
+def _render_breakdown(checkins: pd.DataFrame) -> None:
+    """Render top-breweries and top-beer-styles bar charts side by side."""
+    breweries = top_breweries(checkins, top_n=_TOP_N)
+    styles = top_styles(checkins, top_n=_TOP_N)
+
+    col1, col2 = st.columns(2)
+    with col1:
+        st.subheader("Top Breweries")
+        if breweries.empty:
+            st.info("No brewery data available.")
+        else:
+            st.bar_chart(breweries.set_index("brewery")["checkins"], width="stretch")
+
+    with col2:
+        st.subheader("Top Beer Styles")
+        if styles.empty:
+            st.info("No beer style data available.")
+        else:
+            st.bar_chart(styles.set_index("style")["checkins"], width="stretch")
+
+
+def _render_ratings(checkins: pd.DataFrame) -> None:
+    """Render the rating distribution and the monthly average-rating trend."""
+    distribution = rating_distribution(checkins)
+    trend = rating_trend(checkins)
+
+    st.subheader("Rating Distribution")
+    if distribution.empty:
+        st.info("No rated check-ins yet.")
+    else:
+        st.bar_chart(distribution.set_index("rating")["checkins"], width="stretch")
+
+    st.subheader("Rating Trend Over Time")
+    if trend.empty:
+        st.info("No rated check-ins yet.")
+    else:
+        st.line_chart(trend.set_index("month")["avg_rating"], width="stretch")
+
+
+def _render_venue_map(checkins: pd.DataFrame) -> None:
+    """Render a map of check-ins that have known venue coordinates."""
+    st.subheader("Venue Map")
+    mapped = checkins_with_venue(checkins)
+    if mapped.empty:
+        st.info("No check-ins with venue location data yet.")
+        return
+
+    fig = px.scatter_map(
+        mapped,
+        lat="venue_lat",
+        lon="venue_lng",
+        color="brewery",
+        hover_name="venue_name",
+        hover_data={"beer": True, "rating": True, "venue_lat": False, "venue_lng": False},
+        color_discrete_sequence=COLORWAY,
+        zoom=1,
+        title="Check-in Venues",
+    )
+    fig.update_layout(
+        map_style="carto-darkmatter",
+        height=560,
+        margin={"r": 0, "t": 40, "l": 0, "b": 0},
+    )
+    apply_dark_theme(fig)
+    st.plotly_chart(fig, width="stretch")
+
+    st.caption(f"{len(mapped):,} of {len(checkins):,} check-ins have venue location data.")
 
 
 def render_beer() -> None:
-    """Render the Beer page.
+    """Render the Drinking History page: summary metrics + four exploration tabs.
 
-    Shows an empty state until the Untappd source plugin is loaded.
+    Shows an empty-state banner until Untappd check-in data has been
+    configured and synced (see ``pages/data_sources.py``); otherwise renders a
+    chronological timeline, brewery/style breakdowns, rating distribution and
+    trend, and a secondary venue map for check-ins with known coordinates.
     """
-    st.header("Beer")
-    st.info(
-        "No beer data loaded yet. Add the Untappd source plugin and configure it in the sidebar."
-    )
+    st.header("Drinking History")
+
+    checkins = _load_untappd_checkins()
+    if checkins.empty:
+        st.info(
+            "No beer data loaded yet. Add the Untappd source plugin and configure it "
+            "in the sidebar, then sync your check-in history."
+        )
+        return
+
+    metric_cols = st.columns(3)
+    with metric_cols[0]:
+        st.metric("Total Check-ins", f"{len(checkins):,}")
+    with metric_cols[1]:
+        rated = checkins["rating"].dropna()
+        st.metric("Average Rating", f"{rated.mean():.2f}" if not rated.empty else "—")
+    with metric_cols[2]:
+        st.metric("Unique Breweries", f"{checkins['brewery'].nunique():,}")
+
+    tabs = st.tabs(["Timeline", "Breakdown", "Ratings", "Venue Map"])
+
+    with tabs[0]:
+        _render_timeline(checkins)
+    with tabs[1]:
+        _render_breakdown(checkins)
+    with tabs[2]:
+        _render_ratings(checkins)
+    with tabs[3]:
+        _render_venue_map(checkins)

--- a/tests/test_beer.py
+++ b/tests/test_beer.py
@@ -1,0 +1,246 @@
+"""Tests for the Drinking History page (``pages/beer.py::render_beer``), issue #124.
+
+Mocks Streamlit and ``pages.beer._load_untappd_checkins`` so these are fast,
+deterministic smoke tests of the page's wiring — the actual data-shaping logic
+(top breweries/styles, rating trend/distribution, venue filtering) is covered
+independently by ``tests/test_drinking_history.py``.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from core.drinking_history import CHECKIN_COLUMNS
+from pages.beer import render_beer
+
+
+def _ts(dt_str: str) -> int:
+    """Return a unix int-seconds timestamp for the given ISO date string."""
+    return int(pd.Timestamp(dt_str).timestamp())
+
+
+def _make_checkins_df() -> pd.DataFrame:
+    """A small, already-shaped checkins frame (as build_checkins_frame would return)."""
+    return pd.DataFrame(
+        {
+            "timestamp": [_ts("2023-06-01"), _ts("2023-06-15"), _ts("2023-07-01")],
+            "date": pd.to_datetime(["2023-06-01", "2023-06-15", "2023-07-01"]),
+            "brewery": ["Test Brewery Co.", "Test Brewery Co.", "Other Brewery"],
+            "beer": ["Hazy IPA", "Pilsner", "Pale Ale"],
+            "style": ["IPA", "Pilsner", "American Pale Ale"],
+            "rating": [4.5, 3.75, float("nan")],
+            "venue_name": ["The Tasting Room", "", ""],
+            "venue_lat": [40.7128, float("nan"), float("nan")],
+            "venue_lng": [-74.0060, float("nan"), float("nan")],
+        }
+    )
+
+
+def _empty_checkins_df() -> pd.DataFrame:
+    return pd.DataFrame(columns=CHECKIN_COLUMNS)
+
+
+def _make_col_mock() -> MagicMock:
+    return MagicMock(
+        __enter__=MagicMock(return_value=MagicMock()),
+        __exit__=MagicMock(return_value=False),
+    )
+
+
+def _cols_side_effect(*args, **kwargs):
+    n = args[0] if args else 1
+    count = len(n) if isinstance(n, (list, tuple)) else int(n)
+    return [_make_col_mock() for _ in range(count)]
+
+
+def _tabs_side_effect(labels, **kwargs):
+    return [_make_col_mock() for _ in labels]
+
+
+# ---------------------------------------------------------------------------
+# Empty state — no Untappd data configured/synced yet
+# ---------------------------------------------------------------------------
+
+
+class TestRenderBeerEmptyState(unittest.TestCase):
+    @patch("pages.beer._load_untappd_checkins")
+    @patch("streamlit.info")
+    @patch("streamlit.header")
+    def test_empty_checkins_shows_info_and_stops(
+        self, mock_hdr: MagicMock, mock_info: MagicMock, mock_load: MagicMock
+    ) -> None:
+        mock_load.return_value = _empty_checkins_df()
+        render_beer()
+        mock_info.assert_called_once()
+
+    @patch("pages.beer._load_untappd_checkins")
+    @patch("streamlit.info")
+    @patch("streamlit.header")
+    @patch("streamlit.columns")
+    def test_empty_checkins_skips_metrics(
+        self,
+        mock_cols: MagicMock,
+        mock_hdr: MagicMock,
+        mock_info: MagicMock,
+        mock_load: MagicMock,
+    ) -> None:
+        mock_load.return_value = _empty_checkins_df()
+        render_beer()
+        mock_cols.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Full render — populated check-ins
+# ---------------------------------------------------------------------------
+
+
+class TestRenderBeerFullRender(unittest.TestCase):
+    @patch("pages.beer._load_untappd_checkins")
+    @patch("streamlit.plotly_chart")
+    @patch("streamlit.line_chart")
+    @patch("streamlit.bar_chart")
+    @patch("streamlit.dataframe")
+    @patch("streamlit.subheader")
+    @patch("streamlit.tabs")
+    @patch("streamlit.metric")
+    @patch("streamlit.columns")
+    @patch("streamlit.header")
+    def test_full_render_calls_header_and_tabs(
+        self,
+        mock_hdr: MagicMock,
+        mock_cols: MagicMock,
+        mock_metric: MagicMock,
+        mock_tabs: MagicMock,
+        mock_sub: MagicMock,
+        mock_df: MagicMock,
+        mock_bar: MagicMock,
+        mock_line: MagicMock,
+        mock_plotly: MagicMock,
+        mock_load: MagicMock,
+    ) -> None:
+        mock_load.return_value = _make_checkins_df()
+        mock_cols.side_effect = _cols_side_effect
+        mock_tabs.side_effect = _tabs_side_effect
+
+        render_beer()
+
+        mock_hdr.assert_called_with("Drinking History")
+        mock_tabs.assert_called_once()
+        # Timeline table must be rendered.
+        mock_df.assert_called()
+
+    @patch("pages.beer._load_untappd_checkins")
+    @patch("streamlit.plotly_chart")
+    @patch("streamlit.line_chart")
+    @patch("streamlit.bar_chart")
+    @patch("streamlit.dataframe")
+    @patch("streamlit.subheader")
+    @patch("streamlit.tabs")
+    @patch("streamlit.metric")
+    @patch("streamlit.columns")
+    @patch("streamlit.header")
+    def test_full_render_computes_metrics_without_error(
+        self,
+        mock_hdr: MagicMock,
+        mock_cols: MagicMock,
+        mock_metric: MagicMock,
+        mock_tabs: MagicMock,
+        mock_sub: MagicMock,
+        mock_df: MagicMock,
+        mock_bar: MagicMock,
+        mock_line: MagicMock,
+        mock_plotly: MagicMock,
+        mock_load: MagicMock,
+    ) -> None:
+        mock_load.return_value = _make_checkins_df()
+        mock_cols.side_effect = _cols_side_effect
+        mock_tabs.side_effect = _tabs_side_effect
+
+        render_beer()
+
+        # 3 summary metrics: total check-ins, average rating, unique breweries.
+        self.assertEqual(mock_metric.call_count, 3)
+
+
+# ---------------------------------------------------------------------------
+# Venue map tab — graceful handling when no venue coordinates are present
+# ---------------------------------------------------------------------------
+
+
+class TestVenueMapTab(unittest.TestCase):
+    @patch("pages.beer._load_untappd_checkins")
+    @patch("streamlit.plotly_chart")
+    @patch("streamlit.line_chart")
+    @patch("streamlit.bar_chart")
+    @patch("streamlit.dataframe")
+    @patch("streamlit.info")
+    @patch("streamlit.subheader")
+    @patch("streamlit.tabs")
+    @patch("streamlit.metric")
+    @patch("streamlit.columns")
+    @patch("streamlit.header")
+    def test_no_venue_data_skips_map_render(
+        self,
+        mock_hdr: MagicMock,
+        mock_cols: MagicMock,
+        mock_metric: MagicMock,
+        mock_tabs: MagicMock,
+        mock_sub: MagicMock,
+        mock_info: MagicMock,
+        mock_df: MagicMock,
+        mock_bar: MagicMock,
+        mock_line: MagicMock,
+        mock_plotly: MagicMock,
+        mock_load: MagicMock,
+    ) -> None:
+        # No rows have venue coordinates.
+        checkins = _make_checkins_df()
+        checkins["venue_lat"] = float("nan")
+        checkins["venue_lng"] = float("nan")
+        mock_load.return_value = checkins
+        mock_cols.side_effect = _cols_side_effect
+        mock_tabs.side_effect = _tabs_side_effect
+
+        render_beer()
+
+        mock_plotly.assert_not_called()
+
+    @patch("pages.beer._load_untappd_checkins")
+    @patch("streamlit.plotly_chart")
+    @patch("streamlit.line_chart")
+    @patch("streamlit.bar_chart")
+    @patch("streamlit.dataframe")
+    @patch("streamlit.caption")
+    @patch("streamlit.subheader")
+    @patch("streamlit.tabs")
+    @patch("streamlit.metric")
+    @patch("streamlit.columns")
+    @patch("streamlit.header")
+    def test_venue_data_renders_map(
+        self,
+        mock_hdr: MagicMock,
+        mock_cols: MagicMock,
+        mock_metric: MagicMock,
+        mock_tabs: MagicMock,
+        mock_sub: MagicMock,
+        mock_cap: MagicMock,
+        mock_df: MagicMock,
+        mock_bar: MagicMock,
+        mock_line: MagicMock,
+        mock_plotly: MagicMock,
+        mock_load: MagicMock,
+    ) -> None:
+        mock_load.return_value = _make_checkins_df()
+        mock_cols.side_effect = _cols_side_effect
+        mock_tabs.side_effect = _tabs_side_effect
+
+        render_beer()
+
+        mock_plotly.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_drinking_history.py
+++ b/tests/test_drinking_history.py
@@ -1,0 +1,287 @@
+"""Tests for core.drinking_history — pure Untappd check-in shaping helpers.
+
+Covers issue #124 (Drinking History exploration view). These functions are
+Streamlit- and DuckDB-free: pure DataFrame-in/DataFrame-out logic, mirroring
+the convention established by core/localizer_frames.py and core/source_filter.py.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import pytest
+
+from core.drinking_history import (
+    build_checkins_frame,
+    checkins_with_venue,
+    rating_distribution,
+    rating_trend,
+    top_breweries,
+    top_styles,
+)
+
+
+def _ts(dt_str: str) -> int:
+    """Return a unix int-seconds timestamp for the given ISO date string."""
+    return int(pd.Timestamp(dt_str).timestamp())
+
+
+def _raw(**kwargs: object) -> str:
+    """Build a JSON raw_json string with rating/venue defaults matching the loader's shape."""
+    base = {
+        "rating": None,
+        "venue_name": "",
+        "venue_lat": None,
+        "venue_lng": None,
+    }
+    base.update(kwargs)
+    return json.dumps(base)
+
+
+def _make_events_df() -> pd.DataFrame:
+    """Four untappd rows plus one lastfm row that must be filtered out."""
+    return pd.DataFrame(
+        {
+            "timestamp": [
+                _ts("2023-06-01"),
+                _ts("2023-06-15"),
+                _ts("2023-07-01"),
+                _ts("2023-07-02"),
+                _ts("2023-06-10"),
+            ],
+            "label": [
+                "Test Brewery Co.",
+                "Test Brewery Co.",
+                "Other Brewery",
+                "Other Brewery",
+                "Radiohead",
+            ],
+            "sublabel": ["Hazy IPA", "Pilsner", "Pale Ale", "Stout", "Creep"],
+            "category": ["IPA", "Pilsner", "American Pale Ale", "Stout", "Rock"],
+            "raw_json": [
+                _raw(
+                    rating=4.5, venue_name="The Tasting Room", venue_lat=40.7128, venue_lng=-74.0060
+                ),
+                _raw(rating=3.75),
+                _raw(rating=None),
+                _raw(rating=4.0, venue_name="Brew Pub", venue_lat=41.0, venue_lng=-73.0),
+                None,
+            ],
+            "source_id": ["untappd", "untappd", "untappd", "untappd", "lastfm"],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_checkins_frame
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCheckinsFrame:
+    def test_filters_to_untappd_only(self) -> None:
+        result = build_checkins_frame(_make_events_df())
+        assert len(result) == 4, f"Expected 4 untappd rows, got {len(result)}"
+        assert "Radiohead" not in result["brewery"].tolist()
+
+    def test_expected_columns_present(self) -> None:
+        result = build_checkins_frame(_make_events_df())
+        expected = {
+            "timestamp",
+            "date",
+            "brewery",
+            "beer",
+            "style",
+            "rating",
+            "venue_name",
+            "venue_lat",
+            "venue_lng",
+        }
+        assert expected.issubset(set(result.columns))
+
+    def test_label_sublabel_category_mapped(self) -> None:
+        result = build_checkins_frame(_make_events_df())
+        hazy = result[result["beer"] == "Hazy IPA"].iloc[0]
+        assert hazy["brewery"] == "Test Brewery Co."
+        assert hazy["style"] == "IPA"
+
+    def test_rating_is_float_when_present(self) -> None:
+        result = build_checkins_frame(_make_events_df())
+        hazy = result[result["beer"] == "Hazy IPA"].iloc[0]
+        assert hazy["rating"] == 4.5
+
+    def test_rating_is_nan_when_missing(self) -> None:
+        result = build_checkins_frame(_make_events_df())
+        pale_ale = result[result["beer"] == "Pale Ale"].iloc[0]
+        assert pd.isna(pale_ale["rating"])
+
+    def test_venue_lat_lng_present_when_given(self) -> None:
+        result = build_checkins_frame(_make_events_df())
+        hazy = result[result["beer"] == "Hazy IPA"].iloc[0]
+        assert hazy["venue_lat"] == 40.7128
+        assert hazy["venue_lng"] == -74.0060
+        assert hazy["venue_name"] == "The Tasting Room"
+
+    def test_venue_lat_lng_nan_when_missing(self) -> None:
+        result = build_checkins_frame(_make_events_df())
+        pilsner = result[result["beer"] == "Pilsner"].iloc[0]
+        assert pd.isna(pilsner["venue_lat"])
+        assert pd.isna(pilsner["venue_lng"])
+
+    def test_date_column_is_datetime(self) -> None:
+        result = build_checkins_frame(_make_events_df())
+        assert pd.api.types.is_datetime64_any_dtype(result["date"])
+
+    def test_sorted_ascending_by_timestamp(self) -> None:
+        result = build_checkins_frame(_make_events_df())
+        assert result["timestamp"].is_monotonic_increasing
+
+    def test_empty_input_returns_empty_frame_with_columns(self) -> None:
+        result = build_checkins_frame(pd.DataFrame())
+        assert result.empty
+        assert "brewery" in result.columns
+
+    def test_none_source_id_column_treated_as_all_rows(self) -> None:
+        """A frame without a source_id column (e.g. already pre-filtered) passes through."""
+        df = pd.DataFrame(
+            {
+                "timestamp": [_ts("2023-06-01")],
+                "label": ["Test Brewery Co."],
+                "sublabel": ["Hazy IPA"],
+                "category": ["IPA"],
+                "raw_json": [_raw(rating=4.5)],
+            }
+        )
+        result = build_checkins_frame(df)
+        assert len(result) == 1
+
+    def test_dict_raw_json_also_supported(self) -> None:
+        """raw_json may already be a parsed dict (not just a JSON string)."""
+        df = pd.DataFrame(
+            {
+                "timestamp": [_ts("2023-06-01")],
+                "label": ["Test Brewery Co."],
+                "sublabel": ["Hazy IPA"],
+                "category": ["IPA"],
+                "raw_json": [
+                    {"rating": 4.5, "venue_name": "", "venue_lat": None, "venue_lng": None}
+                ],
+                "source_id": ["untappd"],
+            }
+        )
+        result = build_checkins_frame(df)
+        assert result.iloc[0]["rating"] == 4.5
+
+
+# ---------------------------------------------------------------------------
+# top_breweries / top_styles
+# ---------------------------------------------------------------------------
+
+
+class TestTopBreweries:
+    def test_counts_and_orders_descending(self) -> None:
+        checkins = build_checkins_frame(_make_events_df())
+        result = top_breweries(checkins)
+        # Both breweries have 2 check-ins each in the fixture (a tie); every row
+        # must report the correct count regardless of tie-break ordering.
+        assert set(result["brewery"]) == {"Test Brewery Co.", "Other Brewery"}
+        assert (result["checkins"] == 2).all()
+
+    def test_respects_top_n(self) -> None:
+        checkins = build_checkins_frame(_make_events_df())
+        result = top_breweries(checkins, top_n=1)
+        assert len(result) == 1
+
+    def test_empty_input_returns_empty_frame(self) -> None:
+        result = top_breweries(pd.DataFrame())
+        assert result.empty
+        assert "brewery" in result.columns
+
+
+class TestTopStyles:
+    def test_counts_and_orders_descending(self) -> None:
+        checkins = build_checkins_frame(_make_events_df())
+        result = top_styles(checkins)
+        assert set(result["style"]) == {"IPA", "Pilsner", "American Pale Ale", "Stout"}
+        assert (result["checkins"] == 1).all()
+
+    def test_empty_input_returns_empty_frame(self) -> None:
+        result = top_styles(pd.DataFrame())
+        assert result.empty
+        assert "style" in result.columns
+
+
+# ---------------------------------------------------------------------------
+# rating_trend
+# ---------------------------------------------------------------------------
+
+
+class TestRatingTrend:
+    def test_groups_by_month_and_averages(self) -> None:
+        checkins = build_checkins_frame(_make_events_df())
+        result = rating_trend(checkins)
+        # June has 4.5 and 3.75 rated checkins -> mean 4.125; July has 4.0 rated (Pale Ale
+        # unrated is excluded).
+        june_row = result[result["month"] == pd.Timestamp("2023-06-01")].iloc[0]
+        assert june_row["avg_rating"] == pytest.approx(4.125)
+        assert june_row["rated_checkins"] == 2
+
+    def test_unrated_checkins_excluded(self) -> None:
+        checkins = build_checkins_frame(_make_events_df())
+        result = rating_trend(checkins)
+        july_row = result[result["month"] == pd.Timestamp("2023-07-01")].iloc[0]
+        assert july_row["rated_checkins"] == 1  # only Stout (4.0), Pale Ale unrated excluded
+
+    def test_empty_input_returns_empty_frame(self) -> None:
+        result = rating_trend(pd.DataFrame())
+        assert result.empty
+        assert "avg_rating" in result.columns
+
+    def test_all_unrated_returns_empty_frame(self) -> None:
+        df = build_checkins_frame(_make_events_df())
+        df = df.assign(rating=float("nan"))
+        result = rating_trend(df)
+        assert result.empty
+
+
+# ---------------------------------------------------------------------------
+# rating_distribution
+# ---------------------------------------------------------------------------
+
+
+class TestRatingDistribution:
+    def test_counts_per_rating_value(self) -> None:
+        checkins = build_checkins_frame(_make_events_df())
+        result = rating_distribution(checkins)
+        assert set(result.columns) == {"rating", "checkins"}
+        assert result["checkins"].sum() == 3  # 4.5, 3.75, 4.0 rated; Pale Ale unrated excluded
+
+    def test_empty_input_returns_empty_frame(self) -> None:
+        result = rating_distribution(pd.DataFrame())
+        assert result.empty
+
+
+# ---------------------------------------------------------------------------
+# checkins_with_venue
+# ---------------------------------------------------------------------------
+
+
+class TestCheckinsWithVenue:
+    def test_filters_to_rows_with_venue_coords(self) -> None:
+        checkins = build_checkins_frame(_make_events_df())
+        result = checkins_with_venue(checkins)
+        assert len(result) == 2
+        assert set(result["brewery"]) == {"Test Brewery Co.", "Other Brewery"}
+
+    def test_rows_without_venue_excluded(self) -> None:
+        checkins = build_checkins_frame(_make_events_df())
+        result = checkins_with_venue(checkins)
+        assert "Pilsner" not in result["beer"].tolist()
+
+    def test_empty_input_returns_empty_frame(self) -> None:
+        result = checkins_with_venue(pd.DataFrame())
+        assert result.empty
+
+    def test_missing_venue_columns_returns_empty_frame(self) -> None:
+        result = checkins_with_venue(pd.DataFrame({"brewery": ["X"]}))
+        assert result.empty

--- a/visualize.py
+++ b/visualize.py
@@ -178,7 +178,7 @@ def main() -> None:
             ],
             "Culture": [
                 st.Page(render_culture, title="Films & Books", icon=":material/local_library:"),
-                st.Page(render_beer, title="Beer", icon=":material/sports_bar:"),
+                st.Page(render_beer, title="Drinking History", icon=":material/sports_bar:"),
             ],
             "Sources": sources_pages,
         }


### PR DESCRIPTION
## Summary
- Adds a **Drinking History** page (`pages/beer.py`, nav renamed from "Beer" in `visualize.py`) surfacing Untappd check-in history: a chronological timeline, top-breweries/top-styles breakdowns, a rating distribution + monthly rating trend, and a secondary venue map for check-ins with known coordinates.
- Adds `core/drinking_history.py`, a pure Streamlit/DuckDB-free module (mirroring `core/localizer_frames.py`'s convention) that shapes a raw events frame into a checkins frame and computes the breakdown/trend/map views. It parses `rating`/`venue_name`/`venue_lat`/`venue_lng` out of each event's `raw_json`, since the events table has no dedicated columns for them.
- Adds an opt-in `include_raw_json: bool = False` parameter to `LocalizerStore.query_events()` (`packages/localizer/src/localizer/store/db.py`) so the page can fetch `raw_json` directly. `core/broker.py`/`LocalizerBroker.get_events_frame()` is untouched — it keeps its existing lastfm-shaped column contract used by the rest of the app.
- Handles check-ins with and without venue coordinates, and shows an empty-state banner until Untappd data is configured/synced.

Closes #124

## Test plan
- [x] `ruff check .` — no issues
- [x] `ruff format --check .` — no issues
- [x] `mypy` — no issues
- [x] `pytest -n auto` (root suite) — 945 passed
- [x] `pytest -n auto` (packages/localizer suite) — 284 passed
- [x] New unit tests: `tests/test_drinking_history.py` (27 tests) for the pure shaping/breakdown/trend/venue-filter helpers
- [x] New unit tests: `tests/test_beer.py` (6 tests) for the page's empty-state, full-render, and venue-map-tab wiring
- [x] New unit tests in `packages/localizer/tests/test_store.py` for `query_events(include_raw_json=True)`