### PR TITLE
feat: add Time Machine card to Overview page

### DIFF
--- a/core/time_machine.py
+++ b/core/time_machine.py
@@ -1,0 +1,324 @@
+"""Pure "this day in history" data-shaping logic for the Overview page's Time Machine
+card (issue #98).
+
+The Overview page already holds two merged DataFrames in session state:
+
+- ``df`` — the Last.fm-shaped "what-when" frame. In legacy (flat-file) mode this is
+  Last.fm scrobbles only. In broker mode (``components/sidebar.py::_load_data_from_broker``)
+  it is *every* what-when source (Last.fm, Untappd, Flickr, Letterboxd, ...) run through
+  ``core.localizer_frames.events_to_lastfm_frame`` and then
+  ``analysis_utils.apply_location_context`` — so it carries a ``source_id`` column plus
+  ``artist``/``track``/``album`` (renamed from the generic ``label``/``sublabel``/``category``
+  columns) *and* the location columns (``city``/``state``/``country``/``lat``/``lng``) that
+  the location-context pipeline already resolved for every row's timestamp. When
+  ``source_id`` is absent (legacy CSV mode), every row is treated as an actual Last.fm listen.
+- ``swarm_df`` — the where-when frame (Foursquare/Swarm, Google Timeline, ...) with
+  ``timestamp, city, state, country, venue, venue_category, lat, lng, source_id`` columns.
+
+This module reuses those two shapes directly rather than re-querying the DuckDB store, so
+it stays a pure, dependency-free DataFrame-in/dataclass-out module — no Streamlit or DB
+imports — mirroring the convention already established by ``core/drinking_history.py`` and
+``core/localizer_frames.py``.
+
+Design notes (documented per issue #98's request to record judgment calls):
+
+- "This day in history" matches on **month + day** across all past years present in the
+  data, not a single fixed N-years-back offset — a fixed offset would almost always land on
+  a day with no data. Every past year with a qualifying record on today's month/day is a
+  "candidate year"; one is picked at random (``pick_year``, seeded via an injectable
+  ``random.Random`` so callers can make the choice deterministic for tests).
+- Location, listening, and events are resolved **independently** — a missing source_id
+  column, an empty frame, or no rows on the target date just leaves that field ``None``
+  (or an empty tuple for events) rather than suppressing the whole entry.
+- Location is read preferentially off the matched Last.fm/events rows (since
+  ``apply_location_context`` already resolved the nearest known location for every listen
+  timestamp); it falls back to the places/swarm frame's own rows for that date when no
+  listen exists but a place record does.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from datetime import date
+
+import pandas as pd
+
+LASTFM_SOURCE_ID = "lastfm"
+
+# How many sample tracks / events to surface per category, to keep the card compact.
+_MAX_SAMPLE_TRACKS = 5
+_MAX_EVENTS = 5
+
+
+@dataclass(frozen=True)
+class LocationSnapshot:
+    """Where the user was, resolved for a single historical date.
+
+    Attributes:
+        city: City name, or "" if unknown.
+        state: State/region name, or "" if unknown.
+        country: Country name, or "" if unknown.
+    """
+
+    city: str
+    state: str
+    country: str
+
+
+@dataclass(frozen=True)
+class ListeningSnapshot:
+    """What the user was listening to, resolved for a single historical date.
+
+    Attributes:
+        scrobble_count: Total Last.fm scrobbles on the date.
+        top_artist: The most-played artist that date ("" if unknown).
+        sample_tracks: Up to ``_MAX_SAMPLE_TRACKS`` distinct "artist — track" strings,
+            in listen order.
+    """
+
+    scrobble_count: int
+    top_artist: str
+    sample_tracks: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class EventSnapshot:
+    """A single non-listening EVENTS-shaped record (check-in, photo, drink, ...).
+
+    Attributes:
+        label: The event's primary label (e.g. brewery name, photo title).
+        sublabel: The event's secondary label (e.g. beer name).
+        category: The event's category (e.g. beer style).
+        source_id: Which source plugin produced this record (e.g. "untappd").
+    """
+
+    label: str
+    sublabel: str
+    category: str
+    source_id: str
+
+
+@dataclass(frozen=True)
+class TimeMachineEntry:
+    """A fully-resolved "this day in history" result for one historical date.
+
+    Attributes:
+        target_date: The historical date this entry describes.
+        years_ago: How many years before ``today`` ``target_date`` falls.
+        location: Where the user was, or None if unknown.
+        listening: What the user was listening to, or None if no scrobbles that date.
+        events: Non-listening EVENTS-shaped records that date (possibly empty).
+    """
+
+    target_date: date
+    years_ago: int
+    location: LocationSnapshot | None
+    listening: ListeningSnapshot | None
+    events: tuple[EventSnapshot, ...]
+
+
+def candidate_years(today: date, activity_df: pd.DataFrame, places_df: pd.DataFrame) -> list[int]:
+    """Return distinct past years with at least one record on today's month/day.
+
+    Args:
+        today: The reference "today" date (month/day drive the match).
+        activity_df: The Last.fm-shaped what-when frame (``df`` in session state).
+            Must have a ``date_text`` column to contribute; missing/empty is fine.
+        places_df: The where-when frame (``swarm_df`` in session state). Must have a
+            ``timestamp`` column (unix seconds) to contribute; missing/empty is fine.
+
+    Returns:
+        Sorted (descending) list of years strictly before ``today.year`` that have at
+        least one matching row in either frame. Empty list if nothing matches.
+    """
+    years: set[int] = set()
+
+    if activity_df is not None and not activity_df.empty and "date_text" in activity_df.columns:
+        dates = pd.to_datetime(activity_df["date_text"])
+        mask = (
+            (dates.dt.month == today.month)
+            & (dates.dt.day == today.day)
+            & (dates.dt.year < today.year)
+        )
+        years.update(int(y) for y in dates[mask].dt.year.unique().tolist())
+
+    if places_df is not None and not places_df.empty and "timestamp" in places_df.columns:
+        place_dates = pd.to_datetime(places_df["timestamp"], unit="s")
+        place_mask = (
+            (place_dates.dt.month == today.month)
+            & (place_dates.dt.day == today.day)
+            & (place_dates.dt.year < today.year)
+        )
+        years.update(int(y) for y in place_dates[place_mask].dt.year.unique().tolist())
+
+    return sorted(years, reverse=True)
+
+
+def pick_year(years: list[int], rng: random.Random | None = None) -> int | None:
+    """Pick one candidate year at random.
+
+    Args:
+        years: Candidate years, as returned by ``candidate_years``.
+        rng: A ``random.Random`` instance to draw from. Pass a seeded instance for
+            deterministic tests; defaults to a fresh, unseeded ``random.Random()``
+            (real wall-clock randomness) when omitted.
+
+    Returns:
+        One of ``years``, chosen at random, or None if ``years`` is empty.
+    """
+    if not years:
+        return None
+    # Not a cryptographic use — just picking which past year's card to display.
+    chooser = rng if rng is not None else random.Random()  # noqa: S311
+    return chooser.choice(years)
+
+
+def _rows_on_date(
+    df: pd.DataFrame, date_col: str, target_date: date, unit: str | None
+) -> pd.DataFrame:
+    """Return the subset of `df` whose `date_col` falls on `target_date`."""
+    if df is None or df.empty or date_col not in df.columns:
+        return pd.DataFrame(columns=df.columns if df is not None else [])
+    dates = pd.to_datetime(df[date_col], unit=unit) if unit else pd.to_datetime(df[date_col])
+    return df[dates.dt.date == target_date]
+
+
+def _location_from_rows(
+    rows: pd.DataFrame, name_cols: tuple[str, str, str]
+) -> LocationSnapshot | None:
+    """Build a LocationSnapshot from the first row with a non-empty city/state/country."""
+    city_col, state_col, country_col = name_cols
+    if rows.empty or not {city_col, state_col, country_col}.issubset(rows.columns):
+        return None
+    row = rows.iloc[0]
+    city = str(row.get(city_col) or "")
+    state = str(row.get(state_col) or "")
+    country = str(row.get(country_col) or "")
+    if not (city or state or country):
+        return None
+    return LocationSnapshot(city=city, state=state, country=country)
+
+
+def _listening_snapshot(rows: pd.DataFrame) -> ListeningSnapshot | None:
+    """Build a ListeningSnapshot from Last.fm-only rows for a single date."""
+    if rows.empty or "artist" not in rows.columns:
+        return None
+
+    top_artist = ""
+    counts = rows["artist"].dropna()
+    if not counts.empty:
+        top_artist = str(counts.value_counts().idxmax())
+
+    sample: list[str] = []
+    for _, row in rows.iterrows():
+        if len(sample) >= _MAX_SAMPLE_TRACKS:
+            break
+        artist = str(row.get("artist") or "")
+        track = str(row.get("track") or "")
+        label = f"{artist} — {track}" if artist and track else artist or track
+        if label and label not in sample:
+            sample.append(label)
+
+    return ListeningSnapshot(
+        scrobble_count=len(rows),
+        top_artist=top_artist,
+        sample_tracks=tuple(sample),
+    )
+
+
+def _event_snapshots(rows: pd.DataFrame) -> tuple[EventSnapshot, ...]:
+    """Build EventSnapshots from non-Last.fm activity rows for a single date."""
+    if rows.empty:
+        return ()
+
+    events: list[EventSnapshot] = []
+    for _, row in rows.iterrows():
+        if len(events) >= _MAX_EVENTS:
+            break
+        events.append(
+            EventSnapshot(
+                label=str(row.get("artist") or ""),
+                sublabel=str(row.get("track") or ""),
+                category=str(row.get("album") or ""),
+                source_id=str(row.get("source_id") or ""),
+            )
+        )
+    return tuple(events)
+
+
+def build_entry(
+    today: date,
+    year: int,
+    activity_df: pd.DataFrame,
+    places_df: pd.DataFrame,
+) -> TimeMachineEntry:
+    """Build a fully-resolved TimeMachineEntry for a specific historical year.
+
+    Args:
+        today: The reference "today" date (month/day are combined with ``year``).
+        year: The historical year to build an entry for (must be < today.year).
+        activity_df: The Last.fm-shaped what-when frame (``df`` in session state).
+        places_df: The where-when frame (``swarm_df`` in session state).
+
+    Returns:
+        A TimeMachineEntry. Each of ``location``/``listening``/``events`` is
+        independently None/empty when that category has no data for the date.
+    """
+    target_date = date(year, today.month, today.day)
+
+    activity_rows = _rows_on_date(activity_df, "date_text", target_date, unit=None)
+
+    if "source_id" in activity_rows.columns:
+        listening_rows = activity_rows[activity_rows["source_id"] == LASTFM_SOURCE_ID]
+        event_rows = activity_rows[activity_rows["source_id"] != LASTFM_SOURCE_ID]
+    else:
+        listening_rows = activity_rows
+        event_rows = activity_rows.iloc[0:0]
+
+    places_rows = _rows_on_date(places_df, "timestamp", target_date, unit="s")
+
+    location = _location_from_rows(listening_rows, ("city", "state", "country"))
+    if location is None:
+        location = _location_from_rows(places_rows, ("city", "state", "country"))
+        if location is None and not places_rows.empty and "venue" in places_rows.columns:
+            venue = str(places_rows.iloc[0].get("venue") or "")
+            if venue:
+                location = LocationSnapshot(city=venue, state="", country="")
+
+    return TimeMachineEntry(
+        target_date=target_date,
+        years_ago=today.year - year,
+        location=location,
+        listening=_listening_snapshot(listening_rows),
+        events=_event_snapshots(event_rows),
+    )
+
+
+def get_time_machine_entry(
+    today: date,
+    activity_df: pd.DataFrame,
+    places_df: pd.DataFrame,
+    rng: random.Random | None = None,
+) -> TimeMachineEntry | None:
+    """Pick a random past "this day in history" and build its TimeMachineEntry.
+
+    This is the top-level entry point: find every past year with a matching record on
+    today's month/day, pick one at random, and shape its location/listening/events data.
+
+    Args:
+        today: The reference "today" date.
+        activity_df: The Last.fm-shaped what-when frame (``df`` in session state).
+        places_df: The where-when frame (``swarm_df`` in session state).
+        rng: A ``random.Random`` instance for deterministic year selection in tests.
+
+    Returns:
+        A TimeMachineEntry for a randomly-chosen candidate year, or None if there is no
+        historical data at all for today's month/day (the caller should show an
+        empty-state message in that case).
+    """
+    years = candidate_years(today, activity_df, places_df)
+    year = pick_year(years, rng)
+    if year is None:
+        return None
+    return build_entry(today, year, activity_df, places_df)

--- a/pages/overview.py
+++ b/pages/overview.py
@@ -1,8 +1,9 @@
-"""Overview page — hero card."""
+"""Overview page — hero card and Time Machine ("this day in history") card."""
 
 from __future__ import annotations
 
 import datetime
+import random
 from datetime import timezone
 
 import streamlit as st
@@ -18,7 +19,9 @@ from components.theme import (
     ACCENT_PURPLE,
     ACCENT_YELLOW,
     TEXT_DIM,
+    TEXT_PRIMARY,
 )
+from core.time_machine import TimeMachineEntry, get_time_machine_entry
 from export_html import build_overview_page_html
 
 
@@ -31,6 +34,119 @@ def _stat_html(value: str, label: str, color: str) -> str:
         f'<p style="font-size:11px;color:{TEXT_DIM};margin:4px 0 0 0">{label}</p>'
         f"</div>"
     )
+
+
+def _time_machine_location_html(entry: TimeMachineEntry) -> str:
+    """Return HTML for the Time Machine card's location line, or "" if unknown."""
+    if entry.location is None:
+        return ""
+    parts = [p for p in (entry.location.city, entry.location.state, entry.location.country) if p]
+    if not parts:
+        return ""
+    return (
+        f'<p style="font-size:13px;color:{TEXT_PRIMARY};margin:0 0 0.5rem 0">'
+        f'<strong style="color:{ACCENT_CYAN}">Where you were —</strong> {", ".join(parts)}</p>'
+    )
+
+
+def _time_machine_listening_html(entry: TimeMachineEntry) -> str:
+    """Return HTML for the Time Machine card's listening line, or "" if no scrobbles."""
+    listening = entry.listening
+    if listening is None or listening.scrobble_count == 0:
+        return ""
+    summary = f"{listening.scrobble_count:,} scrobble{'s' if listening.scrobble_count != 1 else ''}"
+    if listening.top_artist:
+        summary += f" &middot; top artist: {listening.top_artist}"
+    lines = [
+        f'<p style="font-size:13px;color:{TEXT_PRIMARY};margin:0 0 0.25rem 0">'
+        f'<strong style="color:{ACCENT_INDIGO}">What you were listening to —</strong> {summary}</p>'
+    ]
+    if listening.sample_tracks:
+        tracks = ", ".join(listening.sample_tracks)
+        lines.append(f'<p style="font-size:12px;color:{TEXT_DIM};margin:0 0 0.5rem 0">{tracks}</p>')
+    return "".join(lines)
+
+
+def _time_machine_events_html(entry: TimeMachineEntry) -> str:
+    """Return HTML for the Time Machine card's events line, or "" if none."""
+    if not entry.events:
+        return ""
+    items = []
+    for event in entry.events:
+        label = " — ".join(p for p in (event.label, event.sublabel) if p)
+        if not label:
+            continue
+        items.append(label)
+    if not items:
+        return ""
+    return (
+        f'<p style="font-size:13px;color:{TEXT_PRIMARY};margin:0 0 0.5rem 0">'
+        f'<strong style="color:{ACCENT_PINK}">What you were doing —</strong> {", ".join(items)}</p>'
+    )
+
+
+def render_time_machine_card(
+    df: DataFrame | None,
+    swarm_df: DataFrame | None,
+    today: datetime.date | None = None,
+    rng: random.Random | None = None,
+) -> None:
+    """Render the "Time Machine" this-day-in-history card.
+
+    Picks a random past year (relative to ``today``) that has at least one matching
+    record on today's month/day across listening, location, or events data, and shows
+    a compact card summarizing where the user was, what they were listening to, and
+    what else they were doing (check-ins, photos, drinks, etc.). Degrades gracefully to
+    an empty-state message when no historical data exists for any candidate year.
+
+    Args:
+        df: The Last.fm-shaped what-when frame from ``st.session_state['df']``.
+        swarm_df: The where-when frame from ``st.session_state['swarm_df']``.
+        today: The reference "today" date; defaults to the real current date. Callers
+            (tests) can inject a fixed date for deterministic behavior.
+        rng: A ``random.Random`` instance for deterministic year selection in tests;
+            defaults to real wall-clock randomness.
+    """
+    resolved_today = today if today is not None else datetime.date.today()
+    activity_df = df if df is not None else DataFrame()
+    places_df = swarm_df if swarm_df is not None else DataFrame()
+
+    entry = get_time_machine_entry(resolved_today, activity_df, places_df, rng=rng)
+
+    st.markdown(
+        f'<h2 style="font-size:16px;font-weight:700;margin:1.5rem 0 0.5rem 0;'
+        f'color:{TEXT_PRIMARY}">Time Machine</h2>',
+        unsafe_allow_html=True,
+    )
+
+    if entry is None:
+        st.info("No historical data found for this day yet. Keep tracking, and check back later.")
+        return
+
+    body_parts = [
+        _time_machine_location_html(entry),
+        _time_machine_listening_html(entry),
+        _time_machine_events_html(entry),
+    ]
+    body_html = "".join(p for p in body_parts if p)
+    if not body_html:
+        st.info("No historical data found for this day yet. Keep tracking, and check back later.")
+        return
+
+    years_label = f"{entry.years_ago} year{'s' if entry.years_ago != 1 else ''} ago"
+    date_label = entry.target_date.strftime("%B %d, %Y")
+
+    html = (
+        '<div style="background:linear-gradient(135deg,#1e1b4b,#0c1120);'
+        "border:1px solid #6366f1;border-radius:12px;padding:1.5rem 2rem;"
+        'margin-bottom:1.5rem">'
+        f'<p style="font-size:12px;color:{TEXT_DIM};margin:0 0 0.75rem 0;'
+        f'text-transform:uppercase;letter-spacing:0.08em">'
+        f"{years_label} today &middot; {date_label}</p>"
+        f"{body_html}"
+        "</div>"
+    )
+    st.markdown(html, unsafe_allow_html=True)
 
 
 def render_overview() -> None:
