### PR TITLE
feat: add Photograph History view and Flickr EVENTS pipeline

### DIFF
--- a/packages/localizer/src/localizer/cli.py
+++ b/packages/localizer/src/localizer/cli.py
@@ -27,6 +27,34 @@ from localizer.settings import LocalizerSettings
 _BATCH_SIZE = 1_000  # records per DuckDB write; keeps peak RAM at O(batch) not O(total)
 
 
+def _upsert_for_table(store: Any, batch: list[dict[str, Any]], table: Any) -> None:
+    """Write a batch of records to whichever store table ``table`` designates.
+
+    Shared by ``fetch`` and ``sync`` so both single-output plugins (the
+    common case — one ``OUTPUT_TABLES`` entry) and dual-output plugins (e.g.
+    ``FlickrPlugin``, which declares ``[PLACES, EVENTS]`` and drains its
+    primary ``fetch_records()`` stream into the first entry and its
+    ``fetch_secondary_records()`` stream into the second) route through one
+    place instead of duplicating the events/places/content if-chain.
+
+    Args:
+        store: Open ``LocalizerStore``.
+        batch: List of record dicts already shaped for the target table.
+        table: The ``OutputTable`` member this batch belongs to. Falls back
+            to ``upsert_events`` when ``table`` is ``None``/unrecognized,
+            matching the historical default for plugins with an empty
+            ``OUTPUT_TABLES`` list.
+    """
+    from localizer.plugins.base import OutputTable  # noqa: PLC0415
+
+    if table == OutputTable.PLACES:
+        store.upsert_places(batch)
+    elif table == OutputTable.CONTENT:
+        store.upsert_content(batch)
+    else:
+        store.upsert_events(batch)
+
+
 def _get_store_path() -> Path:
     """Resolve the DuckDB store path via settings / env var.
 
@@ -300,28 +328,22 @@ def fetch_cmd(
 
     from rich.console import Console  # noqa: PLC0415
 
-    from localizer.plugins.base import OutputTable  # noqa: PLC0415
-
     console = Console(stderr=True)
     output_tables = getattr(plugin_cls, "OUTPUT_TABLES", [])
+    primary_table = output_tables[0] if output_tables else None
+    secondary_table = output_tables[1] if len(output_tables) > 1 else None
     count = 0
     batch: list[dict[str, Any]] = []
-
-    def _upsert(store: Any, b: list[dict[str, Any]]) -> None:
-        if OutputTable.EVENTS in output_tables:
-            store.upsert_events(b)
-        elif OutputTable.PLACES in output_tables:
-            store.upsert_places(b)
-        elif OutputTable.CONTENT in output_tables:
-            store.upsert_content(b)
-        else:
-            store.upsert_events(b)
 
     if dry_run:
         with console.status(f"  {source}: counting…", spinner="dots") as status:
             for _ in plugin.fetch_records(since=effective_since):
                 count += 1
                 status.update(f"  {source}: {count} records (dry-run)…")
+            if secondary_table is not None:
+                for _ in plugin.fetch_secondary_records(since=effective_since):
+                    count += 1
+                    status.update(f"  {source}: {count} records (dry-run)…")
         click.echo(f"[dry-run] Would write {count} record(s) from '{source}' to store.")
         return
 
@@ -334,13 +356,28 @@ def fetch_cmd(
             count += 1
             if len(batch) >= _BATCH_SIZE:
                 status.update(f"  {source}: writing batch… ({count} records so far)")
-                _upsert(store, batch)
+                _upsert_for_table(store, batch, primary_table)
                 batch.clear()
             status.update(f"  {source}: fetching {count} records…")
         if batch:
             status.update(f"  {source}: writing final batch… ({count} records)")
-            _upsert(store, batch)
+            _upsert_for_table(store, batch, primary_table)
             batch.clear()
+
+        if secondary_table is not None:
+            for record in plugin.fetch_secondary_records(since=effective_since):
+                batch.append(record)
+                count += 1
+                if len(batch) >= _BATCH_SIZE:
+                    status.update(f"  {source}: writing batch… ({count} records so far)")
+                    _upsert_for_table(store, batch, secondary_table)
+                    batch.clear()
+                status.update(f"  {source}: fetching {count} records…")
+            if batch:
+                status.update(f"  {source}: writing final batch… ({count} records)")
+                _upsert_for_table(store, batch, secondary_table)
+                batch.clear()
+
         # Only advance the cursor when records were actually written — a zero-record
         # run (misconfiguration, transient error) must not set last_synced_at to now,
         # or the next run would filter out all historical data.
@@ -372,7 +409,6 @@ def sync_cmd(since: int | None, dry_run: bool) -> None:
     from rich.console import Console  # noqa: PLC0415
 
     from localizer.plugins import REGISTRY, load_builtin_plugins  # noqa: PLC0415
-    from localizer.plugins.base import OutputTable  # noqa: PLC0415
     from localizer.store.db import LocalizerStore  # noqa: PLC0415
 
     load_builtin_plugins()
@@ -388,6 +424,8 @@ def sync_cmd(since: int | None, dry_run: bool) -> None:
             click.echo(f"  {plugin_id}: skipped (requires configuration — {exc})", err=True)
             continue
         output_tables = getattr(plugin_cls, "OUTPUT_TABLES", [])
+        primary_table = output_tables[0] if output_tables else None
+        secondary_table = output_tables[1] if len(output_tables) > 1 else None
 
         # Determine effective since from sync state.
         effective_since = since
@@ -403,24 +441,20 @@ def sync_cmd(since: int | None, dry_run: bool) -> None:
         count = 0
         batch: list[dict[str, Any]] = []
 
-        def _upsert_batch(
-            store: Any, b: list[dict[str, Any]], _ot: list[Any] = output_tables
-        ) -> None:
-            if OutputTable.EVENTS in _ot:
-                store.upsert_events(b)
-            elif OutputTable.PLACES in _ot:
-                store.upsert_places(b)
-            elif OutputTable.CONTENT in _ot:
-                store.upsert_content(b)
-            else:
-                store.upsert_events(b)
-
         if dry_run:
             try:
                 with console.status(f"  {plugin_id}: counting…", spinner="dots") as status:
                     for _ in plugin.fetch_records(since=effective_since, progress_cb=_progress_cb):
                         count += 1
                         status.update(f"  {plugin_id}: {count} records{page_label[0]} (dry-run)…")
+                    if secondary_table is not None:
+                        for _ in plugin.fetch_secondary_records(
+                            since=effective_since, progress_cb=_progress_cb
+                        ):
+                            count += 1
+                            status.update(
+                                f"  {plugin_id}: {count} records{page_label[0]} (dry-run)…"
+                            )
             except OSError as exc:
                 click.echo(f"  {plugin_id}: skipped ({exc})", err=True)
                 continue
@@ -441,13 +475,32 @@ def sync_cmd(since: int | None, dry_run: bool) -> None:
                         status.update(
                             f"  {plugin_id}: writing batch… ({count} records{page_label[0]})"
                         )
-                        _upsert_batch(store, batch)
+                        _upsert_for_table(store, batch, primary_table)
                         batch.clear()
                     status.update(f"  {plugin_id}: fetching {count} records{page_label[0]}…")
                 if batch:
                     status.update(f"  {plugin_id}: writing final batch… ({count} records)")
-                    _upsert_batch(store, batch)
+                    _upsert_for_table(store, batch, primary_table)
                     batch.clear()
+
+                if secondary_table is not None:
+                    for record in plugin.fetch_secondary_records(
+                        since=effective_since, progress_cb=_progress_cb
+                    ):
+                        batch.append(record)
+                        count += 1
+                        if len(batch) >= _BATCH_SIZE:
+                            status.update(
+                                f"  {plugin_id}: writing batch… ({count} records{page_label[0]})"
+                            )
+                            _upsert_for_table(store, batch, secondary_table)
+                            batch.clear()
+                        status.update(f"  {plugin_id}: fetching {count} records{page_label[0]}…")
+                    if batch:
+                        status.update(f"  {plugin_id}: writing final batch… ({count} records)")
+                        _upsert_for_table(store, batch, secondary_table)
+                        batch.clear()
+
                 if count > 0:
                     store.set_sync_state(
                         plugin_id,

--- a/packages/localizer/src/localizer/plugins/base.py
+++ b/packages/localizer/src/localizer/plugins/base.py
@@ -84,6 +84,32 @@ class SourcePlugin(ABC):
     # Optional (non-abstract) stubs — override in concrete plugins
     # ------------------------------------------------------------------
 
+    def fetch_secondary_records(
+        self,
+        since: int | None = None,
+        progress_cb: Any | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Yield records for a plugin's *second* ``OUTPUT_TABLES`` entry.
+
+        Most plugins declare exactly one entry in ``OUTPUT_TABLES`` and never
+        need this — ``fetch_records()`` alone is their whole output. A
+        dual-output plugin (e.g. ``FlickrPlugin``, which emits both
+        ``PLACES`` and ``EVENTS`` from a single import: geotagged photos as
+        places, every photo as a timeline event) overrides this to yield the
+        second output table's records independently of ``fetch_records()``'s
+        primary stream, so the two shapes never have to be interleaved into
+        one generator.
+
+        Args:
+            since: Optional Unix timestamp; yield only records newer than this.
+            progress_cb: Optional callback invoked with ``(current, total)``
+                for progress reporting.
+
+        Returns:
+            Empty iterator by default.
+        """
+        return iter([])
+
     def get_playwright_script(self) -> str | None:
         """Return a Playwright script string for PLAYWRIGHT-mode plugins.
 

--- a/packages/localizer/src/localizer/plugins/flickr/loader.py
+++ b/packages/localizer/src/localizer/plugins/flickr/loader.py
@@ -52,7 +52,7 @@ class FlickrPlugin(SourcePlugin):
     PLUGIN_ID = "flickr"
     DISPLAY_NAME = "Flickr Photos"
     FETCH_MODE = FetchMode.MANUAL
-    OUTPUT_TABLES = [OutputTable.PLACES]
+    OUTPUT_TABLES = [OutputTable.PLACES, OutputTable.EVENTS]
     ICON = ":material/photo_camera:"
 
     def __init__(
@@ -115,24 +115,21 @@ class FlickrPlugin(SourcePlugin):
             "   folder containing the 'photo_*.json' files.\n"
         )
 
-    def fetch_records(
-        self,
-        since: int | None = None,
-        progress_cb: Any | None = None,
-    ) -> Iterator[dict[str, Any]]:
-        """Yield normalized place dicts from Flickr JSON export files.
+    def _iter_photo_records(self, since: int | None) -> Iterator[tuple[dict[str, Any], int, int]]:
+        """Glob, parse, and timestamp every ``photo_*.json`` export file once.
 
-        Reads all ``photo_*.json`` files in ``export_dir`` and yields one
-        record per photo. Missing or non-existent directories yield nothing
-        gracefully; a malformed file is skipped without aborting the rest.
+        Shared by :meth:`fetch_records` (PLACES output) and
+        :meth:`fetch_secondary_records` (EVENTS output) so the file-reading,
+        malformed-file skipping, and ``date_taken`` parsing logic lives in
+        exactly one place.
 
         Args:
-            since: Optional Unix timestamp; yield only photos newer than this.
-            progress_cb: Optional progress callback (unused for manual plugins).
+            since: Optional Unix timestamp; only photos newer than this are
+                yielded.
 
         Yields:
-            Dicts with keys: source_id, timestamp, lat, lng, place_name,
-            place_type, raw_json, fetched_at.
+            Tuples of ``(data, timestamp, fetched_at)`` for every valid,
+            since-filtered photo — geotagged or not.
         """
         if not self._export_dir:
             return
