### PR TITLE
fix: make localizer sync resumable across interrupted first-history loads

### DIFF
--- a/packages/localizer/src/localizer/cli.py
+++ b/packages/localizer/src/localizer/cli.py
@@ -76,6 +76,48 @@ def _get_settings() -> LocalizerSettings:
     return LocalizerSettings()
 
 
+def _resolve_since_floor(store: Any, source_id: str, output_tables: list[Any]) -> int | None:
+    """Resolve the incremental-resume floor for a source's ``since`` cursor.
+
+    Prefers the newest already-committed record timestamp — across every
+    table the plugin declares in ``OUTPUT_TABLES`` — over
+    ``sync_state.last_synced_at``. This makes a resync (including resuming
+    an initial full-history load that was interrupted mid-write) pick up
+    from exactly what has actually landed in the store, regardless of
+    whether the interrupted run ever reached ``set_sync_state``: each
+    ``upsert_*`` batch commits its own transaction, so committed batches
+    survive a crash even when the final cursor write does not (see issue
+    #109).
+
+    For a dual-output plugin (e.g. Flickr, which writes both PLACES and
+    EVENTS), the floor is the *minimum* of each table's max timestamp, so
+    neither stream skips data the other table hasn't caught up to yet. If
+    any declared table has no committed rows at all, this falls back to
+    ``sync_state.last_synced_at`` (typically None, i.e. full history) so a
+    partially-started dual-output plugin still fetches everything for the
+    table that has nothing yet.
+
+    Args:
+        store: Open ``LocalizerStore``.
+        source_id: Plugin ID whose cursor is being resolved.
+        output_tables: The plugin's ``OUTPUT_TABLES`` list (may be empty).
+
+    Returns:
+        Unix timestamp floor to pass as ``since=``, or None for full history.
+    """
+    tables = output_tables or [None]
+    floors: list[int] = []
+    for table in tables:
+        table_name = table.value if table is not None else "events"
+        latest = store.get_latest_timestamp(source_id, table=table_name)
+        if latest is None:
+            state = store.get_sync_state(source_id)
+            return state.get("last_synced_at")  # type: ignore[no-any-return]
+        floors.append(latest)
+
+    return min(floors)
+
+
 # ---------------------------------------------------------------------------
 # Root group
 # ---------------------------------------------------------------------------