@@ -126,3 +242,6 @@ def render_overview() -> None:
 
     parts += ["</div>", "</div>"]
     st.markdown("".join(parts), unsafe_allow_html=True)
+
+    # ── Time Machine — "this day in history" (issue #98) ───────────────────
+    render_time_machine_card(df, swarm_df)

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -1,0 +1,139 @@
+"""Tests for the Overview page's Time Machine card (``pages/overview.py``, issue #98).
+
+Mocks Streamlit's ``markdown``/``info`` and injects a fixed ``today``/seeded
+``random.Random`` into ``render_time_machine_card`` so these are fast, deterministic
+smoke tests of the page's wiring — the actual "this day in history" data-shaping logic
+is covered independently by ``tests/test_time_machine.py``.
+"""
+
+from __future__ import annotations
+
+import random
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from pages.overview import render_time_machine_card
+
+
+def _ts(dt_str: str) -> int:
+    """Return a unix int-seconds timestamp for the given ISO date string."""
+    return int(pd.Timestamp(dt_str).timestamp())
+
+
+TODAY = pd.Timestamp("2026-07-11").date()
+
+
+class TestRenderTimeMachineCardEmptyState(unittest.TestCase):
+    @patch("streamlit.info")
+    @patch("streamlit.markdown")
+    def test_no_data_at_all_shows_empty_state(
+        self, mock_md: MagicMock, mock_info: MagicMock
+    ) -> None:
+        render_time_machine_card(None, None, today=TODAY)
+        mock_info.assert_called_once()
+        # No hero-style card div should be rendered when there's nothing to show.
+        card_calls = [c for c in mock_md.call_args_list if "linear-gradient" in str(c)]
+        self.assertEqual(len(card_calls), 0)
+
+    @patch("streamlit.info")
+    @patch("streamlit.markdown")
+    def test_no_matching_historical_date_shows_empty_state(
+        self, mock_md: MagicMock, mock_info: MagicMock
+    ) -> None:
+        df = pd.DataFrame(
+            {
+                "timestamp": [_ts("2025-01-01")],
+                "date_text": pd.to_datetime(["2025-01-01"]),
+                "artist": ["Off-day Artist"],
+                "track": ["T"],
+                "album": ["A"],
+            }
+        )
+        render_time_machine_card(df, None, today=TODAY)
+        mock_info.assert_called_once()
+
+
+class TestRenderTimeMachineCardPopulated(unittest.TestCase):
+    @patch("streamlit.markdown")
+    def test_full_data_renders_card_with_all_sections(self, mock_md: MagicMock) -> None:
+        df = pd.DataFrame(
+            {
+                "timestamp": [_ts("2019-07-11")],
+                "date_text": pd.to_datetime(["2019-07-11"]),
+                "artist": ["Radiohead"],
+                "track": ["Idioteque"],
+                "album": ["Kid A"],
+                "source_id": ["lastfm"],
+                "city": ["Lisbon"],
+                "state": [""],
+                "country": ["Portugal"],
+            }
+        )
+        render_time_machine_card(df, None, today=TODAY, rng=random.Random(1))
+
+        all_html = " ".join(str(c) for c in mock_md.call_args_list)
+        self.assertIn("Where you were", all_html)
+        self.assertIn("Lisbon", all_html)
+        self.assertIn("What you were listening to", all_html)
+        self.assertIn("Radiohead", all_html)
+
+    @patch("streamlit.markdown")
+    def test_listening_only_omits_other_sections(self, mock_md: MagicMock) -> None:
+        df = pd.DataFrame(
+            {
+                "timestamp": [_ts("2019-07-11")],
+                "date_text": pd.to_datetime(["2019-07-11"]),
+                "artist": ["Boards of Canada"],
+                "track": ["Roygbiv"],
+                "album": ["MHTRTC"],
+                "source_id": ["lastfm"],
+            }
+        )
+        render_time_machine_card(df, None, today=TODAY, rng=random.Random(1))
+
+        all_html = " ".join(str(c) for c in mock_md.call_args_list)
+        self.assertIn("What you were listening to", all_html)
+        self.assertNotIn("Where you were", all_html)
+        self.assertNotIn("What you were doing", all_html)
+
+    @patch("streamlit.markdown")
+    def test_events_only_from_non_lastfm_source(self, mock_md: MagicMock) -> None:
+        df = pd.DataFrame(
+            {
+                "timestamp": [_ts("2019-07-11")],
+                "date_text": pd.to_datetime(["2019-07-11"]),
+                "artist": ["Tasting Room Brewing"],
+                "track": ["Hazy IPA"],
+                "album": ["IPA"],
+                "source_id": ["untappd"],
+            }
+        )
+        render_time_machine_card(df, None, today=TODAY, rng=random.Random(1))
+
+        all_html = " ".join(str(c) for c in mock_md.call_args_list)
+        self.assertIn("What you were doing", all_html)
+        self.assertIn("Tasting Room Brewing", all_html)
+        self.assertNotIn("What you were listening to", all_html)
+
+    @patch("streamlit.markdown")
+    def test_swarm_only_location(self, mock_md: MagicMock) -> None:
+        swarm_df = pd.DataFrame(
+            {
+                "timestamp": [_ts("2019-07-11")],
+                "city": ["Berlin"],
+                "state": [""],
+                "country": ["Germany"],
+                "venue": ["Cafe A"],
+            }
+        )
+        render_time_machine_card(None, swarm_df, today=TODAY, rng=random.Random(1))
+
+        all_html = " ".join(str(c) for c in mock_md.call_args_list)
+        self.assertIn("Where you were", all_html)
+        self.assertIn("Berlin", all_html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -1,0 +1,374 @@
+"""Tests for core.time_machine — pure "this day in history" data-shaping (issue #98).
+
+Covers the Time Machine card's acceptance criteria: exact-date matches, no data at all,
+one-of-three-categories-only data, deterministic multi-year picking (seeded ``random.Random``
+rather than real wall-clock randomness), and each of location/listening/events degrading
+independently.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pandas as pd
+import pytest
+
+from core.time_machine import (
+    EventSnapshot,
+    ListeningSnapshot,
+    LocationSnapshot,
+    TimeMachineEntry,
+    build_entry,
+    candidate_years,
+    get_time_machine_entry,
+    pick_year,
+)
+
+
+def _ts(dt_str: str) -> int:
+    """Return a unix int-seconds timestamp for the given ISO date string."""
+    return int(pd.Timestamp(dt_str).timestamp())
+
+
+def _activity_row(
+    date_str: str,
+    artist: str,
+    track: str = "",
+    album: str = "",
+    source_id: str = "lastfm",
+    city: str | None = "Reykjavik",
+    state: str | None = "IS",
+    country: str | None = "Iceland",
+) -> dict:
+    row = {
+        "timestamp": _ts(date_str),
+        "date_text": pd.Timestamp(date_str),
+        "artist": artist,
+        "track": track,
+        "album": album,
+        "source_id": source_id,
+    }
+    if city is not None:
+        row["city"] = city
+        row["state"] = state
+        row["country"] = country
+    return row
+
+
+def _activity_df(rows: list[dict]) -> pd.DataFrame:
+    return pd.DataFrame(rows)
+
+
+def _places_df(rows: list[dict]) -> pd.DataFrame:
+    return pd.DataFrame(rows)
+
+
+def _place_row(
+    date_str: str, city: str = "", state: str = "", country: str = "", venue: str = ""
+) -> dict:
+    return {
+        "timestamp": _ts(date_str),
+        "city": city,
+        "state": state,
+        "country": country,
+        "venue": venue,
+    }
+
+
+EMPTY_ACTIVITY = pd.DataFrame(
+    columns=["timestamp", "date_text", "artist", "track", "album", "source_id"]
+)
+EMPTY_PLACES = pd.DataFrame(columns=["timestamp", "city", "state", "country", "venue"])
+
+
+# ---------------------------------------------------------------------------
+# candidate_years
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_years_matches_month_and_day_across_multiple_past_years() -> None:
+    activity = _activity_df(
+        [
+            _activity_row("2019-07-11", "Artist A"),
+            _activity_row("2021-07-11", "Artist B"),
+            _activity_row("2021-08-01", "Artist Off-Day"),  # different day, must not match
+        ]
+    )
+    years = candidate_years(pd.Timestamp("2026-07-11").date(), activity, EMPTY_PLACES)
+    assert years == [2021, 2019]
+
+
+def test_candidate_years_excludes_current_year_and_future() -> None:
+    activity = _activity_df(
+        [
+            _activity_row("2026-07-11", "Today, not history"),
+        ]
+    )
+    years = candidate_years(pd.Timestamp("2026-07-11").date(), activity, EMPTY_PLACES)
+    assert years == []
+
+
+def test_candidate_years_includes_places_only_years() -> None:
+    places = _places_df([_place_row("2018-07-11", city="Lisbon")])
+    years = candidate_years(pd.Timestamp("2026-07-11").date(), EMPTY_ACTIVITY, places)
+    assert years == [2018]
+
+
+def test_candidate_years_empty_when_no_data_at_all() -> None:
+    years = candidate_years(pd.Timestamp("2026-07-11").date(), EMPTY_ACTIVITY, EMPTY_PLACES)
+    assert years == []
+
+
+def test_candidate_years_tolerates_missing_columns() -> None:
+    """A frame missing date_text/timestamp altogether must not raise."""
+    activity = pd.DataFrame({"artist": ["A"]})
+    places = pd.DataFrame({"city": ["X"]})
+    assert candidate_years(pd.Timestamp("2026-07-11").date(), activity, places) == []
+
+
+def test_candidate_years_tolerates_none_frames() -> None:
+    assert candidate_years(pd.Timestamp("2026-07-11").date(), None, None) == []  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# pick_year
+# ---------------------------------------------------------------------------
+
+
+def test_pick_year_returns_none_for_empty_list() -> None:
+    assert pick_year([]) is None
+
+
+def test_pick_year_is_deterministic_with_seeded_rng() -> None:
+    years = [2018, 2019, 2020, 2021]
+    picked_a = pick_year(years, rng=random.Random(42))
+    picked_b = pick_year(years, rng=random.Random(42))
+    assert picked_a == picked_b
+    assert picked_a in years
+
+
+def test_pick_year_single_candidate_returns_it() -> None:
+    assert pick_year([2020], rng=random.Random(0)) == 2020
+
+
+# ---------------------------------------------------------------------------
+# build_entry — full entry (all three categories present)
+# ---------------------------------------------------------------------------
+
+
+def test_build_entry_full_data_all_categories_present() -> None:
+    activity = _activity_df(
+        [
+            _activity_row(
+                "2019-07-11",
+                "Radiohead",
+                "Idioteque",
+                "Kid A",
+                city="Lisbon",
+                state="",
+                country="Portugal",
+            ),
+            _activity_row("2019-07-11", "Radiohead", "Everything In Its Right Place", "Kid A"),
+            _activity_row(
+                "2019-07-11",
+                "Tasting Room Brewing",
+                "Hazy IPA",
+                "IPA",
+                source_id="untappd",
+            ),
+        ]
+    )
+    places = _places_df(
+        [_place_row("2019-07-11", city="Lisbon", country="Portugal", venue="Cafe A")]
+    )
+
+    entry = build_entry(pd.Timestamp("2026-07-11").date(), 2019, activity, places)
+
+    assert entry.target_date == pd.Timestamp("2019-07-11").date()
+    assert entry.years_ago == 7
+
+    assert entry.location is not None
+    assert entry.location.city == "Lisbon"
+    assert entry.location.country == "Portugal"
+
+    assert entry.listening is not None
+    assert entry.listening.scrobble_count == 2
+    assert entry.listening.top_artist == "Radiohead"
+    assert "Radiohead — Idioteque" in entry.listening.sample_tracks
+
+    assert len(entry.events) == 1
+    assert entry.events[0].label == "Tasting Room Brewing"
+    assert entry.events[0].sublabel == "Hazy IPA"
+    assert entry.events[0].source_id == "untappd"
+
+
+# ---------------------------------------------------------------------------
+# build_entry — independent optionality: only one of three categories has data
+# ---------------------------------------------------------------------------
+
+
+def test_build_entry_listening_only_leaves_location_and_events_absent() -> None:
+    activity = _activity_df(
+        [
+            _activity_row(
+                "2020-03-05", "Boards of Canada", "Roygbiv", city=None, state=None, country=None
+            )
+        ]
+    )
+    entry = build_entry(pd.Timestamp("2026-03-05").date(), 2020, activity, EMPTY_PLACES)
+
+    assert entry.listening is not None
+    assert entry.listening.scrobble_count == 1
+    assert entry.location is None
+    assert entry.events == ()
+
+
+def test_build_entry_events_only_leaves_location_and_listening_absent() -> None:
+    activity = _activity_df(
+        [
+            _activity_row(
+                "2020-03-05",
+                "Some Brewery",
+                "Stout",
+                "Stout",
+                source_id="untappd",
+                city=None,
+                state=None,
+                country=None,
+            )
+        ]
+    )
+    entry = build_entry(pd.Timestamp("2026-03-05").date(), 2020, activity, EMPTY_PLACES)
+
+    assert entry.listening is None
+    assert entry.location is None
+    assert len(entry.events) == 1
+    assert entry.events[0].label == "Some Brewery"
+
+
+def test_build_entry_location_only_from_places_leaves_listening_and_events_absent() -> None:
+    places = _places_df([_place_row("2020-03-05", city="Berlin", country="Germany")])
+    entry = build_entry(pd.Timestamp("2026-03-05").date(), 2020, EMPTY_ACTIVITY, places)
+
+    assert entry.location is not None
+    assert entry.location.city == "Berlin"
+    assert entry.listening is None
+    assert entry.events == ()
+
+
+def test_build_entry_location_falls_back_to_venue_when_places_lack_city() -> None:
+    places = _places_df([_place_row("2020-03-05", venue="The Loft")])
+    entry = build_entry(pd.Timestamp("2026-03-05").date(), 2020, EMPTY_ACTIVITY, places)
+
+    assert entry.location is not None
+    assert entry.location.city == "The Loft"
+
+
+def test_build_entry_no_matching_rows_on_date_returns_all_absent() -> None:
+    activity = _activity_df([_activity_row("2020-03-06", "Off by one day")])
+    entry = build_entry(pd.Timestamp("2026-03-05").date(), 2020, activity, EMPTY_PLACES)
+
+    assert entry.location is None
+    assert entry.listening is None
+    assert entry.events == ()
+
+
+def test_build_entry_missing_source_id_treats_all_rows_as_listening() -> None:
+    """Legacy (flat-file) mode has no source_id column at all — every row is a real listen."""
+    activity = pd.DataFrame(
+        [
+            {
+                "timestamp": _ts("2020-03-05"),
+                "date_text": pd.Timestamp("2020-03-05"),
+                "artist": "Aphex Twin",
+                "track": "Windowlicker",
+                "album": "Windowlicker EP",
+                "city": "Perth",
+                "state": "WA",
+                "country": "Australia",
+            }
+        ]
+    )
+    entry = build_entry(pd.Timestamp("2026-03-05").date(), 2020, activity, EMPTY_PLACES)
+
+    assert entry.listening is not None
+    assert entry.listening.scrobble_count == 1
+    assert entry.events == ()
+    assert entry.location is not None
+    assert entry.location.city == "Perth"
+
+
+# ---------------------------------------------------------------------------
+# get_time_machine_entry — top-level orchestration
+# ---------------------------------------------------------------------------
+
+
+def test_get_time_machine_entry_no_data_at_all_returns_none() -> None:
+    result = get_time_machine_entry(pd.Timestamp("2026-07-11").date(), EMPTY_ACTIVITY, EMPTY_PLACES)
+    assert result is None
+
+
+def test_get_time_machine_entry_exact_date_match_returns_entry() -> None:
+    activity = _activity_df([_activity_row("2022-07-11", "Artist X", "Track X")])
+    result = get_time_machine_entry(
+        pd.Timestamp("2026-07-11").date(), activity, EMPTY_PLACES, rng=random.Random(1)
+    )
+    assert result is not None
+    assert result.target_date == pd.Timestamp("2022-07-11").date()
+    assert result.years_ago == 4
+
+
+def test_get_time_machine_entry_picks_deterministically_among_multiple_years() -> None:
+    activity = _activity_df(
+        [
+            _activity_row("2018-07-11", "Artist 2018"),
+            _activity_row("2020-07-11", "Artist 2020"),
+            _activity_row("2022-07-11", "Artist 2022"),
+        ]
+    )
+    today = pd.Timestamp("2026-07-11").date()
+
+    result_a = get_time_machine_entry(today, activity, EMPTY_PLACES, rng=random.Random(7))
+    result_b = get_time_machine_entry(today, activity, EMPTY_PLACES, rng=random.Random(7))
+
+    assert result_a is not None
+    assert result_b is not None
+    assert result_a.target_date == result_b.target_date
+    assert result_a.target_date.year in (2018, 2020, 2022)
+
+
+def test_get_time_machine_entry_tries_multiple_candidates_not_just_fixed_offset() -> None:
+    """Data exists 3 years ago but not exactly 1 year ago — must still find it."""
+    activity = _activity_df([_activity_row("2023-07-11", "Old Artist")])
+    today = pd.Timestamp("2026-07-11").date()  # "1 year ago" (2025) has nothing
+
+    result = get_time_machine_entry(today, activity, EMPTY_PLACES)
+    assert result is not None
+    assert result.target_date.year == 2023
+
+
+# ---------------------------------------------------------------------------
+# Dataclass sanity (construction / equality used elsewhere, e.g. page rendering)
+# ---------------------------------------------------------------------------
+
+
+def test_dataclasses_are_constructible_and_comparable() -> None:
+    loc = LocationSnapshot(city="Lisbon", state="", country="Portugal")
+    listening = ListeningSnapshot(
+        scrobble_count=2, top_artist="Radiohead", sample_tracks=("A — B",)
+    )
+    event = EventSnapshot(label="Brewery", sublabel="IPA", category="IPA", source_id="untappd")
+    entry = TimeMachineEntry(
+        target_date=pd.Timestamp("2019-07-11").date(),
+        years_ago=7,
+        location=loc,
+        listening=listening,
+        events=(event,),
+    )
+    assert entry.location == loc
+    assert entry.listening == listening
+    assert entry.events == (event,)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary
- Adds a "Time Machine" card to the Overview page that surfaces "this day in history": for today's month/day, it picks a random past year with matching data and shows where the user was, what they were listening to (Last.fm), and what else they were doing (check-ins, photos, drinks, etc. via EVENTS-shaped sources like Untappd/Flickr).
- `core/time_machine.py` holds the pure, Streamlit/DB-free data-shaping logic (`candidate_years`, `pick_year`, `build_entry`, `get_time_machine_entry`), reusing the already-loaded `df`/`swarm_df` session-state frames rather than issuing a fresh DuckDB query, mirroring the `core/drinking_history.py` convention.
- `pages/overview.py` gets `render_time_machine_card()`, wired into `render_overview()` after the existing hero card, with an injectable `today`/`rng` for deterministic tests.
- Location, listening, and events are each resolved independently — a missing one never suppresses the others — and the card falls back to a clear "no historical data for this day yet" message when no candidate year exists at all.

### Design/judgment calls
- **Year selection**: rather than a single fixed "N years ago" offset (which would almost always land on a day with nothing), every past year with *any* matching record on today's month/day is a candidate; one is picked at random via an injectable `random.Random` so tests are deterministic.
- **Data source**: reuses `st.session_state['df']` (which, in broker mode, already contains every what-when source — Last.fm, Untappd, Flickr, etc. — merged with location context via `apply_location_context()`) and `st.session_state['swarm_df']` (places/location pipeline), rather than opening a new `LocalizerStore` connection. This keeps the page self-contained and avoids a redundant DB round-trip, since the Overview page already loads these frames. `source_id == "lastfm"` rows are "listening"; all other `source_id` values are "events"; frames without a `source_id` column (legacy CSV mode) are treated entirely as listens, with no events.
- **Empty state**: uses `st.info(...)`, consistent with the rest of the app's empty-state convention (Insights, Drinking History, Venue Patterns, etc.).

## Test plan
- [x] `pytest tests/test_time_machine.py -v` — 21 unit tests covering exact-date matches, no-data-at-all, single-category-only data (listening-only / events-only / location-only), multi-year deterministic picking via seeded `random.Random`, and edge cases (missing columns, missing `source_id`, off-by-one-day, venue-only location fallback).
- [x] `pytest tests/test_overview.py -v` — 6 tests covering the Streamlit wiring (empty state, full render, per-category rendering) with injected `today`/`rng`.
- [x] `pytest tests/test_visualize.py -k overview -v` — existing Overview page tests still pass unmodified.
- [x] Full local quality gate: `ruff check .`, `ruff format --check .`, `mypy`, `pytest -n auto` (999 passed, 0 failed).
- [ ] Manual: run `streamlit run visualize.py`, load a store with historical data spanning multiple years, and visually confirm the Time Machine card renders on the Overview page.

Closes #98