@@ -165,6 +162,30 @@ class FlickrPlugin(SourcePlugin):
             if since is not None and timestamp <= since:
                 continue
 
+            yield data, timestamp, fetched_at
+
+    def fetch_records(
+        self,
+        since: int | None = None,
+        progress_cb: Any | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Yield normalized place dicts from Flickr JSON export files.
+
+        Reads all ``photo_*.json`` files in ``export_dir`` and yields one
+        record per geotagged photo (or every photo, with NaN lat/lng, when
+        ``geotagged_only`` is False). Missing or non-existent directories
+        yield nothing gracefully; a malformed file is skipped without
+        aborting the rest.
+
+        Args:
+            since: Optional Unix timestamp; yield only photos newer than this.
+            progress_cb: Optional progress callback (unused for manual plugins).
+
+        Yields:
+            Dicts with keys: source_id, timestamp, lat, lng, place_name,
+            place_type, raw_json, fetched_at.
+        """
+        for data, timestamp, fetched_at in self._iter_photo_records(since):
             geo = data.get("geo")
             geotagged = False
             lat = float("nan")
@@ -187,6 +208,44 @@ class FlickrPlugin(SourcePlugin):
                 "lng": lng,
                 "place_name": data.get("name") or "",
                 "place_type": "photo",
+                "raw_json": data,
+                "fetched_at": fetched_at,
+            }
+
+    def fetch_secondary_records(
+        self,
+        since: int | None = None,
+        progress_cb: Any | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Yield every photo as a timeline event, geotagged or not.
+
+        A photograph is fundamentally an event too — a moment in time with a
+        shareable URL, independent of whether it happened to carry GPS
+        coordinates. Unlike :meth:`fetch_records`, this is never filtered by
+        ``geotagged_only``: every photo in the export directory becomes one
+        event record, so photos dropped from the PLACES pipeline are still
+        visible via the EVENTS pipeline (e.g. the Photograph History page).
+
+        Args:
+            since: Optional Unix timestamp; yield only photos newer than this.
+            progress_cb: Optional progress callback (unused for manual plugins).
+
+        Yields:
+            Dicts with keys: source_id, timestamp, label, sublabel, category,
+            raw_json, fetched_at. ``label`` is the photo title, ``sublabel``
+            is its first album (if any). ``raw_json`` preserves the full
+            export record, including ``tags``, ``albums``, and ``photopage``.
+        """
+        for data, timestamp, fetched_at in self._iter_photo_records(since):
+            albums = data.get("albums")
+            sublabel = albums[0] if isinstance(albums, list) and albums else ""
+
+            yield {
+                "source_id": "flickr",
+                "timestamp": timestamp,
+                "label": data.get("name") or "",
+                "sublabel": sublabel,
+                "category": "photo",
                 "raw_json": data,
                 "fetched_at": fetched_at,
             }

--- a/packages/localizer/src/localizer/store/db.py
+++ b/packages/localizer/src/localizer/store/db.py
@@ -263,15 +263,21 @@ class LocalizerStore:
         self,
         source_id: str | None = None,
         since: int | None = None,
+        include_raw_json: bool = False,
     ) -> pd.DataFrame:
         """Query events, returning the backwards-compat what-when schema.
 
         Args:
             source_id: Filter to this source only; None returns all sources.
             since: Return only rows with timestamp >= since; None returns all.
+            include_raw_json: When True, also select the ``raw_json`` column
+                (e.g. for consumers that need source-specific detail such as
+                a photo's tags or shareable URL). Defaults to False so
+                existing callers see the same column set as before.
 
         Returns:
-            DataFrame with columns [timestamp, label, sublabel, category, source_id].
+            DataFrame with columns [timestamp, label, sublabel, category,
+            source_id], plus [raw_json] when include_raw_json is True.
         """
         assert self._conn is not None
         clauses: list[str] = []
