### PR TITLE
feat: add Runkeeper source plugin

### DIFF
--- a/packages/localizer/src/localizer/plugins/__init__.py
+++ b/packages/localizer/src/localizer/plugins/__init__.py
@@ -51,6 +51,7 @@ def load_builtin_plugins() -> None:
     from localizer.plugins.lastfm.loader import LastFmPlugin
     from localizer.plugins.letterboxd.loader import LetterboxdPlugin
     from localizer.plugins.rss.loader import RssPlugin
+    from localizer.plugins.runkeeper.loader import RunkeeperPlugin
     from localizer.plugins.swarm.loader import SwarmPlugin
     from localizer.plugins.untappd.loader import UntappdPlugin
 
@@ -64,3 +65,4 @@ def load_builtin_plugins() -> None:
     REGISTRY[GoogleLocationPlugin.PLUGIN_ID] = GoogleLocationPlugin
     REGISTRY[FlickrPlugin.PLUGIN_ID] = FlickrPlugin
     REGISTRY[UntappdPlugin.PLUGIN_ID] = UntappdPlugin
+    REGISTRY[RunkeeperPlugin.PLUGIN_ID] = RunkeeperPlugin

--- a/packages/localizer/src/localizer/plugins/runkeeper/loader.py
+++ b/packages/localizer/src/localizer/plugins/runkeeper/loader.py
@@ -1,0 +1,219 @@
+"""Runkeeper source plugin for the localizer package."""
+
+from __future__ import annotations
+
+import csv
+import json
+import time
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from localizer.plugins import register
+from localizer.plugins.base import FetchMode, OutputTable, SourcePlugin
+
+_EXPORT_FILENAME = "cardioActivities.csv"
+
+
+def _parse_optional_float(value: str | None) -> float | None:
+    """Parse a string to a float, returning None when blank/unparseable.
+
+    Args:
+        value: Raw string value from a CSV cell (may be None or empty).
+
+    Returns:
+        The parsed float, or None when the value is blank or not a valid
+        float (never raises, never returns NaN).
+    """
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    try:
+        return float(stripped)
+    except ValueError:
+        return None
+
+
+def _parse_duration_to_seconds(value: str | None) -> int | None:
+    """Convert an ``HH:MM:SS`` (or ``MM:SS``/``SS``) duration string to seconds.
+
+    Args:
+        value: Raw ``Duration`` CSV cell, e.g. ``"00:32:15"``.
+
+    Returns:
+        Total seconds as an int, or None when blank/malformed (never raises).
+    """
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+
+    parts = stripped.split(":")
+    try:
+        numeric_parts = [int(part) for part in parts]
+    except ValueError:
+        return None
+
+    if len(numeric_parts) == 3:
+        hours, minutes, seconds = numeric_parts
+    elif len(numeric_parts) == 2:
+        hours = 0
+        minutes, seconds = numeric_parts
+    elif len(numeric_parts) == 1:
+        hours, minutes = 0, 0
+        seconds = numeric_parts[0]
+    else:
+        return None
+
+    return hours * 3600 + minutes * 60 + seconds
+
+
+@register
+class RunkeeperPlugin(SourcePlugin):
+    """Load Runkeeper activity history from a local ``cardioActivities.csv`` export.
+
+    ``FETCH_MODE`` is ``MANUAL`` — the user must export their data from
+    Runkeeper (Settings -> Export Data) and point this plugin's
+    ``export_dir`` config field at the unzipped export directory. The
+    export also contains individual per-activity ``.gpx`` files, which this
+    plugin never reads; only the ``cardioActivities.csv`` summary is parsed.
+
+    The Runkeeper ``cardioActivities.csv`` columns are:
+    ``Date,Type,Route Name,Distance (km),Duration,Average Pace,
+    Average Speed (km/h),Calories Burned,Average Heart Rate (bpm),Notes,
+    GPX File``.
+    """
+
+    PLUGIN_ID = "runkeeper"
+    DISPLAY_NAME = "Runkeeper"
+    FETCH_MODE = FetchMode.MANUAL
+    OUTPUT_TABLES = [OutputTable.EVENTS]
+
+    def get_config_fields(self) -> list[dict[str, Any]]:
+        """Return config fields required by this plugin.
+
+        Returns:
+            List with a single ``export_dir`` directory-path field.
+        """
+        return [
+            {
+                "key": "export_dir",
+                "label": "Runkeeper export directory",
+                "type": "dir_path",
+            }
+        ]
+
+    def get_manual_download_instructions(self) -> str:
+        """Return instructions for obtaining the Runkeeper data export.
+
+        Returns:
+            Multi-line instruction string.
+        """
+        return (
+            "To export your Runkeeper activity history:\n"
+            "1. Log in at https://runkeeper.com\n"
+            "2. Go to Settings -> Export Data.\n"
+            "3. Click 'Export Data' to download a ZIP file immediately.\n"
+            "4. Extract the ZIP; it contains 'cardioActivities.csv' plus a\n"
+            "   '.gpx' file per activity (the GPX files are not used here).\n"
+            "5. Point this plugin's 'export_dir' config field at the\n"
+            "   extracted folder containing 'cardioActivities.csv'.\n"
+        )
+
+    def fetch_records(
+        self,
+        since: int | None = None,
+        progress_cb: Any | None = None,
+        export_dir: str | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Yield normalized event dicts from a Runkeeper export directory.
+
+        Args:
+            since: Optional Unix timestamp; yield only records newer than this.
+            progress_cb: Optional callback invoked with ``(current, total)``
+                for progress reporting.
+            export_dir: Path to the unzipped Runkeeper export directory
+                containing ``cardioActivities.csv``. When not provided,
+                resolved from ``LocalizerSettings``.
+
+        Yields:
+            Dicts with keys: ``source_id``, ``timestamp``, ``label``,
+            ``sublabel``, ``category``, ``raw_json``, ``fetched_at``.
+
+        Raises:
+            FileNotFoundError: If ``export_dir`` is configured but does not
+                contain a ``cardioActivities.csv`` file.
+        """
+        if export_dir is None:
+            try:
+                from localizer.settings import LocalizerSettings  # noqa: PLC0415
+
+                export_dir = LocalizerSettings().get_setting("export_dir") or None
+            except ImportError:
+                pass
+        if export_dir is not None:
+            yield from self._parse_export(export_dir, since)
+        # else: no export directory configured, yield nothing
+
+    def _parse_export(self, export_dir: str, since: int | None) -> Iterator[dict[str, Any]]:
+        """Parse the ``cardioActivities.csv`` summary in a Runkeeper export directory.
+
+        Args:
+            export_dir: Path to the export directory.
+            since: Optional Unix timestamp; yield only records newer than this.
+
+        Yields:
+            Normalized event dicts.
+
+        Raises:
+            FileNotFoundError: If ``cardioActivities.csv`` does not exist
+                inside ``export_dir``.
+        """
+        csv_path = Path(export_dir) / _EXPORT_FILENAME
+        if not csv_path.exists():
+            raise FileNotFoundError(
+                f"Runkeeper 'cardioActivities.csv' not found in export dir: {export_dir!r}. "
+                "Export your data from runkeeper.com/settings and select 'Export Data' "
+                "to download and unzip an export containing cardioActivities.csv."
+            )
+
+        fetched_at = int(time.time())
+
+        with csv_path.open(encoding="utf-8", newline="") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                date_str = (row.get("Date", "") or "").strip()
+                timestamp = fetched_at
+                if date_str:
+                    try:
+                        dt = datetime.fromisoformat(date_str.replace(" ", "T"))
+                        timestamp = int(dt.timestamp())
+                    except ValueError:
+                        timestamp = fetched_at
+
+                if since is not None and timestamp <= since:
+                    continue
+
+                activity_type = row.get("Type", "") or ""
+                route_name = row.get("Route Name", "") or ""
+                label = route_name if route_name else activity_type
+
+                raw = dict(row)
+                raw["distance_km"] = _parse_optional_float(row.get("Distance (km)"))
+                raw["duration_s"] = _parse_duration_to_seconds(row.get("Duration"))
+                raw["avg_hr"] = _parse_optional_float(row.get("Average Heart Rate (bpm)"))
+                raw["gpx_file"] = row.get("GPX File", "") or ""
+
+                yield {
+                    "source_id": "runkeeper",
+                    "timestamp": timestamp,
+                    "label": label,
+                    "sublabel": activity_type,
+                    "category": "fitness",
+                    "raw_json": json.dumps(raw),
+                    "fetched_at": fetched_at,
+                }

--- a/packages/localizer/tests/test_runkeeper_plugin.py
+++ b/packages/localizer/tests/test_runkeeper_plugin.py
@@ -1,0 +1,554 @@
+"""Failing tests for RunkeeperPlugin in the localizer package (issue #21).
+
+All tests here are expected to FAIL until the coder implements:
+  - packages/localizer/src/localizer/plugins/runkeeper/__init__.py
+  - packages/localizer/src/localizer/plugins/runkeeper/loader.py
+  - Updated packages/localizer/src/localizer/plugins/__init__.py (load_builtin_plugins)
+
+RunkeeperPlugin is FetchMode.MANUAL, OutputTable.EVENTS — it reads a single
+``cardioActivities.csv`` summary file from an unzipped Runkeeper export
+directory (mirroring flickr/loader.py's directory-based ``export_dir``
+config field, and untappd/loader.py's FileNotFoundError-on-configured-
+missing-file convention). Individual per-activity GPX files in the same
+export directory are never parsed — Phase 1 only reads the summary CSV.
+
+Field mapping (per issue #21): label=Route Name (falls back to Type when
+blank), sublabel=Type, category="fitness". distance_km/duration_s/avg_hr
+and the remaining CSV columns (Average Pace, Average Speed (km/h),
+Calories Burned, Notes, GPX File) live only inside raw_json — events has
+no dedicated columns for them, following Untappd's precedent.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal Runkeeper cardioActivities.csv content
+# ---------------------------------------------------------------------------
+
+RUNKEEPER_CSV_HEADER = (
+    "Date,Type,Route Name,Distance (km),Duration,Average Pace,"
+    "Average Speed (km/h),Calories Burned,Average Heart Rate (bpm),Notes,GPX File"
+)
+
+# Row 1: named route, full data including heart rate.
+# Row 2: unnamed route (blank Route Name), missing heart rate.
+RUNKEEPER_CSV_TWO_ROWS = f"""\
+{RUNKEEPER_CSV_HEADER}
+2023-06-15 07:30:00,Running,Morning Run,5.2,00:32:15,6:12 min/km,9.67,420,145,Felt great,2023-06-15-073000.gpx
+2023-06-16 18:00:00,Cycling,,15.0,00:45:00,,20.0,600,,,2023-06-16-180000.gpx
+"""
+
+RUNKEEPER_CSV_HEADER_ONLY = f"{RUNKEEPER_CSV_HEADER}\n"
+
+RUNKEEPER_CSV_ZERO_DISTANCE = f"""\
+{RUNKEEPER_CSV_HEADER}
+2023-06-17 08:00:00,Walking,Quick Walk,0,00:05:00,,0,10,90,,2023-06-17-080000.gpx
+"""
+
+RUNKEEPER_CSV_SINCE_CURSOR = f"""\
+{RUNKEEPER_CSV_HEADER}
+2023-01-01 08:00:00,Running,Old Run,3.0,00:20:00,,9.0,200,140,,2023-01-01-080000.gpx
+2023-06-15 07:30:00,Running,Morning Run,5.2,00:32:15,6:12 min/km,9.67,420,145,Felt great,2023-06-15-073000.gpx
+"""
+
+RUNKEEPER_CSV_MALFORMED_DURATION = f"""\
+{RUNKEEPER_CSV_HEADER}
+2023-06-15 07:30:00,Running,Morning Run,5.2,not-a-duration,6:12 min/km,9.67,420,145,Felt great,2023-06-15-073000.gpx
+"""
+
+
+def _make_plugin() -> Any:
+    """Instantiate a RunkeeperPlugin."""
+    from localizer.plugins.runkeeper.loader import RunkeeperPlugin
+
+    return RunkeeperPlugin()
+
+
+def _write_export(tmp_path: Path, content: str, filename: str = "cardioActivities.csv") -> Path:
+    """Write CSV content into *tmp_path* as an export dir and return the dir path."""
+    csv_path = tmp_path / filename
+    csv_path.write_text(content, encoding="utf-8")
+    return tmp_path
+
+
+def _raw_json(record: dict[str, Any]) -> dict[str, Any]:
+    """Return record['raw_json'] as a dict, parsing it if it is a JSON string."""
+    raw = record["raw_json"]
+    if isinstance(raw, str):
+        parsed: dict[str, Any] = json.loads(raw)
+        return parsed
+    return raw  # type: ignore[no-any-return]
+
+
+def _no_settings_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch LocalizerSettings.get_setting to always return its default.
+
+    Simulates a machine with no config.toml/env overrides, so the
+    unconfigured-plugin test is deterministic regardless of the developer's
+    local ~/.localizer state.
+    """
+    from localizer.settings import LocalizerSettings
+
+    monkeypatch.setattr(
+        LocalizerSettings,
+        "get_setting",
+        lambda self, key, default=None: default,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ABC / class attribute / registration tests
+# ---------------------------------------------------------------------------
+
+
+def test_runkeeper_plugin_id() -> None:
+    """RunkeeperPlugin.PLUGIN_ID must equal 'runkeeper'."""
+    from localizer.plugins.runkeeper.loader import RunkeeperPlugin
+
+    assert RunkeeperPlugin.PLUGIN_ID == "runkeeper"
+
+
+def test_runkeeper_fetch_mode_manual() -> None:
+    """RunkeeperPlugin.FETCH_MODE must be FetchMode.MANUAL."""
+    from localizer.plugins.base import FetchMode
+    from localizer.plugins.runkeeper.loader import RunkeeperPlugin
+
+    assert RunkeeperPlugin.FETCH_MODE == FetchMode.MANUAL
+
+
+def test_runkeeper_output_tables_events() -> None:
+    """OutputTable.EVENTS must be in RunkeeperPlugin.OUTPUT_TABLES."""
+    from localizer.plugins.base import OutputTable
+    from localizer.plugins.runkeeper.loader import RunkeeperPlugin
+
+    assert OutputTable.EVENTS in RunkeeperPlugin.OUTPUT_TABLES
+
+
+def test_runkeeper_is_registered() -> None:
+    """After load_builtin_plugins(), REGISTRY['runkeeper'] must exist."""
+    from localizer.plugins import REGISTRY, load_builtin_plugins
+
+    REGISTRY.clear()
+    load_builtin_plugins()
+    assert "runkeeper" in REGISTRY, f"'runkeeper' not in REGISTRY; keys: {list(REGISTRY)}"
+
+
+def test_runkeeper_get_config_fields_shape() -> None:
+    """get_config_fields() must return one dir_path field keyed 'export_dir'."""
+    plugin = _make_plugin()
+    fields = plugin.get_config_fields()
+
+    assert isinstance(fields, list)
+    assert len(fields) == 1, f"Expected exactly 1 config field, got {len(fields)}"
+    field = fields[0]
+    assert field["key"] == "export_dir"
+    assert "label" in field
+    assert field["type"] == "dir_path"
+
+
+def test_runkeeper_manual_download_instructions() -> None:
+    """get_manual_download_instructions() must mention 'runkeeper.com' and 'cardioActivities'."""
+    plugin = _make_plugin()
+    instructions = plugin.get_manual_download_instructions()
+
+    assert isinstance(instructions, str)
+    assert len(instructions.strip()) > 0, "Expected non-empty manual download instructions"
+
+    assert "runkeeper.com" in instructions.lower(), (
+        f"'runkeeper.com' not found in instructions: {instructions!r}"
+    )
+    assert "cardioActivities" in instructions, (
+        f"'cardioActivities' not found in instructions: {instructions!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CSV parsing — basic shape / required keys
+# ---------------------------------------------------------------------------
+
+
+def test_runkeeper_fetch_records_from_export_dir_count(tmp_path: Path) -> None:
+    """fetch_records(export_dir=...) must yield 2 records from a 2-row CSV."""
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_TWO_ROWS)
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+
+    assert len(records) == 2, f"Expected 2 records, got {len(records)}"
+
+
+def test_runkeeper_required_keys_present(tmp_path: Path) -> None:
+    """Each record must have exactly the events-schema keys."""
+    required_keys = {
+        "source_id",
+        "timestamp",
+        "label",
+        "sublabel",
+        "category",
+        "raw_json",
+        "fetched_at",
+    }
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_TWO_ROWS)
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+
+    for record in records:
+        missing = required_keys - set(record.keys())
+        assert not missing, f"Record missing required keys: {missing}"
+
+
+def test_runkeeper_source_id_is_runkeeper(tmp_path: Path) -> None:
+    """source_id in each record must equal 'runkeeper'."""
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_TWO_ROWS)
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+
+    for record in records:
+        assert record["source_id"] == "runkeeper", (
+            f"source_id {record['source_id']!r} != 'runkeeper'"
+        )
+
+
+def test_runkeeper_fetched_at_is_recent(tmp_path: Path) -> None:
+    """fetched_at must be a Unix timestamp close to now."""
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_TWO_ROWS)
+
+    before = int(time.time())
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+    after = int(time.time())
+
+    for record in records:
+        assert isinstance(record["fetched_at"], int)
+        assert before - 5 <= record["fetched_at"] <= after + 5, (
+            f"fetched_at {record['fetched_at']} not close to now ({before}-{after})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# label / sublabel / category mapping
+# ---------------------------------------------------------------------------
+
+
+def test_runkeeper_named_route_used_as_label(tmp_path: Path) -> None:
+    """label must be the 'Route Name' column when non-blank."""
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_TWO_ROWS)
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+
+    morning_run = next(r for r in records if r["label"] == "Morning Run")
+    assert morning_run["sublabel"] == "Running"
+
+
+def test_runkeeper_unnamed_route_falls_back_to_type(tmp_path: Path) -> None:
+    """A blank 'Route Name' must fall back to the 'Type' column for label."""
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_TWO_ROWS)
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+
+    cycling = next(r for r in records if r["sublabel"] == "Cycling")
+    assert cycling["label"] == "Cycling", f"label {cycling['label']!r} != 'Cycling'"
+
+
+def test_runkeeper_category_is_fitness(tmp_path: Path) -> None:
+    """category must always be the literal string 'fitness'."""
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_TWO_ROWS)
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+
+    for record in records:
+        assert record["category"] == "fitness"
+
+
+# ---------------------------------------------------------------------------
+# Date -> timestamp parsing
+# ---------------------------------------------------------------------------
+
+
+def test_runkeeper_date_parses_to_positive_int_timestamp(tmp_path: Path) -> None:
+    """The 'Date' column (YYYY-MM-DD HH:MM:SS) must parse to a positive int timestamp."""
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_TWO_ROWS)
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+
+    for record in records:
+        assert isinstance(record["timestamp"], int)
+        assert record["timestamp"] > 0
+
+
+def test_runkeeper_unparseable_date_falls_back_to_fetched_at(tmp_path: Path) -> None:
+    """An unparseable Date value must not raise; timestamp falls back to fetched_at."""
+    bad_csv = f"""\
+{RUNKEEPER_CSV_HEADER}
+not-a-real-date,Running,Morning Run,5.2,00:32:15,,9.67,420,145,,2023-06-15-073000.gpx
+"""
+    export_dir = _write_export(tmp_path, bad_csv)
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+
+    assert len(records) == 1
+    assert records[0]["timestamp"] == records[0]["fetched_at"]
+
+
+# ---------------------------------------------------------------------------
+# Duration -> duration_s parsing
+# ---------------------------------------------------------------------------
+
+
+def test_runkeeper_duration_converts_to_integer_seconds(tmp_path: Path) -> None:
+    """Duration '00:32:15' must convert to raw_json['duration_s'] == 1935 (int)."""
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_TWO_ROWS)
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+
+    morning_run = next(r for r in records if r["label"] == "Morning Run")
+    duration_s = _raw_json(morning_run)["duration_s"]
+    assert isinstance(duration_s, int), f"duration_s is {type(duration_s)}, expected int"
+    assert duration_s == 1935
+
+
+def test_runkeeper_malformed_duration_does_not_raise(tmp_path: Path) -> None:
+    """A malformed Duration value must not raise; duration_s becomes None."""
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_MALFORMED_DURATION)
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+
+    assert len(records) == 1
+    assert _raw_json(records[0])["duration_s"] is None
+
+
+# ---------------------------------------------------------------------------
+# distance_km / avg_hr in raw_json
+# ---------------------------------------------------------------------------
+
+
+def test_runkeeper_distance_km_is_float_in_raw_json(tmp_path: Path) -> None:
+    """raw_json['distance_km'] must be a Python float equal to the CSV value."""
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_TWO_ROWS)
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+
+    morning_run = next(r for r in records if r["label"] == "Morning Run")
+    distance_km = _raw_json(morning_run)["distance_km"]
+    assert isinstance(distance_km, float)
+    assert distance_km == 5.2
+
+
+def test_runkeeper_zero_distance_activity_preserves_zero(tmp_path: Path) -> None:
+    """A zero-distance activity must have raw_json['distance_km'] == 0.0, not None."""
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_ZERO_DISTANCE)
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+
+    assert len(records) == 1
+    distance_km = _raw_json(records[0])["distance_km"]
+    assert distance_km == 0.0
+    assert distance_km is not None
+
+
+def test_runkeeper_present_heart_rate_is_float_in_raw_json(tmp_path: Path) -> None:
+    """A row with a heart rate value must have raw_json['avg_hr'] as a float."""
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_TWO_ROWS)
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+
+    morning_run = next(r for r in records if r["label"] == "Morning Run")
+    avg_hr = _raw_json(morning_run)["avg_hr"]
+    assert isinstance(avg_hr, float)
+    assert avg_hr == 145.0
+
+
+def test_runkeeper_missing_heart_rate_is_none_in_raw_json(tmp_path: Path) -> None:
+    """A row with a blank heart rate column must have raw_json['avg_hr'] as None."""
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_TWO_ROWS)
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+
+    cycling = next(r for r in records if r["sublabel"] == "Cycling")
+    assert _raw_json(cycling)["avg_hr"] is None
+
+
+# ---------------------------------------------------------------------------
+# raw_json preservation / round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_runkeeper_raw_json_round_trips_and_preserves_fields(tmp_path: Path) -> None:
+    """raw_json must be JSON-serializable and preserve pace/speed/calories/notes/gpx_file."""
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_TWO_ROWS)
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+
+    for record in records:
+        raw = record["raw_json"]
+        if isinstance(raw, str):
+            json.loads(raw)  # must not raise
+        else:
+            json.dumps(raw)  # must not raise
+
+    morning_run = next(r for r in records if r["label"] == "Morning Run")
+    raw = _raw_json(morning_run)
+    assert raw["Average Pace"] == "6:12 min/km"
+    assert raw["Average Speed (km/h)"] == "9.67"
+    assert raw["Calories Burned"] == "420"
+    assert raw["Notes"] == "Felt great"
+    assert raw["gpx_file"] == "2023-06-15-073000.gpx"
+
+
+def test_runkeeper_raw_json_none_values_round_trip(tmp_path: Path) -> None:
+    """raw_json containing None values (missing HR, blank route) must still round-trip."""
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_TWO_ROWS)
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+
+    cycling = next(r for r in records if r["sublabel"] == "Cycling")
+    raw = cycling["raw_json"]
+    if isinstance(raw, str):
+        parsed = json.loads(raw)
+    else:
+        parsed = json.loads(json.dumps(raw))
+
+    assert parsed["avg_hr"] is None
+
+
+# ---------------------------------------------------------------------------
+# empty CSV / missing file / unconfigured
+# ---------------------------------------------------------------------------
+
+
+def test_runkeeper_empty_csv_yields_empty_list(tmp_path: Path) -> None:
+    """A CSV with only a header row (zero data rows) must yield an empty list, not raise."""
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_HEADER_ONLY)
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+
+    assert records == []
+
+
+def test_runkeeper_missing_export_file_raises_file_not_found(tmp_path: Path) -> None:
+    """A configured export_dir without a cardioActivities.csv inside it must raise."""
+    plugin = _make_plugin()
+
+    with pytest.raises(FileNotFoundError):
+        list(plugin.fetch_records(export_dir=str(tmp_path)))
+
+
+def test_runkeeper_missing_export_dir_raises_file_not_found(tmp_path: Path) -> None:
+    """A configured export_dir that does not exist at all must raise FileNotFoundError."""
+    plugin = _make_plugin()
+    missing_dir = tmp_path / "nonexistent_export"
+
+    with pytest.raises(FileNotFoundError):
+        list(plugin.fetch_records(export_dir=str(missing_dir)))
+
+
+def test_runkeeper_missing_export_error_mentions_runkeeper(tmp_path: Path) -> None:
+    """The FileNotFoundError message should point at runkeeper.com."""
+    plugin = _make_plugin()
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        list(plugin.fetch_records(export_dir=str(tmp_path)))
+
+    assert "runkeeper.com" in str(exc_info.value).lower()
+
+
+def test_runkeeper_unconfigured_yields_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With export_dir=None and no LocalizerSettings override, fetch_records() yields nothing."""
+    _no_settings_override(monkeypatch)
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records())
+
+    assert records == []
+
+
+# ---------------------------------------------------------------------------
+# since cursor
+# ---------------------------------------------------------------------------
+
+
+def test_runkeeper_since_cursor_excludes_older_row(tmp_path: Path) -> None:
+    """A row whose timestamp is <= since must be excluded; a newer row must be included."""
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_SINCE_CURSOR)
+
+    plugin = _make_plugin()
+    all_records = list(plugin.fetch_records(export_dir=str(export_dir)))
+    assert len(all_records) == 2, f"Expected 2 records with no cursor, got {len(all_records)}"
+
+    old_record = next(r for r in all_records if r["label"] == "Old Run")
+    since = old_record["timestamp"]
+
+    filtered_records = list(plugin.fetch_records(export_dir=str(export_dir), since=since))
+
+    assert len(filtered_records) == 1, (
+        f"Expected 1 record after since-cursor filtering, got {len(filtered_records)}"
+    )
+    assert filtered_records[0]["label"] == "Morning Run"
+
+
+# ---------------------------------------------------------------------------
+# no-network-imports guard
+# ---------------------------------------------------------------------------
+
+
+def test_runkeeper_loader_has_no_network_imports() -> None:
+    """loader.py must not import requests/urllib/httpx/socket — zero network code."""
+    import localizer.plugins.runkeeper.loader as loader_module
+
+    source = Path(loader_module.__file__).read_text(encoding="utf-8")
+
+    for forbidden in ("import requests", "import urllib", "import httpx", "import socket"):
+        assert forbidden not in source, f"Found forbidden network import: {forbidden!r}"
+
+
+def test_runkeeper_loader_no_other_plugin_references() -> None:
+    """loader.py must not reference other source plugins, their schemas, or join keys."""
+    import localizer.plugins.runkeeper.loader as loader_module
+
+    source = Path(loader_module.__file__).read_text(encoding="utf-8")
+
+    for forbidden in ("swarm", "lastfm", "letterboxd", "untappd", "flickr", "feedly", "github"):
+        assert forbidden not in source.lower(), (
+            f"Found forbidden cross-plugin reference: {forbidden!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# GPX files present in export dir must never be parsed
+# ---------------------------------------------------------------------------
+
+
+def test_runkeeper_ignores_gpx_files_in_export_dir(tmp_path: Path) -> None:
+    """A .gpx file sitting alongside cardioActivities.csv must be ignored entirely."""
+    export_dir = _write_export(tmp_path, RUNKEEPER_CSV_TWO_ROWS)
+    (export_dir / "2023-06-15-073000.gpx").write_text(
+        "<gpx>not real gpx content</gpx>", encoding="utf-8"
+    )
+
+    plugin = _make_plugin()
+    records = list(plugin.fetch_records(export_dir=str(export_dir)))
+
+    assert len(records) == 2


### PR DESCRIPTION
## Summary
- Adds `RunkeeperPlugin`, a `FetchMode.MANUAL`, `OutputTable.EVENTS` source plugin under `packages/localizer/src/localizer/plugins/runkeeper/`, following the current Letterboxd/Untappd CSV-export convention (not the legacy `PLUGIN_TYPE`/`@register`-generic system referenced in the original issue text).
- Parses `cardioActivities.csv` from an unzipped Runkeeper export directory (`export_dir` config field, `dir_path` type, mirroring Flickr's pattern); individual per-activity `.gpx` files in the same directory are intentionally never read.
- Maps `Route Name` (falling back to `Type` when blank) to `label`, `Type` to `sublabel`, and a fixed `"fitness"` to `category`. `Date` is parsed to a Unix timestamp; `Duration` (`HH:MM:SS`) is converted to integer seconds. `distance_km`, `duration_s`, `avg_hr`, and the remaining CSV columns (`Average Pace`, `Average Speed (km/h)`, `Calories Burned`, `Notes`, `gpx_file`) are preserved in `raw_json`.
- Registers the plugin via `@register` and adds one import + one `REGISTRY[...]` line to the shared `packages/localizer/src/localizer/plugins/__init__.py` registry.

## Test plan
- [x] `RunkeeperPlugin` is registered and discoverable via `REGISTRY`/`load_builtin_plugins()`
- [x] `Date` parses to a positive Unix timestamp (with fallback to `fetched_at` on unparseable input)
- [x] `Duration` (`HH:MM:SS`) converts to integer seconds correctly (malformed values fall back to `None`, never raise)
- [x] Unnamed routes (blank `Route Name`) fall back to `Type` for `label`
- [x] Unit tests cover: basic load, unnamed route, missing heart rate, zero-distance activity, empty CSV, missing export file/dir (`FileNotFoundError`), unconfigured plugin, `since`-cursor filtering, and that stray `.gpx` files in the export dir are ignored
- [x] Zero HTTP/network code in the plugin (asserted via source-scan test) — reads only from the local export file
- [x] Zero references to other source plugins, their schemas, or join keys (asserted via source-scan test)
- [x] `packages/localizer` suite: 371 passed
- [x] Root suite: 972 passed
- [x] `ruff check .`, `ruff format --check .`, `mypy` all clean

Closes #21