@@ -253,6 +295,14 @@ def export_cmd(fmt: str, table: str | None, since: int | None, output: str) -> N
     "--full", "full", is_flag=True, default=False, help="Ignore last cursor and fetch all records."
 )
 @click.option(
+    "--force",
+    "force",
+    is_flag=True,
+    default=False,
+    help="Alias for --full: bypass the stored cursor and any resumable "
+    "committed-data floor, forcing a full rebuild.",
+)
+@click.option(
     "--dry-run", "dry_run", is_flag=True, default=False, help="Fetch but do not write to store."
 )
 @click.option(
@@ -273,6 +323,7 @@ def fetch_cmd(
     source: str,
     since: int | None,
     full: bool,
+    force: bool,
     dry_run: bool,
     set_dir: str | None,
     set_file: str | None,
@@ -286,6 +337,7 @@ def fetch_cmd(
       localizer fetch swarm --set-dir "G:/My Drive/Swarm Export"
       localizer fetch letterboxd --set-file "/path/to/diary.csv"
     """
+    full = full or force
     from localizer.plugins import REGISTRY, load_builtin_plugins  # noqa: PLC0415
     from localizer.store.db import LocalizerStore  # noqa: PLC0415
 
@@ -316,20 +368,19 @@ def fetch_cmd(
     plugin = plugin_cls()
 
     store_path = _get_store_path()
+    output_tables = getattr(plugin_cls, "OUTPUT_TABLES", [])
 
-    # Determine since timestamp from sync state when not forced.
+    # Determine since timestamp from the resumable-sync floor when not forced.
     effective_since = since
     if not full and effective_since is None:
         with LocalizerStore(store_path) as store:
-            state = store.get_sync_state(source)
-            effective_since = state.get("last_synced_at")
+            effective_since = _resolve_since_floor(store, source, output_tables)
 
     import time  # noqa: PLC0415
 
     from rich.console import Console  # noqa: PLC0415
 
     console = Console(stderr=True)
-    output_tables = getattr(plugin_cls, "OUTPUT_TABLES", [])
     primary_table = output_tables[0] if output_tables else None
     secondary_table = output_tables[1] if len(output_tables) > 1 else None
     count = 0
@@ -404,7 +455,15 @@ def fetch_cmd(
 @click.option(
     "--dry-run", "dry_run", is_flag=True, default=False, help="Fetch but do not write to store."
 )
-def sync_cmd(since: int | None, dry_run: bool) -> None:
+@click.option(
+    "--force",
+    "force",
+    is_flag=True,
+    default=False,
+    help="Bypass the stored cursor and any resumable committed-data floor for "
+    "every plugin, forcing a full rebuild.",
+)
+def sync_cmd(since: int | None, dry_run: bool, force: bool) -> None:
     """Sync all registered plugins."""
     from rich.console import Console  # noqa: PLC0415
 
@@ -427,12 +486,11 @@ def sync_cmd(since: int | None, dry_run: bool) -> None:
         primary_table = output_tables[0] if output_tables else None
         secondary_table = output_tables[1] if len(output_tables) > 1 else None
 
-        # Determine effective since from sync state.
+        # Determine effective since from the resumable-sync floor, unless forced.
         effective_since = since
-        if effective_since is None and not dry_run:
+        if effective_since is None and not dry_run and not force:
             with LocalizerStore(store_path) as store:
-                state = store.get_sync_state(plugin_id)
-                effective_since = state.get("last_synced_at")
+                effective_since = _resolve_since_floor(store, plugin_id, output_tables)
         page_label: list[str] = [""]
 
         def _progress_cb(current: int, total: int, _pl: list[str] = page_label) -> None:

--- a/packages/localizer/src/localizer/store/db.py
+++ b/packages/localizer/src/localizer/store/db.py
@@ -356,6 +356,41 @@ class LocalizerStore:
         return self._conn.execute(sql, params).df()
 
     # ------------------------------------------------------------------
+    # Resumable-sync support (issue #109)
+    # ------------------------------------------------------------------
+
+    _TIMESTAMP_TABLES = ("events", "places", "content")
+
+    def get_latest_timestamp(self, source_id: str, table: str = "events") -> int | None:
+        """Return the newest already-committed record timestamp for a source.
+
+        Used to resume an interrupted or incremental sync from exactly what
+        has actually landed in the store, instead of relying solely on
+        ``sync_state.last_synced_at`` — which is only written after a run
+        completes. A crash mid-write still leaves already-committed batches
+        intact (each ``upsert_*`` call commits its own transaction), so
+        re-querying the real data gives an accurate resume point even when
+        ``set_sync_state`` was never reached.
+
+        Args:
+            source_id: The plugin's source identifier.
+            table: Which table to query — one of "events", "places",
+                "content". Falls back to "events" for any other value.
+
+        Returns:
+            The max ``timestamp`` among rows matching ``source_id`` in
+            ``table``, or None if there are no such rows.
+        """
+        if table not in self._TIMESTAMP_TABLES:
+            table = "events"
+        assert self._conn is not None
+        sql = f"SELECT MAX(timestamp) FROM {table} WHERE source_id = ?"  # noqa: S608
+        row = self._conn.execute(sql, [source_id]).fetchone()
+        if row is None or row[0] is None:
+            return None
+        return int(row[0])
+
+    # ------------------------------------------------------------------
     # Sync state
     # ------------------------------------------------------------------
 

--- a/packages/localizer/tests/test_cli.py
+++ b/packages/localizer/tests/test_cli.py
@@ -575,3 +575,222 @@ def test_fetch_writes_dual_output_plugin_to_both_tables(tmp_db: Path) -> None:
 
     assert len(places_df) == 1
     assert len(events_df) == 1
+
+
+# ---------------------------------------------------------------------------
+# 15. Resumable sync (issue #109)
+# ---------------------------------------------------------------------------
+
+_LASTFM_ENV = {
+    "AUTOBIO_LASTFM_API_KEY": "dummy_key",
+    "AUTOBIO_LASTFM_API_SECRET": "dummy_secret",
+    "AUTOBIO_LASTFM_USERNAME": "dummy_user",
+}
+
+
+def _seed_lastfm_events(db_path: Path, n: int, base_timestamp: int) -> None:
+    """Seed `n` lastfm event rows at base_timestamp..base_timestamp+n-1, no sync_state."""
+    from localizer.store.db import LocalizerStore
+
+    with LocalizerStore(db_path) as store:
+        store.upsert_events(
+            [
+                {
+                    "source_id": "lastfm",
+                    "timestamp": base_timestamp + i,
+                    "label": f"Artist{i}",
+                    "sublabel": f"Track{i}",
+                    "category": None,
+                    "raw_json": None,
+                    "fetched_at": int(time.time()),
+                }
+                for i in range(n)
+            ]
+        )
+
+
+def _scope_registry_to_lastfm() -> None:
+    """Return a callable that replaces load_builtin_plugins with a lastfm-only REGISTRY.
+
+    Keeps `sync` tests from touching any other (network-calling) plugin.
+    """
+    from localizer.plugins.lastfm.loader import LastFmPlugin
+
+    def _fake_load_builtin_plugins() -> None:
+        from localizer.plugins import REGISTRY  # noqa: PLC0415
+
+        REGISTRY.clear()
+        REGISTRY["lastfm"] = LastFmPlugin
+
+    return _fake_load_builtin_plugins
+
+
+def test_fetch_resumes_from_latest_committed_timestamp(tmp_db: Path) -> None:
+    """When no sync_state exists but the store already has committed rows for
+    this source (e.g. an interrupted first sync that wrote some batches but
+    never reached set_sync_state), `localizer fetch` must resume from the
+    newest already-committed timestamp instead of re-fetching everything."""
+    _seed_lastfm_events(tmp_db, n=10, base_timestamp=5_000_000)
+
+    captured_since: list[int | None] = []
+
+    def _fake_fetch_records(self: Any, since: int | None = None, **_: Any) -> Any:
+        captured_since.append(since)
+        return iter([])
+
+    runner = CliRunner()
+    env = {**os.environ, "LOCALIZER_DB_PATH": str(tmp_db), **_LASTFM_ENV}
+    with patch(
+        "localizer.plugins.lastfm.loader.LastFmPlugin.fetch_records",
+        _fake_fetch_records,
+    ):
+        result = runner.invoke(cli, ["fetch", "lastfm"], env=env)
+
+    assert result.exit_code == 0, result.output
+    assert captured_since == [5_000_009], (
+        f"Expected fetch to resume from the newest committed timestamp (5000009), "
+        f"got {captured_since}. CLI output: {result.output}"
+    )
+
+
+def test_sync_resumes_from_latest_committed_timestamp(tmp_db: Path) -> None:
+    """`localizer sync` must apply the same resumability floor as `fetch` —
+    resuming from the newest committed row when no sync_state exists yet."""
+    _seed_lastfm_events(tmp_db, n=5, base_timestamp=6_000_000)
+
+    captured_since: list[int | None] = []
+
+    def _fake_fetch_records(self: Any, since: int | None = None, **_: Any) -> Any:
+        captured_since.append(since)
+        return iter([])
+
+    runner = CliRunner()
+    env = {**os.environ, "LOCALIZER_DB_PATH": str(tmp_db), **_LASTFM_ENV}
+    with (
+        patch("localizer.plugins.lastfm.loader.LastFmPlugin.fetch_records", _fake_fetch_records),
+        patch("localizer.plugins.load_builtin_plugins", _scope_registry_to_lastfm()),
+    ):
+        result = runner.invoke(cli, ["sync"], env=env)
+
+    assert result.exit_code == 0, result.output
+    assert captured_since == [6_000_004], (
+        f"Expected sync to resume from the newest committed timestamp (6000004), "
+        f"got {captured_since}. CLI output: {result.output}"
+    )
+
+
+def test_resume_floor_prefers_committed_data_over_stale_sync_state(tmp_db: Path) -> None:
+    """The resumability floor must be based on actually-committed data, per the
+    issue #109 acceptance criteria — not on `sync_state.last_synced_at` — even
+    when a (stale or otherwise mismatched) sync_state row exists."""
+    from localizer.store.db import LocalizerStore
+
+    _seed_lastfm_events(tmp_db, n=1, base_timestamp=1_000)
+    with LocalizerStore(tmp_db) as store:
+        # last_synced_at is set far in the future relative to the committed
+        # data's own timestamp — the floor must still come from the data.
+        store.set_sync_state("lastfm", last_synced_at=9_999_999, record_count=1, status="ok")
+
+    captured_since: list[int | None] = []
+
+    def _fake_fetch_records(self: Any, since: int | None = None, **_: Any) -> Any:
+        captured_since.append(since)
+        return iter([])
+
+    runner = CliRunner()
+    env = {**os.environ, "LOCALIZER_DB_PATH": str(tmp_db), **_LASTFM_ENV}
+    with patch(
+        "localizer.plugins.lastfm.loader.LastFmPlugin.fetch_records",
+        _fake_fetch_records,
+    ):
+        result = runner.invoke(cli, ["fetch", "lastfm"], env=env)
+
+    assert result.exit_code == 0, result.output
+    assert captured_since == [1_000], (
+        f"Expected the floor to come from committed data (1000), not stale "
+        f"sync_state (9999999); got {captured_since}. CLI output: {result.output}"
+    )
+
+
+def test_fetch_first_ever_sync_has_no_since_floor(tmp_db: Path) -> None:
+    """A true first-ever fetch (empty store, no sync_state) must pass since=None,
+    unaffected by the new resumability floor logic."""
+    captured_since: list[int | None] = []
+
+    def _fake_fetch_records(self: Any, since: int | None = None, **_: Any) -> Any:
+        captured_since.append(since)
+        return iter([])
+
+    runner = CliRunner()
+    env = {**os.environ, "LOCALIZER_DB_PATH": str(tmp_db), **_LASTFM_ENV}
+    with patch(
+        "localizer.plugins.lastfm.loader.LastFmPlugin.fetch_records",
+        _fake_fetch_records,
+    ):
+        result = runner.invoke(cli, ["fetch", "lastfm"], env=env)
+
+    assert result.exit_code == 0, result.output
+    assert captured_since == [None], (
+        f"Expected since=None for a true first-ever sync, got {captured_since}. "
+        f"CLI output: {result.output}"
+    )
+
+
+def test_fetch_force_bypasses_resume_floor(tmp_db: Path) -> None:
+    """`localizer fetch <source> --force` must ignore both sync_state and any
+    already-committed data, fetching from the beginning (full rebuild)."""
+    from localizer.store.db import LocalizerStore
+
+    _seed_lastfm_events(tmp_db, n=1, base_timestamp=7_000_000)
+    with LocalizerStore(tmp_db) as store:
+        store.set_sync_state("lastfm", last_synced_at=7_500_000, record_count=1, status="ok")
+
+    captured_since: list[int | None] = []
+
+    def _fake_fetch_records(self: Any, since: int | None = None, **_: Any) -> Any:
+        captured_since.append(since)
+        return iter([])
+
+    runner = CliRunner()
+    env = {**os.environ, "LOCALIZER_DB_PATH": str(tmp_db), **_LASTFM_ENV}
+    with patch(
+        "localizer.plugins.lastfm.loader.LastFmPlugin.fetch_records",
+        _fake_fetch_records,
+    ):
+        result = runner.invoke(cli, ["fetch", "lastfm", "--force"], env=env)
+
+    assert result.exit_code == 0, result.output
+    assert captured_since == [None], (
+        f"Expected --force to bypass both sync_state and the committed-data "
+        f"floor, got since={captured_since}. CLI output: {result.output}"
+    )
+
+
+def test_sync_force_bypasses_resume_floor(tmp_db: Path) -> None:
+    """`localizer sync --force` must ignore stored state for every plugin and
+    perform a full rebuild."""
+    from localizer.store.db import LocalizerStore
+
+    _seed_lastfm_events(tmp_db, n=1, base_timestamp=8_000_000)
+    with LocalizerStore(tmp_db) as store:
+        store.set_sync_state("lastfm", last_synced_at=8_500_000, record_count=1, status="ok")
+
+    captured_since: list[int | None] = []
+
+    def _fake_fetch_records(self: Any, since: int | None = None, **_: Any) -> Any:
+        captured_since.append(since)
+        return iter([])
+
+    runner = CliRunner()
+    env = {**os.environ, "LOCALIZER_DB_PATH": str(tmp_db), **_LASTFM_ENV}
+    with (
+        patch("localizer.plugins.lastfm.loader.LastFmPlugin.fetch_records", _fake_fetch_records),
+        patch("localizer.plugins.load_builtin_plugins", _scope_registry_to_lastfm()),
+    ):
+        result = runner.invoke(cli, ["sync", "--force"], env=env)
+
+    assert result.exit_code == 0, result.output
+    assert captured_since == [None], (
+        f"Expected --force to bypass stored state, got since={captured_since}. "
+        f"CLI output: {result.output}"
+    )

--- a/packages/localizer/tests/test_store.py
+++ b/packages/localizer/tests/test_store.py
@@ -569,3 +569,70 @@ def test_set_and_get_sync_state(tmp_path):
     assert state["last_cursor"] == "page5"
     assert state["status"] == "ok"
     assert state["record_count"] == 42
+
+
+# ---------------------------------------------------------------------------
+# 10. get_latest_timestamp (resumable-sync support, issue #109)
+# ---------------------------------------------------------------------------
+
+
+def test_get_latest_timestamp_returns_max_for_source(tmp_path):
+    """get_latest_timestamp returns the max timestamp among a source's events."""
+    db_path = tmp_path / "store.duckdb"
+    with LocalizerStore(db_path) as store:
+        store.upsert_events(_make_events(5, source_id="lastfm"))  # timestamps 1000..1004
+        latest = store.get_latest_timestamp("lastfm", table="events")
+
+    assert latest == 1004
+
+
+def test_get_latest_timestamp_none_when_no_rows(tmp_path):
+    """get_latest_timestamp returns None when the source has no rows in that table."""
+    db_path = tmp_path / "store.duckdb"
+    with LocalizerStore(db_path) as store:
+        latest = store.get_latest_timestamp("neversynced", table="events")
+
+    assert latest is None
+
+
+def test_get_latest_timestamp_scoped_to_source_id(tmp_path):
+    """get_latest_timestamp for one source ignores rows belonging to another source."""
+    db_path = tmp_path / "store.duckdb"
+    with LocalizerStore(db_path) as store:
+        store.upsert_events(_make_events(3, source_id="lastfm"))  # 1000..1002
+        store.upsert_events(
+            [
+                {
+                    "source_id": "other",
+                    "timestamp": 9999,
+                    "label": "X",
+                    "sublabel": None,
+                    "category": None,
+                    "raw_json": None,
+                    "fetched_at": int(time.time()),
+                }
+            ]
+        )
+        latest = store.get_latest_timestamp("lastfm", table="events")
+
+    assert latest == 1002
+
+
+def test_get_latest_timestamp_supports_places_table(tmp_path):
+    """get_latest_timestamp against table='places' reads from the places table."""
+    db_path = tmp_path / "store.duckdb"
+    with LocalizerStore(db_path) as store:
+        store.upsert_places(_make_places(4, source_id="swarm"))  # timestamps 2000..2003
+        latest = store.get_latest_timestamp("swarm", table="places")
+
+    assert latest == 2003
+
+
+def test_get_latest_timestamp_supports_content_table(tmp_path):
+    """get_latest_timestamp against table='content' reads from the content table."""
+    db_path = tmp_path / "store.duckdb"
+    with LocalizerStore(db_path) as store:
+        store.upsert_content(_make_content(3, source_id="feedly"))
+        latest = store.get_latest_timestamp("feedly", table="content")
+
+    assert latest is not None


### PR DESCRIPTION
## Summary

- Adds `LocalizerStore.get_latest_timestamp(source_id, table)`, which queries the newest already-committed record timestamp for a source/table pair.
- `localizer fetch` and `localizer sync` now derive their `since` floor from this — preferring actually-committed data over `sync_state.last_synced_at` — so a sync interrupted mid-write (e.g. a 100k+ scrobble Last.fm first-sync that gets killed partway through) resumes from exactly what already landed in the store on the next run, instead of re-fetching the full history from scratch.
- Each `upsert_events`/`upsert_places`/`upsert_content` batch already commits its own DuckDB transaction, so this required no new write-path changes — only a smarter read of what's already there. For dual-output plugins (e.g. Flickr writing both PLACES and EVENTS), the floor is the *minimum* of each table's max timestamp, so neither stream skips data the other hasn't caught up to.
- Adds a real `--force` flag to both `localizer sync` and `localizer fetch` (aliased with fetch's existing `--full`) that bypasses all resume logic and performs a full rebuild on demand.

Design choice: rather than writing `last_synced_at` incrementally per batch, the fix queries the store's actual committed data as the resume floor. This is simpler (no new write-path bookkeeping, no risk of `sync_state` claiming a range was synced when it wasn't) and satisfies the interrupted-first-load, incremental-resync, and force-rebuild acceptance criteria with one mechanism. No plugin's `fetch_records(since=...)` contract changes — all built-in plugins already support it.

## Test plan

- [x] `packages/localizer` full suite: `pytest -n auto` → 382 passed
- [x] Root suite: `pytest -n auto` → 999 passed
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `mypy` clean
- [x] New test: interrupted first-sync (data committed, no `sync_state`) resumes from the newest committed timestamp instead of refetching (`fetch` and `sync`)
- [x] New test: resume floor prefers committed data over a stale/mismatched `sync_state.last_synced_at`
- [x] New test: true first-ever sync (empty store, no state) still passes `since=None`
- [x] New test: `--force` on both `fetch` and `sync` bypasses the resume floor entirely
- [x] New test: `LocalizerStore.get_latest_timestamp` scoping across events/places/content tables and per-source_id

Closes #109