@@ -284,7 +290,10 @@ class LocalizerStore:
             params.append(since)
 
         where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
-        sql = f"SELECT timestamp, label, sublabel, category, source_id FROM events{where}"  # noqa: S608
+        columns = "timestamp, label, sublabel, category, source_id"
+        if include_raw_json:
+            columns += ", raw_json"
+        sql = f"SELECT {columns} FROM events{where}"  # noqa: S608
         return self._conn.execute(sql, params).df()
 
     def query_places(

--- a/packages/localizer/tests/test_cli.py
+++ b/packages/localizer/tests/test_cli.py
@@ -448,3 +448,130 @@ def test_fetch_dry_run_does_not_write(tmp_db: Path) -> None:
             f"--dry-run must not write events; store has rows after fetch --dry-run. "
             f"CLI output: {result.output}"
         )
+
+
+# ---------------------------------------------------------------------------
+# 14. Dual-output plugin (FlickrPlugin) routes to both PLACES and EVENTS
+# ---------------------------------------------------------------------------
+
+
+def test_sync_writes_dual_output_plugin_to_both_tables(tmp_db: Path) -> None:
+    """A plugin with OUTPUT_TABLES=[PLACES, EVENTS] (FlickrPlugin) must write its
+    primary fetch_records() stream to places AND its fetch_secondary_records()
+    stream to events — not collapse both into one table."""
+    fake_place = {
+        "source_id": "flickr",
+        "timestamp": 1_800_000,
+        "lat": 51.5074,
+        "lng": -0.1278,
+        "place_name": "Geotagged Photo",
+        "place_type": "photo",
+        "raw_json": None,
+        "fetched_at": int(time.time()),
+    }
+    fake_events = [
+        {
+            "source_id": "flickr",
+            "timestamp": 1_800_000 + i,
+            "label": f"Photo {i}",
+            "sublabel": "Album",
+            "category": "photo",
+            "raw_json": None,
+            "fetched_at": int(time.time()),
+        }
+        for i in range(2)
+    ]
+
+    runner = CliRunner()
+    env = {**os.environ, "LOCALIZER_DB_PATH": str(tmp_db)}
+
+    # Scope the registry to just FlickrPlugin so `sync` never touches the
+    # real (network-calling) API plugins — this test only cares about
+    # dual-output dispatch, not the other plugins' fetch behavior.
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    def _fake_load_builtin_plugins() -> None:
+        from localizer.plugins import REGISTRY  # noqa: PLC0415
+
+        REGISTRY.clear()
+        REGISTRY["flickr"] = FlickrPlugin
+
+    with (
+        patch(
+            "localizer.plugins.flickr.loader.FlickrPlugin.fetch_records",
+            return_value=iter([fake_place]),
+        ),
+        patch(
+            "localizer.plugins.flickr.loader.FlickrPlugin.fetch_secondary_records",
+            return_value=iter(fake_events),
+        ),
+        patch("localizer.plugins.load_builtin_plugins", _fake_load_builtin_plugins),
+    ):
+        result = runner.invoke(cli, ["sync"], env=env)
+
+    assert result.exit_code == 0, result.output
+
+    from localizer.store.db import LocalizerStore
+
+    with LocalizerStore(tmp_db) as store:
+        places_df = store.query_places(source_id="flickr")
+        events_df = store.query_events(source_id="flickr")
+
+    assert len(places_df) == 1, (
+        f"Expected 1 place row from FlickrPlugin's primary stream, got {len(places_df)}. "
+        f"CLI output: {result.output}"
+    )
+    assert len(events_df) == 2, (
+        f"Expected 2 event rows from FlickrPlugin's secondary stream, got {len(events_df)}. "
+        f"CLI output: {result.output}"
+    )
+
+
+def test_fetch_writes_dual_output_plugin_to_both_tables(tmp_db: Path) -> None:
+    """localizer fetch flickr must also route primary/secondary streams to
+    places/events respectively (same guarantee as sync, single-source path)."""
+    fake_place = {
+        "source_id": "flickr",
+        "timestamp": 1_900_000,
+        "lat": 40.0,
+        "lng": -74.0,
+        "place_name": "Geotagged Photo 2",
+        "place_type": "photo",
+        "raw_json": None,
+        "fetched_at": int(time.time()),
+    }
+    fake_event = {
+        "source_id": "flickr",
+        "timestamp": 1_900_001,
+        "label": "Photo X",
+        "sublabel": "",
+        "category": "photo",
+        "raw_json": None,
+        "fetched_at": int(time.time()),
+    }
+
+    runner = CliRunner()
+    env = {**os.environ, "LOCALIZER_DB_PATH": str(tmp_db)}
+
+    with (
+        patch(
+            "localizer.plugins.flickr.loader.FlickrPlugin.fetch_records",
+            return_value=iter([fake_place]),
+        ),
+        patch(
+            "localizer.plugins.flickr.loader.FlickrPlugin.fetch_secondary_records",
+            return_value=iter([fake_event]),
+        ),
+    ):
+        result = runner.invoke(cli, ["fetch", "flickr"], env=env)
+
+    assert result.exit_code == 0, result.output
+
+    from localizer.store.db import LocalizerStore
+
+    with LocalizerStore(tmp_db) as store:
+        places_df = store.query_places(source_id="flickr")
+        events_df = store.query_events(source_id="flickr")
+
+    assert len(places_df) == 1
+    assert len(events_df) == 1

--- a/packages/localizer/tests/test_flickr_plugin.py
+++ b/packages/localizer/tests/test_flickr_plugin.py
@@ -554,6 +554,240 @@ def test_fetch_records_fetched_at_is_recent(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# OUTPUT_TABLES dual-output (issue #123)
+# ---------------------------------------------------------------------------
+
+
+def test_flickr_plugin_output_tables_includes_events() -> None:
+    """OutputTable.EVENTS must now also be in FlickrPlugin.OUTPUT_TABLES."""
+    from localizer.plugins.base import OutputTable
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    assert OutputTable.EVENTS in FlickrPlugin.OUTPUT_TABLES
+
+
+def test_flickr_plugin_output_tables_still_includes_places() -> None:
+    """OutputTable.PLACES must remain in FlickrPlugin.OUTPUT_TABLES (unchanged)."""
+    from localizer.plugins.base import OutputTable
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    assert OutputTable.PLACES in FlickrPlugin.OUTPUT_TABLES
+
+
+# ---------------------------------------------------------------------------
+# fetch_secondary_records — EVENTS output (issue #123)
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_secondary_records_non_geotagged_photo_is_yielded(tmp_path: Path) -> None:
+    """A non-geotagged photo, dropped by fetch_records(geotagged_only=True), must
+    still appear via fetch_secondary_records() — the whole point of the EVENTS pipeline."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(geo=None))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path), geotagged_only=True)
+    place_records = list(plugin.fetch_records())
+    event_records = list(plugin.fetch_secondary_records())
+
+    assert place_records == [], "Sanity check: PLACES pipeline still drops non-geotagged photos"
+    assert len(event_records) == 1, (
+        f"Expected the non-geotagged photo to appear via EVENTS, got {len(event_records)}"
+    )
+
+
+def test_fetch_secondary_records_geotagged_photo_also_yielded(tmp_path: Path) -> None:
+    """A geotagged photo must also appear via fetch_secondary_records() (EVENTS)."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(geo=GEOTAGGED))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    event_records = list(plugin.fetch_secondary_records())
+
+    assert len(event_records) == 1
+
+
+def test_fetch_secondary_records_label_is_photo_title(tmp_path: Path) -> None:
+    """label must equal the photo's 'name' (title)."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(name="Sunset over the bay", geo=None))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_secondary_records())
+
+    assert len(records) == 1
+    assert records[0]["label"] == "Sunset over the bay"
+
+
+def test_fetch_secondary_records_missing_title_yields_empty_label(tmp_path: Path) -> None:
+    """A photo with no 'name' key must yield label == '' (not KeyError/None)."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(name=None, geo=None))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_secondary_records())
+
+    assert len(records) == 1
+    assert records[0]["label"] == ""
+
+
+def test_fetch_secondary_records_sublabel_is_first_album(tmp_path: Path) -> None:
+    """sublabel must equal the first album title when albums are present."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(
+        tmp_path,
+        "photo_1.json",
+        _make_photo_data(albums=["Alps 2023", "Best Of"], geo=None),
+    )
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_secondary_records())
+
+    assert len(records) == 1
+    assert records[0]["sublabel"] == "Alps 2023"
+
+
+def test_fetch_secondary_records_no_albums_yields_empty_sublabel(tmp_path: Path) -> None:
+    """sublabel must be '' when the photo has no albums."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(albums=[], geo=None))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_secondary_records())
+
+    assert len(records) == 1
+    assert records[0]["sublabel"] == ""
+
+
+def test_fetch_secondary_records_category_is_photo(tmp_path: Path) -> None:
+    """category must be 'photo' for every EVENTS record."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(geo=None))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_secondary_records())
+
+    assert records[0]["category"] == "photo"
+
+
+def test_fetch_secondary_records_raw_json_preserves_tags_and_photopage(tmp_path: Path) -> None:
+    """raw_json must preserve tags/albums/photopage verbatim for the EVENTS record."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    data = _make_photo_data(
+        geo=None,
+        tags=["mountains", "hiking"],
+        albums=["Alps 2023"],
+        photopage="https://www.flickr.com/photos/testuser/42/",
+    )
+    _write_photo(tmp_path, "photo_1.json", data)
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_secondary_records())
+    assert len(records) == 1
+
+    raw = _raw_json(records[0])
+    assert raw["tags"] == ["mountains", "hiking"]
+    assert raw["albums"] == ["Alps 2023"]
+    assert raw["photopage"] == "https://www.flickr.com/photos/testuser/42/"
+
+
+def test_fetch_secondary_records_source_id_is_flickr(tmp_path: Path) -> None:
+    """Each EVENTS record's source_id must equal 'flickr'."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(geo=None))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_secondary_records())
+
+    assert records[0]["source_id"] == "flickr"
+
+
+def test_fetch_secondary_records_dict_has_required_keys(tmp_path: Path) -> None:
+    """Each EVENTS record must have the required event record keys."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(geo=None))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_secondary_records())
+    assert len(records) == 1
+
+    required_keys = {
+        "source_id",
+        "timestamp",
+        "label",
+        "sublabel",
+        "category",
+        "raw_json",
+        "fetched_at",
+    }
+    missing = required_keys - set(records[0].keys())
+    assert not missing, f"EVENTS record missing required keys: {missing}"
+
+
+def test_fetch_secondary_records_empty_export_dir_yields_empty_list(tmp_path: Path) -> None:
+    """An empty export directory must yield [] from fetch_secondary_records()."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_secondary_records())
+
+    assert records == []
+
+
+def test_fetch_secondary_records_malformed_json_file_skipped(tmp_path: Path) -> None:
+    """A malformed photo_*.json file must be skipped; the valid one still yielded."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    (tmp_path / "photo_bad.json").write_text("{not valid json", encoding="utf-8")
+    _write_photo(tmp_path, "photo_good.json", _make_photo_data(geo=None))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_secondary_records())
+
+    assert len(records) == 1
+
+
+def test_fetch_secondary_records_since_cursor_excludes_older_photo(tmp_path: Path) -> None:
+    """A photo older than 'since' must be excluded from fetch_secondary_records()."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    older_date = "2023-01-01 00:00:00"
+    newer_date = "2023-06-15 18:30:00"
+    _write_photo(tmp_path, "photo_old.json", _make_photo_data(date_taken=older_date, geo=None))
+    _write_photo(tmp_path, "photo_new.json", _make_photo_data(date_taken=newer_date, geo=None))
+
+    older_ts = int(datetime.fromisoformat(older_date.replace(" ", "T")).timestamp())
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_secondary_records(since=older_ts))
+
+    assert len(records) == 1
+
+
+def test_fetch_secondary_records_multiple_files_all_parsed(tmp_path: Path) -> None:
+    """Multiple photo_*.json files (mixed geotagged status) must all appear as events."""
+    from localizer.plugins.flickr.loader import FlickrPlugin
+
+    _write_photo(tmp_path, "photo_1.json", _make_photo_data(geo=GEOTAGGED))
+    _write_photo(tmp_path, "photo_2.json", _make_photo_data(geo=None))
+    _write_photo(tmp_path, "photo_3.json", _make_photo_data(geo=None))
+
+    plugin = FlickrPlugin(export_dir=str(tmp_path))
+    records = list(plugin.fetch_secondary_records())
+
+    assert len(records) == 3
+
+
+# ---------------------------------------------------------------------------
 # Network-isolation test
 # ---------------------------------------------------------------------------
 

--- a/packages/localizer/tests/test_store.py
+++ b/packages/localizer/tests/test_store.py
@@ -141,6 +141,34 @@ def test_query_events_filters_by_source_id(tmp_path):
     assert (df["source_id"] == "lastfm").all()
 
 
+def test_query_events_default_omits_raw_json(tmp_path):
+    """query_events() without include_raw_json must not add a raw_json column."""
+    db_path = tmp_path / "store.duckdb"
+    with LocalizerStore(db_path) as store:
+        store.upsert_events(_make_events(1))
+        df = store.query_events()
+
+    assert "raw_json" not in df.columns
+
+
+def test_query_events_include_raw_json_adds_column(tmp_path):
+    """query_events(include_raw_json=True) must add a raw_json column with the stored value."""
+    import json
+
+    db_path = tmp_path / "store.duckdb"
+    records = _make_events(1)
+    records[0]["raw_json"] = json.dumps({"tags": ["a", "b"], "photopage": "https://example.com/1"})
+    with LocalizerStore(db_path) as store:
+        store.upsert_events(records)
+        df = store.query_events(include_raw_json=True)
+
+    assert "raw_json" in df.columns
+    assert len(df) == 1
+    parsed = json.loads(df.iloc[0]["raw_json"])
+    assert parsed["tags"] == ["a", "b"]
+    assert parsed["photopage"] == "https://example.com/1"
+
+
 def test_query_events_filters_by_since(tmp_path):
     """Upsert 3 events at timestamps 1000, 2000, 3000; since=1500 returns 2 rows."""
     db_path = tmp_path / "store.duckdb"

--- a/pages/photograph_history.py
+++ b/pages/photograph_history.py
@@ -1,0 +1,218 @@
+"""Photograph History page — chronological browsing of Flickr photo events.
+
+Reads the ``flickr`` source's EVENTS-shaped rows directly from the localizer
+DuckDB store (bypassing ``core/broker.py``, which stays untouched here) so
+every photo — geotagged or not — shows up as a timeline entry with a
+clickable link to its original Flickr photo page.
+
+The geotagged subset already has its own dedicated view: Geo Explorer, fed by
+the unchanged PLACES pipeline. This page cross-links there rather than
+duplicating any map rendering.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pandas as pd
+import streamlit as st
+
+_ALL = "All"
+
+
+def _load_flickr_events_df() -> pd.DataFrame:
+    """Query the localizer store for flickr EVENTS rows, including raw_json.
+
+    Returns:
+        DataFrame with columns [timestamp, label, sublabel, category,
+        source_id, raw_json], or an empty DataFrame if the store is missing,
+        unreadable, or has no flickr event rows.
+    """
+    try:
+        from localizer.store.db import LocalizerStore  # noqa: PLC0415
+
+        with LocalizerStore() as store:
+            return store.query_events(source_id="flickr", include_raw_json=True)
+    except Exception:  # noqa: BLE001
+        return pd.DataFrame()
+
+
+def _parse_raw_json(raw: Any) -> dict[str, Any]:
+    """Parse a raw_json cell (JSON string, dict, or missing) into a dict.
+
+    Args:
+        raw: The raw_json cell value — a JSON string, an already-parsed
+            dict, or a falsy/NaN value.
+
+    Returns:
+        Parsed dict, or {} when raw is empty or unparsable.
+    """
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str) and raw.strip():
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def build_photo_table(events_df: pd.DataFrame) -> pd.DataFrame:
+    """Adapt raw flickr EVENTS rows into a display-ready photo table.
+
+    Args:
+        events_df: DataFrame with columns [timestamp, label, sublabel,
+            category, source_id, raw_json] — the shape returned by
+            :func:`_load_flickr_events_df`.
+
+    Returns:
+        DataFrame with columns [date, title, album, tags, url], sorted by
+        date descending (most recent photo first). ``tags`` is a list of
+        strings per row. Empty input returns an empty frame with these
+        columns.
+    """
+    columns = ["date", "title", "album", "tags", "url"]
+    if events_df is None or events_df.empty:
+        return pd.DataFrame(columns=columns)
+
+    rows: list[dict[str, Any]] = []
+    for _, row in events_df.iterrows():
+        raw = _parse_raw_json(row.get("raw_json"))
+        tags = raw.get("tags")
+        rows.append(
+            {
+                "date": pd.to_datetime(row["timestamp"], unit="s"),
+                "title": row.get("label") or "",
+                "album": row.get("sublabel") or "",
+                "tags": list(tags) if isinstance(tags, list) else [],
+                "url": raw.get("photopage") or "",
+            }
+        )
+
+    return (
+        pd.DataFrame(rows, columns=columns)
+        .sort_values("date", ascending=False)
+        .reset_index(drop=True)
+    )
+
+
+def get_tag_options(photo_df: pd.DataFrame) -> list[str]:
+    """Return the sorted, de-duplicated set of tags across all photos.
+
+    Args:
+        photo_df: A photo table from :func:`build_photo_table`.
+
+    Returns:
+        ``["All"]`` when empty or lacking a ``tags`` column, else ``["All"]``
+        followed by every distinct tag, alphabetically sorted.
+    """
+    if photo_df is None or photo_df.empty or "tags" not in photo_df.columns:
+        return [_ALL]
+    all_tags: set[str] = set()
+    for tags in photo_df["tags"]:
+        if isinstance(tags, list):
+            all_tags.update(tags)
+    return [_ALL, *sorted(all_tags)]
+
+
+def get_album_options(photo_df: pd.DataFrame) -> list[str]:
+    """Return the sorted, de-duplicated set of non-empty albums.
+
+    Args:
+        photo_df: A photo table from :func:`build_photo_table`.
+
+    Returns:
+        ``["All"]`` when empty or lacking an ``album`` column, else
+        ``["All"]`` followed by every distinct non-empty album name.
+    """
+    if photo_df is None or photo_df.empty or "album" not in photo_df.columns:
+        return [_ALL]
+    albums = sorted({a for a in photo_df["album"] if a})
+    return [_ALL, *albums]
+
+
+def filter_photos(photo_df: pd.DataFrame, tag: str, album: str) -> pd.DataFrame:
+    """Filter a photo table down to a selected tag and/or album.
+
+    Args:
+        photo_df: A photo table from :func:`build_photo_table`.
+        tag: A tag previously returned by :func:`get_tag_options`, or "All".
+        album: An album previously returned by :func:`get_album_options`, or "All".
+
+    Returns:
+        ``photo_df`` unchanged when both filters are "All" (or the frame is
+        empty). Otherwise the subset of rows matching both filters, with a
+        reset index. The input frame is never mutated.
+    """
+    if photo_df is None or photo_df.empty:
+        return photo_df
+
+    mask = pd.Series(True, index=photo_df.index)
+    if tag != _ALL:
+        mask &= photo_df["tags"].apply(lambda tags: isinstance(tags, list) and tag in tags)
+    if album != _ALL:
+        mask &= photo_df["album"] == album
+
+    return photo_df[mask].reset_index(drop=True)
+
+
+def render_photograph_history() -> None:
+    """Render the Photograph History page.
+
+    Shows a chronological timeline of every Flickr photo (geotagged or not)
+    with a clickable link to its original Flickr photo page, filterable by
+    tag and album. Shows an empty-state banner when no Flickr data has been
+    configured/synced yet.
+    """
+    st.header("Photograph History")
+    st.caption("Every photo from your Flickr export, in chronological order.")
+
+    events_df = _load_flickr_events_df()
+    photo_df = build_photo_table(events_df)
+
+    if photo_df.empty:
+        st.info(
+            "No Flickr photo data loaded yet. "
+            "Configure the Flickr Photos source under Sources and run a sync "
+            "to populate your photograph history."
+        )
+        return
+
+    filter_col1, filter_col2 = st.columns(2)
+    with filter_col1:
+        selected_tag = st.selectbox("Tag", get_tag_options(photo_df), key="photo_history_tag")
+    with filter_col2:
+        selected_album = st.selectbox(
+            "Album", get_album_options(photo_df), key="photo_history_album"
+        )
+
+    filtered = filter_photos(photo_df, selected_tag, selected_album)
+
+    st.caption(f"Showing {len(filtered):,} of {len(photo_df):,} photos")
+
+    display = filtered.copy()
+    display["tags"] = display["tags"].apply(lambda tags: ", ".join(tags) if tags else "")
+
+    st.dataframe(
+        display.rename(
+            columns={
+                "date": "Date",
+                "title": "Title",
+                "album": "Album",
+                "tags": "Tags",
+                "url": "Link",
+            }
+        ),
+        column_config={
+            "Link": st.column_config.LinkColumn("Link", display_text="Open on Flickr"),
+        },
+        hide_index=True,
+        width="stretch",
+    )
+
+    st.caption(
+        "Tip: geotagged photos from this same Flickr export also appear on the "
+        "**Geo Explorer** map (Overview → Geo Explorer)."
+    )

--- a/tests/test_photograph_history.py
+++ b/tests/test_photograph_history.py
@@ -1,0 +1,325 @@
+"""Tests for the Photograph History page (issue #123).
+
+Covers the pure DataFrame-in/DataFrame-out helpers (build_photo_table,
+get_tag_options, get_album_options, filter_photos) with hand-built fixtures,
+plus a Streamlit smoke test for render_photograph_history() with all st.*
+calls mocked (mirroring the pattern in tests/test_life_events.py).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from pages.photograph_history import (
+    build_photo_table,
+    filter_photos,
+    get_album_options,
+    get_tag_options,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _raw(
+    tags: list[str] | None = None,
+    albums: list[str] | None = None,
+    photopage: str = "https://www.flickr.com/photos/testuser/1/",
+) -> str:
+    """Return a JSON-serialized raw_json blob matching the Flickr export shape."""
+    return json.dumps(
+        {
+            "tags": tags if tags is not None else [],
+            "albums": albums if albums is not None else [],
+            "photopage": photopage,
+        }
+    )
+
+
+def _events_fixture() -> pd.DataFrame:
+    """Three flickr EVENTS rows: two share an album/tag, one has neither."""
+    return pd.DataFrame(
+        [
+            {
+                "timestamp": 1_686_849_000,  # 2023-06-15
+                "label": "Sunset over the bay",
+                "sublabel": "Summer Trip",
+                "category": "photo",
+                "source_id": "flickr",
+                "raw_json": _raw(
+                    tags=["travel", "sunset"],
+                    albums=["Summer Trip"],
+                    photopage="https://www.flickr.com/photos/testuser/1/",
+                ),
+            },
+            {
+                "timestamp": 1_700_000_000,  # later
+                "label": "Mountain hike",
+                "sublabel": "Alps 2023",
+                "category": "photo",
+                "source_id": "flickr",
+                "raw_json": _raw(
+                    tags=["travel", "hiking"],
+                    albums=["Alps 2023"],
+                    photopage="https://www.flickr.com/photos/testuser/2/",
+                ),
+            },
+            {
+                "timestamp": 1_650_000_000,  # earliest, no album/tags
+                "label": "Untitled",
+                "sublabel": "",
+                "category": "photo",
+                "source_id": "flickr",
+                "raw_json": _raw(tags=[], albums=[], photopage=""),
+            },
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_photo_table
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPhotoTable:
+    def test_empty_input_returns_empty_frame_with_expected_columns(self) -> None:
+        result = build_photo_table(pd.DataFrame())
+        assert result.empty
+        assert list(result.columns) == ["date", "title", "album", "tags", "url"]
+
+    def test_none_input_returns_empty_frame(self) -> None:
+        result = build_photo_table(None)  # type: ignore[arg-type]
+        assert result.empty
+
+    def test_row_count_matches_input(self) -> None:
+        result = build_photo_table(_events_fixture())
+        assert len(result) == 3
+
+    def test_sorted_descending_by_date_most_recent_first(self) -> None:
+        result = build_photo_table(_events_fixture())
+        assert result.iloc[0]["title"] == "Mountain hike"
+        assert result.iloc[-1]["title"] == "Untitled"
+
+    def test_title_comes_from_label(self) -> None:
+        result = build_photo_table(_events_fixture())
+        titles = set(result["title"])
+        assert "Sunset over the bay" in titles
+        assert "Mountain hike" in titles
+
+    def test_album_comes_from_sublabel(self) -> None:
+        result = build_photo_table(_events_fixture())
+        row = result[result["title"] == "Sunset over the bay"].iloc[0]
+        assert row["album"] == "Summer Trip"
+
+    def test_tags_parsed_from_raw_json(self) -> None:
+        result = build_photo_table(_events_fixture())
+        row = result[result["title"] == "Mountain hike"].iloc[0]
+        assert row["tags"] == ["travel", "hiking"]
+
+    def test_url_parsed_from_raw_json_photopage(self) -> None:
+        result = build_photo_table(_events_fixture())
+        row = result[result["title"] == "Sunset over the bay"].iloc[0]
+        assert row["url"] == "https://www.flickr.com/photos/testuser/1/"
+
+    def test_photo_with_no_tags_or_album_yields_empty_values(self) -> None:
+        result = build_photo_table(_events_fixture())
+        row = result[result["title"] == "Untitled"].iloc[0]
+        assert row["tags"] == []
+        assert row["album"] == ""
+        assert row["url"] == ""
+
+    def test_handles_dict_raw_json_not_just_string(self) -> None:
+        """raw_json may already be a parsed dict (not just a JSON string)."""
+        df = pd.DataFrame(
+            [
+                {
+                    "timestamp": 1_600_000_000,
+                    "label": "Dict Photo",
+                    "sublabel": "",
+                    "category": "photo",
+                    "source_id": "flickr",
+                    "raw_json": {"tags": ["a"], "albums": [], "photopage": "https://x/1"},
+                }
+            ]
+        )
+        result = build_photo_table(df)
+        assert result.iloc[0]["tags"] == ["a"]
+        assert result.iloc[0]["url"] == "https://x/1"
+
+    def test_malformed_raw_json_string_does_not_raise(self) -> None:
+        df = pd.DataFrame(
+            [
+                {
+                    "timestamp": 1_600_000_000,
+                    "label": "Bad JSON",
+                    "sublabel": "",
+                    "category": "photo",
+                    "source_id": "flickr",
+                    "raw_json": "{not valid json",
+                }
+            ]
+        )
+        result = build_photo_table(df)
+        assert result.iloc[0]["tags"] == []
+        assert result.iloc[0]["url"] == ""
+
+
+# ---------------------------------------------------------------------------
+# get_tag_options / get_album_options
+# ---------------------------------------------------------------------------
+
+
+class TestGetTagOptions:
+    def test_empty_frame_returns_all_only(self) -> None:
+        assert get_tag_options(pd.DataFrame()) == ["All"]
+
+    def test_returns_all_distinct_tags_sorted_after_all(self) -> None:
+        photo_df = build_photo_table(_events_fixture())
+        options = get_tag_options(photo_df)
+        assert options[0] == "All"
+        assert set(options[1:]) == {"travel", "sunset", "hiking"}
+        assert options[1:] == sorted(options[1:])
+
+
+class TestGetAlbumOptions:
+    def test_empty_frame_returns_all_only(self) -> None:
+        assert get_album_options(pd.DataFrame()) == ["All"]
+
+    def test_returns_distinct_nonempty_albums_sorted_after_all(self) -> None:
+        photo_df = build_photo_table(_events_fixture())
+        options = get_album_options(photo_df)
+        assert options[0] == "All"
+        assert set(options[1:]) == {"Summer Trip", "Alps 2023"}
+        # The photo with no album ("") must not appear as a spurious option.
+        assert "" not in options
+
+
+# ---------------------------------------------------------------------------
+# filter_photos
+# ---------------------------------------------------------------------------
+
+
+class TestFilterPhotos:
+    def test_all_tag_all_album_returns_everything(self) -> None:
+        photo_df = build_photo_table(_events_fixture())
+        result = filter_photos(photo_df, "All", "All")
+        assert len(result) == len(photo_df)
+
+    def test_filter_by_specific_tag(self) -> None:
+        photo_df = build_photo_table(_events_fixture())
+        result = filter_photos(photo_df, "hiking", "All")
+        assert len(result) == 1
+        assert result.iloc[0]["title"] == "Mountain hike"
+
+    def test_filter_by_specific_album(self) -> None:
+        photo_df = build_photo_table(_events_fixture())
+        result = filter_photos(photo_df, "All", "Summer Trip")
+        assert len(result) == 1
+        assert result.iloc[0]["title"] == "Sunset over the bay"
+
+    def test_filter_by_tag_and_album_combined(self) -> None:
+        photo_df = build_photo_table(_events_fixture())
+        result = filter_photos(photo_df, "travel", "Summer Trip")
+        assert len(result) == 1
+        assert result.iloc[0]["title"] == "Sunset over the bay"
+
+    def test_filter_shared_tag_returns_multiple_photos(self) -> None:
+        photo_df = build_photo_table(_events_fixture())
+        result = filter_photos(photo_df, "travel", "All")
+        assert len(result) == 2
+
+    def test_empty_frame_passthrough(self) -> None:
+        empty = build_photo_table(pd.DataFrame())
+        result = filter_photos(empty, "travel", "All")
+        assert result.empty
+
+    def test_result_has_reset_index(self) -> None:
+        photo_df = build_photo_table(_events_fixture())
+        result = filter_photos(photo_df, "travel", "All")
+        assert list(result.index) == list(range(len(result)))
+
+    def test_does_not_mutate_input(self) -> None:
+        photo_df = build_photo_table(_events_fixture())
+        original_len = len(photo_df)
+        filter_photos(photo_df, "hiking", "All")
+        assert len(photo_df) == original_len
+
+
+# ---------------------------------------------------------------------------
+# render_photograph_history — smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestRenderPhotographHistorySmoke:
+    def test_empty_state_shown_when_no_flickr_data(self) -> None:
+        """When no flickr events exist, an info banner is shown and rendering stops
+        before any filter widgets are created."""
+        with (
+            patch("pages.photograph_history._load_flickr_events_df", return_value=pd.DataFrame()),
+            patch("pages.photograph_history.st") as mock_st,
+        ):
+            mock_st.header = MagicMock()
+            mock_st.caption = MagicMock()
+            mock_st.info = MagicMock()
+            mock_st.columns = MagicMock()
+            mock_st.selectbox = MagicMock()
+            mock_st.dataframe = MagicMock()
+
+            from pages import photograph_history
+
+            photograph_history.render_photograph_history()
+
+            mock_st.info.assert_called_once()
+            mock_st.columns.assert_not_called()
+            mock_st.dataframe.assert_not_called()
+
+    def test_renders_without_exception_with_data(self) -> None:
+        """With real flickr event data, rendering must not raise (all st.* mocked)."""
+        mock_col1, mock_col2 = MagicMock(), MagicMock()
+        mock_col1.__enter__ = MagicMock(return_value=mock_col1)
+        mock_col1.__exit__ = MagicMock(return_value=False)
+        mock_col2.__enter__ = MagicMock(return_value=mock_col2)
+        mock_col2.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch(
+                "pages.photograph_history._load_flickr_events_df",
+                return_value=_events_fixture(),
+            ),
+            patch("pages.photograph_history.st") as mock_st,
+        ):
+            mock_st.header = MagicMock()
+            mock_st.caption = MagicMock()
+            mock_st.info = MagicMock()
+            mock_st.columns = MagicMock(return_value=[mock_col1, mock_col2])
+            mock_st.selectbox = MagicMock(return_value="All")
+            mock_st.dataframe = MagicMock()
+            mock_st.column_config = MagicMock()
+            mock_st.column_config.LinkColumn = MagicMock(return_value="link_column")
+
+            from pages import photograph_history
+
+            try:
+                photograph_history.render_photograph_history()
+            except Exception as exc:  # noqa: BLE001
+                pytest.fail(f"render_photograph_history raised with data present: {exc}")
+
+            mock_st.dataframe.assert_called_once()
+            mock_st.info.assert_not_called()
+
+    def test_load_flickr_events_df_returns_empty_on_store_error(self) -> None:
+        """_load_flickr_events_df must swallow store errors (e.g. missing DB) gracefully."""
+        with patch(
+            "localizer.store.db.LocalizerStore.__init__",
+            side_effect=Exception("no store"),
+        ):
+            from pages.photograph_history import _load_flickr_events_df
+
+            result = _load_flickr_events_df()
+            assert isinstance(result, pd.DataFrame)
+            assert result.empty

--- a/visualize.py
+++ b/visualize.py
@@ -32,6 +32,7 @@ from pages.life_in_chapters import render_life_in_chapters
 from pages.listening_lifestyle import render_listening_lifestyle
 from pages.music import render_music, render_top_charts  # noqa: F401
 from pages.overview import render_overview  # noqa: F401
+from pages.photograph_history import render_photograph_history
 from pages.places import render_checkin_insights  # noqa: F401
 from pages.taste_drift import render_taste_drift
 from pages.venue_patterns import render_venue_patterns
@@ -179,6 +180,11 @@ def main() -> None:
             "Culture": [
                 st.Page(render_culture, title="Films & Books", icon=":material/local_library:"),
                 st.Page(render_beer, title="Beer", icon=":material/sports_bar:"),
+                st.Page(
+                    render_photograph_history,
+                    title="Photograph History",
+                    icon=":material/photo_camera:",
+                ),
             ],
             "Sources": sources_pages,
         }


### PR DESCRIPTION
## Summary
- Extends `FlickrPlugin` to emit both `OutputTable.PLACES` (existing, unchanged — geotagged photos only) and `OutputTable.EVENTS` (new — every photo, geotagged or not) from a single import, via a new `fetch_secondary_records()` hook on `SourcePlugin`. Non-geotagged photos, previously dropped entirely when `geotagged_only=True`, are now visible as timeline events.
- Adds dual-output dispatch to the localizer CLI (`fetch`/`sync`): a plugin declaring two `OUTPUT_TABLES` entries now routes its primary (`fetch_records()`) and secondary (`fetch_secondary_records()`) streams to the correct tables (places + events) instead of collapsing both into one table.
- Adds an opt-in `include_raw_json` flag to `LocalizerStore.query_events()` so consumers that need source-specific detail (tags, shareable URL) can request it without changing the default column shape for existing callers.
- Adds a new **Photograph History** page (`pages/photograph_history.py`, wired into the Culture nav group) showing a chronological, tag/album-filterable timeline of Flickr photos with clickable links to the original Flickr photo page, plus an empty-state banner when no Flickr data is configured yet, and a cross-link hint pointing to Geo Explorer for the geotagged subset.

## Design notes / judgment calls
- `FlickrPlugin.fetch_records()` is untouched byte-for-byte in behavior (still PLACES-only, still respects `geotagged_only`) — all 37 pre-existing tests in `test_flickr_plugin.py` pass unmodified. The new EVENTS output lives entirely in a new `fetch_secondary_records()` method, sharing a private `_iter_photo_records()` generator with `fetch_records()` for the glob/parse/timestamp logic.
- EVENTS row shape: `label` = photo title (`name`), `sublabel` = first album title (empty string if none), `category` = `"photo"`, `raw_json` = the full export record (preserving `tags`, `albums`, `photopage`, `description`).
- The CLI previously dispatched an entire batch to one table based on `OutputTable` membership checked in a fixed EVENTS→PLACES→CONTENT order — this silently mis-routes any plugin with more than one `OUTPUT_TABLES` entry (FlickrPlugin is the first such plugin). Fixed by using `output_tables[0]`/`output_tables[1]` explicitly for primary/secondary dispatch; single-output plugins are unaffected (verified via full regression suite).
- The new page queries `LocalizerStore` directly (not `LocalizerBroker`, which is out of scope for this change) since `core/broker.py` is off-limits for this branch.

## Test plan
- [x] `packages/localizer/tests/test_flickr_plugin.py` — 53 tests (37 pre-existing unchanged + 16 new EVENTS-pipeline tests) pass
- [x] `packages/localizer/tests/test_store.py` — new `include_raw_json` tests pass, existing tests unaffected
- [x] `packages/localizer/tests/test_cli.py` — new dual-output dispatch tests (`sync` and `fetch`) pass; all 18 tests in the file pass
- [x] `tests/test_photograph_history.py` — 26 new tests covering pure table/filter helpers and Streamlit render smoke tests
- [x] Full localizer suite: `cd packages/localizer && pytest -n auto` → 300 passed
- [x] Full root suite: `pytest -n auto` → 938 passed
- [x] `ruff check .`, `ruff format --check .`, `mypy` all clean

Closes #123