### PR TITLE
fix: infer venue category from Foursquare check-in name when export omits categories

### DIFF
--- a/handoff.md
+++ b/handoff.md
@@ -3,363 +3,555 @@
 ## Plan Status
 status: COMPLETE
 
-PR #125 opened: https://github.com/little-big-data/autobiographer/pull/125 (all 4 subtasks
-APPROVED, full-suite integration gate green — 912 passed root suite, 215 passed localizer suite).
-
 ## Task Overview
 
-**The problem**: local and CI test runs are slow. This plan implements performance strategies
-previously discussed with the user:
+**The bug (issue #93)**: real Foursquare/Swarm exports have an empty `categories` array on
+every venue object — confirmed by reading the export-format handling in
+`packages/localizer/src/localizer/plugins/swarm/loader.py`. This makes `place_type` always `""`
+in `SwarmPlugin.fetch_records()`, which becomes `venue_category` always `""` after
+`core/localizer_frames.py::places_to_swarm_frame()`'s pure rename/passthrough. Downstream,
+`analysis_utils.py`'s `_classify_venue_category()` / `_CATEGORY_RULES` (used by
+`get_dining_soundtrack_data()`, issue #81) and `TRANSIT_CATEGORY_KEYWORDS` (used by
+`get_transit_days()`, issue #83) never match against an all-empty column, so both shipped
+features silently return empty results for every real user, with no error surfaced.
 
-1. **Parallelize both pytest suites with `pytest-xdist`** (`pytest -n auto`) — the root suite
-   (`pyproject.toml`, `testpaths = ["tests"]`, 905 tests, ~587s serial) and the independently
-   configured `packages/localizer/tests/` suite (~278 tests, no pytest config file of its own —
-   it relies on pytest's default rootdir-based discovery).
-2. **Remove the full-suite pytest requirement from the pre-push git hook.** Originally this plan's
-   Subtasks 4-5 were going to build a `tools/scoped_pytest.py` changed-files heuristic and wire it
-   into pre-push instead of the full suite. **That approach was abandoned mid-implementation**: the
-   user explicitly asked to just remove the full-suite pre-push requirement outright ("This is a
-   major hurdle for getting this work done") after the scoped-script approach's own verification
-   runs (full-suite `-n auto` runs required by Subtask 2's acceptance criteria) caused repeated
-   cross-process contention and ~10-12 minute pre-push blocks throughout this session. Subtasks 4
-   and 5 (the scope-computation script and its wiring) were dropped per explicit user decision —
-   see Subtask 4 below (renumbered) for the simpler direct-removal fix that replaced them, and the
-   now-deleted `tests/test_scoped_pytest.py` / `tests/test_pre_push_hook_wiring.py` test-ahead
-   files (written by testers before the pivot, removed since `tools/scoped_pytest.py` will never be
-   built).
+**The fix (Option 2 from the issue, already decided — offline-first, no new dependencies, no
+network calls, per CLAUDE.md Section 3)**: infer a `place_type` string from the venue **name**
+when `categories` is empty, using a keyword-matching heuristic scoped to Swarm/Foursquare naming
+conventions. The synthesized value reuses the exact keyword vocabulary the downstream classifiers
+already recognize (`_CATEGORY_RULES` substrings for dining, `TRANSIT_CATEGORY_KEYWORDS`
+substrings for transit — both read in full during planning, see below), so
+`analysis_utils.py` needs **zero changes**. When no heuristic pattern matches, `place_type`
+stays `""` exactly as it does today — no regression, no forced guess, no crash.
 
-**Investigation findings that shaped this plan**:
+**Design decision — where the heuristic lives (and why)**: in
+`packages/localizer/src/localizer/plugins/swarm/loader.py`, as a new private, pure module-level
+function (`_infer_place_type_from_name(venue_name: str) -> str`) plus a name-pattern rule table,
+called from `fetch_records()` only when `categories` is empty/missing. **Not** in
+`analysis_utils.py`. Rationale: the vocabulary here (airport/station/pizza/cafe-style *name*
+patterns) is Foursquare/Swarm-specific naming convention, not a generic place-classification
+concern — `analysis_utils.py` is shared by every source in the unified places layer (Google
+Location History, etc. — see project memory on the places layer), and adding Swarm-specific name
+heuristics there would be the wrong layer for it. Keeping the fix in the plugin loader also means
+`analysis_utils.py`'s well-tested classifiers require zero changes (smallest possible blast
+radius) and the heuristic is unit-testable in complete isolation from real personal data, using
+the same synthetic-fixture style already established in `packages/localizer/tests/test_swarm_plugin.py`.
+**Assumption flagged**: if a reviewer disagrees and prefers a shared `analysis_utils.py` function
+instead, that changes Subtask 1's file target and Subtask 3's integration-test shape — but the
+rationale above (scope, blast radius, existing test conventions) is the basis for this call.
 
-- **Root-suite isolation hazards, confirmed by reading the files (not inferred from names)**:
-  four test files use a *hardcoded, repo-relative, shared* filesystem path in `unittest.TestCase`
-  `setUp()`/`tearDown()` (or inline), instead of a unique-per-invocation path:
-  - `tests/test_caching.py` (`TestCaching`, 7 tests) — `self.test_dir = "data/test_cache_dir"`,
-    `self.cache_dir = "data/test_cache"`, removed via `shutil.rmtree()` in `tearDown()`.
-  - `tests/test_analysis_utils.py` (`TestAnalysisUtils` class only, 26 of the file's 48 tests —
-    the file's five other test classes, `TestSwarmAnalysisCaches`, `TestGetTransitDays`,
-    `TestSplitTransitListens`, `TestClassifyVenueCategory`, `TestGetDiningSoundtrackData`, are
-    unaffected) — `self.test_csv = "data/test_analysis_utils.csv"`.
-  - `tests/test_record_flythrough.py` (`TestRecordFlythrough`, 9 tests) —
-    `self.test_dir = "data_test_fly"`.
-  - `tests/test_autobiographer.py::test_save_tracks_to_csv` (1 of the file's 16 tests, inline,
-    not in `setUp`/`tearDown`) — `test_filename = "data/test_tracks.csv"`.
+**`core/localizer_frames.py::places_to_swarm_frame()` needs no change** — confirmed by reading
+it: it is a pure column rename/passthrough (`place_type` → `venue_category`), with no
+classification logic of its own. The fix belongs upstream (the plugin loader), not here.
 
-  Under `pytest-xdist`'s default "load" scheduling, individual test *methods* — not whole
-  classes — are distributed across worker processes. Two methods of the same `TestCase` (e.g.
-  `test_cache_key_consistency` and `test_save_and_load_cache`) can land on different workers and
-  race on the identical hardcoded path. **RESOLVED — Subtask 1, APPROVED.**
-- **The localizer suite has no equivalent hazard.** Every file under `packages/localizer/tests/`
-  that touches disk uses pytest's `tmp_path` fixture exclusively — confirmed by reading all
-  disk-touching call sites. No isolation-fix subtask is needed for this suite.
-- **`packages/localizer` has no pytest config of its own** — it relies on pytest's default rootdir
-  discovery when invoked from within that directory. This plan does not add one; it only adds the
-  `pytest-xdist` dev dependency and documents `pytest -n auto` as the local command.
-- **Pre-existing, known, out-of-scope gap** (do not fix here, but do not worsen it either):
-  `.github/workflows/ci.yml`'s `quality` job never runs `packages/localizer/tests` at all. Subtask 3
-  explicitly does not add a new CI job for that suite.
-- **Design decision — do not bake `-n auto` into `[tool.pytest.ini_options] addopts`.** Forcing
-  every bare `pytest` invocation (IDE test runners, `--pdb` debugging) into parallel mode is worse
-  for day-to-day debugging. `-n auto` is added explicitly at specific call sites instead (CI's
-  workflow step, `CLAUDE.md`'s documented manual command). Bare `pytest` stays serial by default.
-- **Cross-process contention discovered during this session's own execution (operational lesson,
-  not a code defect)**: multiple concurrent worktrees/agents running full-suite `pytest -n auto`
-  verification simultaneously in the same physical directory caused spurious `WinError 32`
-  (`PermissionError`) failures — e.g. a stray leftover background process from an earlier coder
-  attempt on Subtask 2 collided with a fresh verification run in the same worktree. This was
-  diagnosed as cross-process file contention (shared `.coverage` files, pytest cache, and
-  possibly `~/.streamlit/` user-global config), not a genuine intra-run xdist isolation bug in the
-  test suite itself. Lesson applied going forward: don't run concurrent full-suite verification
-  passes in the same physical worktree directory.
-- **Risk-domain note**: this plan does not implement custom concurrency-limiting code — enabling
-  `pytest-xdist` delegates worker-pool management to that well-tested third-party library. The
-  analogous real risk — test *isolation* under xdist's parallel workers — is what Subtasks 1 and 2's
-  Acceptance Criteria and Test Guidance are built around.
+**Cache files need no new invalidation logic** — confirmed by reading `pages/data_sources.py`
+(~lines 284-399): `swarm_transit_days.json` (`TRANSIT_DAYS_CACHE`) and `swarm_dining.json`
+(`DINING_CACHE`) are only written when the user clicks "Build Swarm Analysis Cache", which calls
+`get_transit_days(swarm_df)` / `get_dining_soundtrack_data(swarm_df, df)` fresh from the
+currently-loaded DataFrames every time. There is no staleness-detection or diffing logic to
+update — once the heuristic populates non-empty `venue_category` values, the very next cache
+rebuild naturally picks up correct results. No cache-invalidation subtask is included.
 
-**PR grouping rationale**: originally two PR groups; simplified to a single PR group
-`pytest-xdist-parallelization` (Subtasks 1-3) plus a small standalone fix (Subtask 4, the direct
-pre-push removal) folded into the same PR since it's a trivial, already-verified config change with
-no meaningful risk of conflicting with Subtasks 1-3's file set (only `.pre-commit-config.yaml` is
-unique to Subtask 4; its `CLAUDE.md` edit is a different paragraph/section than Subtask 2's).
+**Confirmed scope boundary**: `SwarmPlugin` lives only under `packages/localizer/` (the active
+plugin system per project memory on the two-plugin-system migration). Nothing under the legacy
+`plugins/sources/` tree is touched by this plan.
+
+**Shared-source-file note**: Subtasks 1 and 2 both touch `loader.py` (Subtask 1 adds the pure
+heuristic function; Subtask 2 wires it into `fetch_records()`). This is safe because `current:`
+ordering is strictly sequential (Subtask 1 completes — reaches `APPROVED` — before Subtask 2's
+coder phase starts) and Subtask 2 declares `Depends On: 1`, so there is never a concurrent writer
+of `loader.py`. Test files are kept fully disjoint per subtask (see Files to Touch below) so the
+parallel test-ahead batch never has two testers writing the same file.
+
+**Full `_CATEGORY_RULES` list** (from `analysis_utils.py`, lines 1591-1631 — 37 rules mapping a
+lowercase substring to one of 4 buckets): `fast food`, `burger`, `pizza`, `fried chicken`,
+`hot dog`, `sandwich` → Fast Food; `bar`, `nightclub`, `pub`, `brewery`, `wine`, `cocktail`,
+`lounge`, `club` → Bars & Nightlife; `cafe`, `café`, `coffee`, `tea room`, `bakery`, `dessert`,
+`ice cream`, `juice bar` → Cafes; `restaurant`, `diner`, `food`, `sushi`, `ramen`, `noodle`,
+`steakhouse`, `bbq`, `seafood`, `bistro`, `brasserie`, `tapas`, `dim sum`, `buffet`, `grill`,
+`kitchen`, `eatery` → Restaurants.
+
+**Full `TRANSIT_CATEGORY_KEYWORDS` list** (from `analysis_utils.py`, lines 1498-1516 — matched
+case-insensitively via `.str.contains`): `Airport`, `Train Station`, `Transit`, `Bus Station`,
+`Metro`, `Subway`, `Ferry`, `Port`, `Rail`, `Rest Area`, `Rest Stop`, `Travel Plaza`,
+`Service Plaza`, `Turnpike`, `Toll`, `Gas Station`, `Truck Stop`.
+
+**Non-overlap constraint for the new name-heuristic rule table (Subtask 1)**: every synthesized
+`place_type` value must contain at least one of the two lists above (so the existing classifiers
+fire unchanged), and the coder must avoid overly broad name-substring rules that would produce
+false positives — e.g. do **not** add a bare `"port"` name-pattern rule (would false-positive on
+venue names like "Portland" or "Import Foods"); do **not** add a bare `"club"` name-pattern rule
+without disambiguating from generic use. Prefer specific, low-collision name substrings (e.g.
+`"airport"`, `"pizza"`, `"metro station"`, `"train station"`, `"coffee"`) over generic ones.
+
+**Privacy constraint (CLAUDE.md Section 3)**: no real personal venue names anywhere in code or
+tests. All test fixtures use clearly synthetic/generic names (e.g. "O'Hare International
+Airport", "Joe's Pizza Place", "Downtown Metro Station", "Generic City Museum").
 
 **Architecture context**: no prior `/feature-dev` or `/plan-feature` run occurred for this task.
-This plan is investigation-driven, verified against the actual repo state (file reads and greps,
-not assumptions from filenames). Subtasks 4-5 (the original scoped-pre-push-hook design) were
-descoped mid-execution per explicit user direction; this file was manually restructured by the
-orchestrator to reflect that decision rather than re-running the full planner/reviewer pipeline,
-since the user explicitly asked to reduce process overhead for this category of change.
+This plan is investigation-driven — every claim above was verified by reading the actual files
+(`loader.py`, `localizer_frames.py`, `analysis_utils.py`, `pages/data_sources.py`,
+`test_swarm_plugin.py`, `test_analysis_utils.py`), not inferred from the issue text alone.
 
-Plan Review: APPROVED (original 5-subtask version). The plan was subsequently restructured (see
-above) after Subtasks 4-5 were dropped by explicit user decision mid-execution — the surviving
-Subtasks 1-3 were unaffected by this change and retain their original approval basis (falsifiable
-acceptance criteria, valid dependency ordering, disjoint test files, concrete Test Guidance edge
-cases, as re-verified by the reviewer agent in an earlier pass of this file).
+Plan Review: APPROVED — the three subtasks (name-heuristic function, fetch_records() wiring, end-to-end integration test + docs) have disjoint test files, a valid acyclic dependency chain (1 → 2 → {1,2}) matching the `current:` topological order, sufficient falsifiable acceptance criteria and test guidance including the new empty-categories/empty-name edge case in Subtask 2, and the shared `loader.py` source-file edit across Subtasks 1–2 is safe under this workflow's strictly-sequential (non-Phase-2) coder/reviewer/owner execution.
 
 ## Current Subtask
-current: 4
+current: 3
 
 ---
 
 ## Subtasks
 
-### Subtask 1 — Fix hardcoded shared-path test fixtures (root-suite isolation)
+### Subtask 1 — Add name-based venue-category heuristic function
 
 **Status**: APPROVED
 
-**PR Group**: pytest-xdist-parallelization
+**PR Group**: venue-category-heuristics
 
 **Depends On**: none
 
 **Description**:
-Convert the four hardcoded, repo-relative, shared filesystem paths used as test fixtures in the
-root suite into unique-per-invocation paths, so they are safe under `pytest-xdist`'s parallel
-worker scheduling, using `tempfile`-based uniqueness (not a `tmp_path`/pytest-style rewrite).
+Add a new private, pure function `_infer_place_type_from_name(venue_name: str) -> str` to
+`packages/localizer/src/localizer/plugins/swarm/loader.py`, plus a name-pattern rule table (e.g.
+`_NAME_HEURISTIC_RULES: list[tuple[str, str]]`, mirroring the `(substring, result)` list style
+already used by `analysis_utils._CATEGORY_RULES`). The function lower-cases `venue_name` and
+checks it against the rule table in order, returning the first matching rule's synthesized
+`place_type` string. Each synthesized value must contain at least one substring from the full
+`_CATEGORY_RULES` list or the full `TRANSIT_CATEGORY_KEYWORDS` list quoted in the Task Overview,
+so the existing downstream classifiers recognize it unchanged. Returns `""` when no pattern
+matches (never `None`, never raises). This subtask does not wire the function into
+`fetch_records()` yet — that is Subtask 2. No changes to `analysis_utils.py`.
+
+**Acceptance Criteria**:
+- [ ] `_infer_place_type_from_name("O'Hare International Airport")` returns a string containing
+  `"Airport"` (case-sensitive match against `TRANSIT_CATEGORY_KEYWORDS`).
+- [ ] `_infer_place_type_from_name("Downtown Metro Station")` returns a string containing one of
+  the transit keywords (e.g. `"Metro"`).
+- [ ] `_infer_place_type_from_name("Joe's Pizza Place")` returns a string whose lowercased form
+  contains `"pizza"` (matches `_CATEGORY_RULES`).
+- [ ] `_infer_place_type_from_name("Downtown Coffee Roasters")` returns a string whose lowercased
+  form contains `"coffee"`.
+- [ ] `_infer_place_type_from_name("Generic City Museum")` (no pattern matches) returns exactly
+  `""`, not `None`, and does not raise.
+- [ ] Matching is case-insensitive on the input venue name (e.g. `"downtown metro station"` in
+  all-lowercase still matches) and does not crash on an empty string or a name containing only
+  punctuation/whitespace.
 
 **Files to Touch**:
-- `tests/test_caching.py`
-- `tests/test_analysis_utils.py`
-- `tests/test_record_flythrough.py`
-- `tests/test_autobiographer.py`
-- `tests/test_visualize.py` (added post-approval — see addendum below)
+- `packages/localizer/src/localizer/plugins/swarm/loader.py`
+- `packages/localizer/tests/test_swarm_plugin.py`
 
-**Implementation summary**: Replaced all four hardcoded paths with `tempfile.mkdtemp()`/
-`tempfile.mkstemp()`-generated unique-per-invocation paths in `setUp()`/inline fixture
-construction only — no assertion logic changed. Verified: 84 passed (scoped 4-file run, twice
-back-to-back, identical counts, no leftover fixture files); zero matches for the four original
-hardcoded literals; `pytest -n 4` on the four files five times in a row — 84 passed, 0 failed every
-time (the actual regression proof). Code Review: APPROVED. Owner review: APPROVED.
+**Test Guidance**:
+- Cover at least one representative name per downstream bucket that must remain reachable:
+  an airport-style name, a train/metro-station-style name, a pizza-style name, a coffee/cafe-style
+  name, a bar/pub-style name, and a restaurant-style name — assert each produces a value
+  containing the expected keyword substring from the lists in the Task Overview.
+- Cover the explicit no-match fallback: a generic, non-food/non-transit venue name (e.g. "Generic
+  City Museum", "Downtown Art Gallery") must return exactly `""`.
+- Cover false-positive risk: a venue name that superficially resembles a risky substring but
+  should NOT match transit (e.g. "Portland Pizza Co." should classify as pizza/dining via the
+  `"pizza"` rule, not accidentally trip a transit `"port"`-style rule — this also verifies the
+  rule table has no bare `"port"` rule per the Task Overview's non-overlap constraint).
+- Cover case-insensitivity (mixed-case and all-lowercase venue names) and empty-string / purely
+  punctuation input (must return `""`, must not raise).
+- Use only synthetic/generic venue names — no real personal data, per CLAUDE.md Section 3.
 
-**Addendum (found during the PR-group full-suite integration gate, fixed directly by the
-orchestrator)**: `tests/test_visualize.py::TestVisualize` had a fifth hardcoded shared path
-(`self.test_dir = "data_test"`) that the original planner investigation missed — a different
-literal string than the four already fixed, in a file the investigation didn't inspect. Confirmed
-genuine (not cross-process contention) by running the full-suite gate in a verified-uncontested
-worktree (zero stray processes checked via `Get-CimInstance` beforehand) and getting
-`OSError: Cannot save file into a non-existent directory: 'data_test'` on
-`test_render_overview_with_swarm_data` — a race where one xdist worker's `tearDown()` deleted the
-shared directory while another worker's test was still using it, same hazard class as the other
-four files. Fixed identically: `self.test_dir = tempfile.mkdtemp(prefix="visualize_test_")`,
-dropped the now-redundant `os.makedirs(..., exist_ok=True)`. Verified: `pytest tests/test_visualize.py
--n 4` four times in a row — 37 passed, 0 failed every time. `ruff check`/`ruff format --check` clean.
-Treated as a trivial, obvious, same-pattern fix per this repo's AGENTS.md trivial-change carve-out —
-no new tester/coder/reviewer/owner cycle spawned.
+**Test Files**:
+- `packages/localizer/tests/test_swarm_plugin.py` — 16 tests appended (all targeting
+  `localizer.plugins.swarm.loader._infer_place_type_from_name`): airport, train/metro station,
+  pizza, coffee, bar/pub, restaurant matches; no-match fallback (parametrized: "Generic City
+  Museum", "Downtown Art Gallery"); false-positive guard ("Portland Pizza Co." must not trip a
+  bare transit "port" rule); case-insensitivity (lowercase and mixed-case); empty-string and
+  punctuation-only input (parametrized: "   ", "!!!", "...,", "---"). RED-confirmed: 0 passed, 16
+  failed, all via `ImportError: cannot import name '_infer_place_type_from_name'` (function does
+  not exist yet — genuine RED, not a vacuous test).
+
+**Implementation Notes**:
+Added `_NAME_HEURISTIC_RULES: list[tuple[str, str]]` (ordered `(lowercase substring,
+synthesized place_type)` pairs) and `_infer_place_type_from_name(venue_name: str) -> str` to
+`packages/localizer/src/localizer/plugins/swarm/loader.py`, placed above the `@register`
+decorator on `SwarmPlugin`. The function returns `""` immediately for a falsy `venue_name`,
+otherwise lower-cases it and returns the first matching rule's synthesized value, else `""`.
+
+Rule table covers the transit bucket (`airport`, `train station`, `metro station`, `subway
+station`, `bus station`, `ferry terminal`, `rail station`, `gas station`, `truck stop`, `rest
+area`, `rest stop`, `travel plaza`, `service plaza`, `turnpike`, `toll plaza`) and the dining/
+nightlife buckets from `_CATEGORY_RULES` (fast food, bars, cafes, restaurants — e.g. `pizza`,
+`coffee`, `pub`, `restaurant`, `bbq`, `sushi`, etc.). Per the Task Overview's non-overlap
+constraint, deliberately omitted a bare `"port"` rule and a bare `"club"` rule; used
+`"nightclub"` (not bare `"club"`) and no transit rule uses `"port"` as a standalone substring,
+so `"Portland Pizza Co."` correctly falls through to the `"pizza"` rule only.
+
+No changes to `analysis_utils.py`; `fetch_records()` wiring is untouched (Subtask 2). Did not
+modify `test_swarm_plugin.py` — its 16 pre-written tests were used as-is.
+
+**Environment note (not a repo file change)**: the venv's editable install of `localizer`
+(`venv/Lib/site-packages/__editable__.localizer-0.1.0.pth`) was pointing at a stale worktree
+copy (`.claude/worktrees/agent-a23c5b3a17bb523c4/packages/localizer/src`) left over from a
+prior agent session, so tests were initially importing that stale `loader.py` instead of this
+repo's copy (masking the fix as 16 ImportErrors). Fixed by re-running
+`pip install -e packages/localizer/ --no-deps` from the repo root, which repointed the `.pth`
+file at `C:\Users\johns\Code\autobiographer\packages\localizer\src`. No source files were
+changed by this step; flagging in case future agents hit the same stale-worktree symptom.
+
+**Verification**:
+- `ruff check --fix packages/localizer/src/localizer/plugins/swarm/loader.py` → "No issues found"
+- `ruff format packages/localizer/src/localizer/plugins/swarm/loader.py` → "All files formatted correctly"
+- `pytest packages/localizer/tests/test_swarm_plugin.py -v --no-cov` → 34 passed (16 new +
+  18 pre-existing, confirming no regression)
+- `mypy packages/localizer/src/localizer/plugins/swarm/loader.py` → "No issues found"
+
+**Review Notes**:
+Code Review: APPROVED — checks clean. `ruff check` and `ruff format --check` on loader.py both
+clean; `mypy` clean; `pytest packages/localizer/tests/test_swarm_plugin.py -v --no-cov` → 34
+passed (18 pre-existing + 16 new, no regressions, none skipped/xfailed). Verified all 16 new
+tests genuinely exercise `_infer_place_type_from_name` (import + call + assert on the real
+return value, not vacuous). Confirmed the non-overlap constraint holds in the actual rule table:
+no bare `"port"` rule (transit rules use `"gas station"`, `"toll plaza"`, etc., never a standalone
+`"port"` substring) and no bare `"club"` rule (`"nightclub"` only) — traced `"Portland Pizza
+Co."` through the rule list by hand and confirmed it falls through all transit rules and matches
+only `"pizza"`. Cross-checked every synthesized value against `_CATEGORY_RULES` /
+`TRANSIT_CATEGORY_KEYWORDS` and confirmed each contains a recognized substring (matching is
+case-insensitive downstream via `.lower()` / `case=False`, so the capitalized synthesized values
+work correctly). Confirmed `fetch_records()` is untouched — the function is added but not yet
+wired in, correctly scoped to Subtask 2.
+
+Owner: APPROVED — independently re-ran the gate: `ruff check` on loader.py + test_swarm_plugin.py
+→ "All checks passed!"; `pytest packages/localizer/tests/test_swarm_plugin.py -q --no-cov` → 34
+passed; `mypy packages/localizer/src/localizer/plugins/swarm/loader.py` → "Success: no issues
+found". Read the full function, rule table, and all 16 tests. Traced `"Portland Pizza Co."` by
+hand: lower-cased, no transit rule matches (no bare `"port"` rule present), falls through to the
+`"pizza"` rule → returns `"Pizza"` — non-overlap constraint holds. Every Test Guidance item
+(airport, train/metro station, pizza, coffee, bar/pub, restaurant, no-match fallback, false-positive
+port/pizza guard, case-insensitivity, empty-string, punctuation-only) has a corresponding test.
+Confirmed `fetch_records()` (lines 267-271) is untouched, correctly scoping the wiring to Subtask 2.
+Function is pure, typed, Google-style docstring, PEP 8-compliant, uses only synthetic venue names —
+no personal data. Simplest implementation that satisfies the contract; no dead code or premature
+abstraction. Deliberate omissions of generic substrings (bare `"bar"`, `"food"`, `"wine"`, `"dessert"`)
+are sound anti-false-positive choices, not gaps — plan only required representative bucket coverage.
+No issues found.
 
 ---
 
-### Subtask 2 — Enable `pytest-xdist` for the root suite and CI
+### Subtask 2 — Wire the heuristic into `SwarmPlugin.fetch_records()`
 
 **Status**: APPROVED
 
-**PR Group**: pytest-xdist-parallelization
+**PR Group**: venue-category-heuristics
 
 **Depends On**: 1
 
 **Description**:
-With Subtask 1's isolation fixes landed, add `pytest-xdist` as a declared dev dependency for the
-root suite and wire `-n auto` into CI and local-gate documentation. Specifically:
-- Add `"pytest-xdist>=3.5"` to root `pyproject.toml`'s `[project.optional-dependencies] dev` list
-  and to `requirements.txt`.
-- Update `.github/workflows/ci.yml`'s `quality` job "Tests and coverage" step from `pytest` to
-  `pytest -n auto`.
-- Update `CLAUDE.md`'s "Local Quality Gate" Step 2 pytest invocation to `pytest -n auto`.
-- Do not add `-n auto` to `[tool.pytest.ini_options] addopts` in `pyproject.toml`.
+In `fetch_records()` (`packages/localizer/src/localizer/plugins/swarm/loader.py`, ~lines
+165-169), call `_infer_place_type_from_name(place_name)` **only** when `venue.get("categories")`
+is empty/missing, and use its result as `place_type`. When `categories` is non-empty, behavior is
+completely unchanged (`place_type = categories[0].get("name", "")`, exactly as today) — this is a
+strict additive fallback, not a replacement of existing category-derived classification.
 
 **Acceptance Criteria**:
-- [ ] `"pytest-xdist"` (pinned `>=3.5`) appears in root `pyproject.toml`'s `dev` optional
-  dependencies and in `requirements.txt`.
-- [ ] `.github/workflows/ci.yml`'s "Tests and coverage" step's `run:` line is exactly
-  `pytest -n auto` (not bare `pytest`).
-- [ ] Running `pytest -n auto` (full root suite, no path filter) exits 0, in an **uncontested**
-  worktree (no other concurrent full-suite pytest process in the same directory — see the Task
-  Overview's cross-process-contention lesson), with a pass count matching a serial `pytest` run's
-  pass count.
-- [ ] `CLAUDE.md`'s "Local Quality Gate" Step 2 documents `pytest -n auto` as the pytest
-  invocation; `[tool.pytest.ini_options] addopts` in `pyproject.toml` is unchanged.
+- [ ] A venue with a non-empty `categories` array behaves exactly as before (existing test
+  `test_fetch_records_place_type_from_category` continues to pass unchanged — no regression).
+- [ ] A venue with `categories: []` (or the key missing) and a heuristic-matching `name` (e.g.
+  "O'Hare International Airport") yields a record whose `place_type` is non-empty and contains
+  the expected keyword.
+- [ ] A venue with `categories: []` and a non-matching `name` (e.g. "Generic City Museum") yields
+  a record whose `place_type` is exactly `""` — identical to current (pre-fix) behavior, proving
+  no regression for the no-match case.
+- [ ] The fallback applies identically regardless of which documented export wrapper format the
+  file uses (`{"items": [...]}` vs `{"checkins": {"items": [...]}}` vs bare list) — the loader
+  already normalizes to a single `items` iteration before per-checkin processing, so this proves
+  the fallback isn't wrapper-format-dependent.
 
 **Files to Touch**:
-- `pyproject.toml`
-- `requirements.txt`
-- `.github/workflows/ci.yml`
-- `CLAUDE.md`
-- `tests/test_pytest_xdist_config.py` (new — small config-drift regression guard)
+- `packages/localizer/src/localizer/plugins/swarm/loader.py`
+- `packages/localizer/tests/test_swarm_plugin_heuristic_wiring.py` (new — kept disjoint from
+  Subtask 1's `test_swarm_plugin.py` so the parallel test-ahead batch has no shared-file writer
+  conflict; this file imports and reuses the existing `_make_checkin()` / `_write_checkins_json()`
+  helpers from `test_swarm_plugin.py` rather than duplicating them)
 
-**Implementation status (as of this restructuring)**: All file edits already made by a prior coder
-pass and independently verified by the orchestrator directly (bypassing an unresponsive coder agent
-— see below): `pyproject.toml`/`requirements.txt`/`ci.yml`/`CLAUDE.md` diffs all correct and match
-the Description. `tests/test_pytest_xdist_config.py`'s 3 tests pass (orchestrator-verified directly
-via `rtk proxy python -m pytest tests/test_pytest_xdist_config.py` — 3 passed). **Still needed**: one
-clean, uncontested full-suite `pytest -n auto` run to close out AC #3 (the previous attempt hit a
-`WinError 32` caused by cross-process contention with a stale leftover process from an earlier coder
-attempt, now killed; that verification run was itself then killed as part of an unrelated safety
-intervention and needs to be re-run cleanly).
-
-**Test Files**:
-- `tests/test_pytest_xdist_config.py` — `test_pytest_xdist_is_declared_in_root_dev_dependencies`,
-  `test_ci_workflow_runs_tests_with_xdist_auto_flag`, `test_ci_workflow_raw_text_contains_xdist_auto_flag`
-
-**Implementation Notes**:
-Final clean, uncontested verification run (`rtk proxy python -m pytest -n auto -p no:cacheprovider -q`,
-no other pytest process running in this worktree — confirmed via `Get-CimInstance Win32_Process`
-before starting): **912 passed, 0 failed**, exit 0, in 495.73s (0:08:15) wall time. Coverage:
-72.16% aggregate (above the 70% `--cov-fail-under` threshold, combined correctly across xdist
-workers via pytest-cov's xdist integration — not a suspiciously low single-worker slice). This
-confirms the earlier `WinError 32` failure was genuinely cross-process contention (a stale leftover
-process from an earlier coder attempt running concurrently in the same directory), not a real
-xdist isolation defect in `test_visualize.py` or elsewhere — resolved by ensuring only one
-full-suite process runs per worktree at a time.
-
-**Review Notes**: Approved directly by the orchestrator per the same reduced-process-overhead
-rationale as Subtask 4 — the file edits were independently read and verified line-by-line against
-the Description (not just diffed), the 3 config-drift tests were run directly, and the full-suite
-run above provides the acceptance-criteria proof. No separate reviewer/owner agent spawned.
-
----
-
-### Subtask 3 — Enable `pytest-xdist` for the `packages/localizer` suite
-
-**Status**: APPROVED
-
-**PR Group**: pytest-xdist-parallelization
-
-**Depends On**: none
-
-**Description**:
-Add `pytest-xdist` as a dev dependency for the `packages/localizer` sub-package and document
-`pytest -n auto` as the local test command for that suite. No isolation fixes needed (already
-`tmp_path`-clean). Do not add a new CI job for this suite (pre-existing, out-of-scope gap).
-
-**Acceptance Criteria**:
-- [ ] `"pytest-xdist"` (pinned `>=3.5`) appears in `packages/localizer/pyproject.toml`'s
-  `[project.optional-dependencies] dev` list.
-- [ ] Running `pytest -n auto` from within `packages/localizer/` exits 0, matching a serial run's
-  pass count.
-- [ ] `packages/localizer/README.md` documents `pytest -n auto` as the fast local test command.
-- [ ] `.github/workflows/ci.yml` has zero diff from this subtask.
-
-**Files to Touch**:
-- `packages/localizer/pyproject.toml`
-- `packages/localizer/README.md`
-- `packages/localizer/tests/test_dev_dependencies.py` (new — small config-drift regression guard)
+**Test Guidance**:
+- Import/reuse the existing `_make_checkin()` / `_write_checkins_json()` helpers from
+  `test_swarm_plugin.py`; extend `_make_checkin()` (or add a sibling helper, defined in the new
+  file if the shared helper's signature can't be changed without touching Subtask 1's file) to
+  support constructing a checkin with an empty `categories` list, since the current helper always
+  populates one category.
+- Explicitly re-run/keep the existing category-present tests (e.g.
+  `test_fetch_records_place_type_from_category` in `test_swarm_plugin.py`) untouched to prove no
+  regression — do not weaken or delete them.
+- Add a case where `categories` key is entirely absent from the venue dict (not just an empty
+  list), matching real-world export variance.
+- Add at least one case per wrapper format (`{"items": [...]}`, `{"checkins": {"items": [...]}}`)
+  with an empty-categories, heuristic-eligible venue, to prove the fallback is wrapper-agnostic.
+- Add the combined edge case of empty/missing `categories` **and** an empty (or purely
+  punctuation) venue `name` at the `fetch_records()` integration level — assert the resulting
+  `place_type` is exactly `""` and `fetch_records()` does not raise (Subtask 1 already covers
+  empty-string input at the unit level directly against `_infer_place_type_from_name`; this proves
+  the same guarantee holds through the full wiring).
+- All venue names must be synthetic/generic, per CLAUDE.md Section 3.
 
 **Test Files**:
-- `packages/localizer/tests/test_dev_dependencies.py` — `test_pyproject_toml_is_readable`,
-  `test_dev_dependencies_contains_known_packages`, `test_pytest_xdist_declared_in_dev_dependencies`
-  (RED-confirmed: 2 passed, 1 failed as expected — `pytest-xdist` not yet declared)
+- `packages/localizer/tests/test_swarm_plugin_heuristic_wiring.py` (new, disjoint from Subtask
+  1's file — confirmed via `pytest --collect-only` across both swarm test files: 44 tests
+  collected, no conflicts) — 10 tests: empty-categories heuristic match (airport), missing-key
+  variant (pizza), both wrapper formats (`{"items": [...]}` and `{"checkins": {"items": [...]}}`)
+  with empty-categories heuristic-eligible venues, wiring-contract tests asserting
+  `_infer_place_type_from_name` is actually called when categories is empty/missing (mocked with
+  `create=True` so this file has no hard dependency on Subtask 1's function existing yet), a
+  no-match-flows-through-as-empty-string case, and 3 parametrized combined-edge-case tests (empty
+  categories + blank/whitespace/punctuation-only name must not raise). Note: AC1 (non-empty
+  categories unchanged) is deliberately not re-tested here — already covered by the pre-existing
+  `test_fetch_records_place_type_from_category` in `test_swarm_plugin.py`, which the coder must
+  keep passing unmodified. RED-confirmed: 10 failed, 0 passed, 0 errored (clean AssertionErrors,
+  no import errors).
 
 **Implementation Notes**:
-Added `"pytest-xdist>=3.5"` to `packages/localizer/pyproject.toml`'s `[project.optional-dependencies]
-dev` list (alongside existing `pytest`, `pytest-cov`, `responses`, `ruff`, `mypy`). Documented
-`pytest -n auto` in `packages/localizer/README.md`'s "Installation" section (added a short "run the
-test suite" block right after the `pip install -e packages/localizer/` instructions, before
-"Quickstart"), including the `pip install -e "packages/localizer/[dev]"` extras step and a serial
-`pytest` fallback for `--pdb` debugging. Did not touch `.github/workflows/ci.yml` (confirmed via
-`git diff --stat` — the only diff present there is Subtask 2's pre-existing `pytest` →
-`pytest -n auto` change, not introduced by this subtask).
+In `fetch_records()` (`packages/localizer/src/localizer/plugins/swarm/loader.py`), replaced the
+always-`""` fallback with a call to `_infer_place_type_from_name(place_name)`, invoked only in the
+`else` branch of `if categories: ... else: ...` (i.e. only when `venue.get("categories")` is
+empty or missing). When `categories` is non-empty, the line
+`place_type = categories[0].get("name", "")` is byte-for-byte unchanged from before — same branch,
+same expression, just now paired with an `else` instead of leaving `place_type` at a pre-set `""`.
+No other lines in `fetch_records()` were touched (wrapper-format normalization, timestamp
+handling, lat/lng handling all untouched), so the wrapper-agnostic behavior required by AC4 falls
+out for free — the heuristic call sits after per-checkin normalization is already complete.
 
-`pytest-xdist` (3.8.0) was already installed in the venv from Subtask 2's install, confirmed via
-`pip show pytest-xdist`.
+No changes needed to `_infer_place_type_from_name()` or `_NAME_HEURISTIC_RULES` themselves
+(Subtask 1's code was used as-is). No files beyond the two listed in Files to Touch were touched.
 
-Verified (uncontested worktree, confirmed via `Get-CimInstance Win32_Process` before and after —
-no other pytest process running in this directory at any point):
-- `packages/localizer/tests/test_dev_dependencies.py`'s 3 tests: **3 passed** (0.35s), run from
-  within `packages/localizer/`.
-- Full localizer suite, serial (`pytest -q`, default config incl. root `pyproject.toml`'s
-  `--cov=. --cov-fail-under=70`, discovered via rootdir walk-up since `packages/localizer` has no
-  pytest ini section of its own): **215 passed**, exit 0, coverage 88.39%, 68.21s.
-- Full localizer suite, parallel (`pytest -n auto -q`, same default config): **215 passed**, exit 0,
-  coverage 88.39% (correctly aggregated across xdist workers), 58.99s — identical pass count and
-  coverage to the serial run, confirming AC #2.
-- `ruff check` and `ruff format --check` on the new test file: both clean.
-
-Note: running only the single scoped file `test_dev_dependencies.py` in isolation (without `-n
-auto`, without `--no-cov`) fails the 70%-coverage gate (2 passed, 1 collected file's low intrinsic
-coverage) — this is expected/pre-existing behavior of the shared coverage threshold applying to any
-subset run, not a defect; the full-suite runs above (which are what AC #2 actually asks for) pass
-cleanly at 88.39%.
+**Verification**:
+- `ruff check --fix packages/localizer/src/localizer/plugins/swarm/loader.py` → "No issues found"
+- `ruff format packages/localizer/src/localizer/plugins/swarm/loader.py` → "All files formatted
+  correctly"
+- `pytest packages/localizer/tests/test_swarm_plugin_heuristic_wiring.py
+  packages/localizer/tests/test_swarm_plugin.py -v --no-cov` → 44 passed (10 new wiring tests +
+  34 pre-existing from Subtask 1, including `test_fetch_records_place_type_from_category`
+  unmodified and passing — confirms AC1's no-regression requirement)
+- `mypy packages/localizer/src/localizer/plugins/swarm/loader.py` → "No issues found"
 
 **Review Notes**:
-(filled by owner agent)
+Code Review: APPROVED — checks clean. `ruff check` on loader.py → "No issues found"; `ruff format
+--check` → "1 file already formatted"; `mypy` → "No issues found". Ran
+`pytest packages/localizer/tests/test_swarm_plugin_heuristic_wiring.py
+packages/localizer/tests/test_swarm_plugin.py -v --no-cov` → 44 passed, 0 failed — confirmed
+`test_fetch_records_place_type_from_category` passed unmodified (AC1, no regression). Read the
+full diff: in `fetch_records()` the non-empty-categories branch
+(`place_type = categories[0].get("name", "")`) is byte-for-byte unchanged, only now paired with an
+`else: place_type = _infer_place_type_from_name(place_name)` — confirms the heuristic is called
+only when `categories` is empty/missing, with `place_name` as the sole argument (verified directly
+and via the mock-based wiring-contract tests asserting `mock_infer.assert_called_once_with(...)`).
+Verified all 4 ACs against the diff, not just test mocking: AC1 (unchanged branch, passing
+pre-existing test), AC2 (real end-to-end test with "O'Hare International Airport" yields
+non-empty place_type containing "Airport"), AC3 (mocked-return-"" test proves fetch_records
+surfaces "" via the real call path, combined with Subtask 1's own coverage that the real function
+returns "" for non-matching names), AC4 (separate tests for both `{"items": [...]}` and
+`{"checkins": {"items": [...]}}` wrapper formats, both passing, proving the fallback sits after
+wrapper normalization). Reviewed the new test file for vacuousness — none found; mocks use
+`create=True` deliberately per Subtask 1/2 dependency ordering, not to hide missing coverage. No
+dead code, no secrets/credentials, no N+1/hot-path concerns (pure local JSON parsing). Confirmed
+`test_swarm_plugin.py` diff (lines 329+) is purely additive (Subtask 1's tests), no existing test
+bodies modified. No issues found.
 
-Code Review: APPROVED — checks clean. Verified: `git diff --stat` confirms only
-`packages/localizer/pyproject.toml`, `packages/localizer/README.md`, `handoff.md`, and the new
-`packages/localizer/tests/test_dev_dependencies.py` / `tests/test_pytest_xdist_config.py` (Subtask
-2, pre-existing) changed; `.github/workflows/ci.yml`'s diff is exactly Subtask 2's `pytest` →
-`pytest -n auto` line, zero diff attributable to this subtask. No stray pytest process was running
-in this worktree before testing (confirmed via `Get-CimInstance Win32_Process`). `ruff check` /
-`ruff format --check` clean on the new test file. `test_dev_dependencies.py`'s 3 tests pass in
-isolation (0.03s, `--no-cov`) — note a bare `rtk proxy`-less invocation misreported this as "No
-tests collected" due to the pre-existing/expected single-file coverage-gate exit(1) described in
-the coder's own Implementation Notes; `rtk proxy` invocation showed the true result (3 collected, 3
-passed). Full localizer suite under `-n auto`: **215 passed**, 60.57s, 88.39% coverage — corroborates
-the coder's reported 215 passed / 58.99s / 88.39%. `pyproject.toml` diff confirms
-`"pytest-xdist>=3.5"` landed in `[project.optional-dependencies].dev`, not runtime `dependencies`.
-`README.md` diff is a clean, well-placed addition (right after the install instructions, before
-Quickstart, includes a serial `--pdb` fallback) — no duplication.
-
-Owner review: APPROVED. Independently re-verified the diffs (`git diff -- packages/localizer/pyproject.toml
-packages/localizer/README.md pyproject.toml requirements.txt`): the `pytest-xdist>=3.5` pin in
-`packages/localizer/pyproject.toml` matches Subtask 2's root-suite pin exactly, placed sensibly
-alongside the other pytest-family dev deps (not alphabetical, but consistent with the file's
-existing thematic grouping). `README.md` addition is minimal, correctly placed between the install
-instructions and Quickstart, and not duplicative of anything elsewhere in the file. Confirmed
-`.github/workflows/ci.yml`'s diff is exactly Subtask 2's 1-line change, zero diff attributable to
-this subtask. `test_dev_dependencies.py` exercises real parsed TOML state (observable behavior),
-not implementation details. No issues found.
+Owner: APPROVED — independently re-ran the gate: `pytest packages/localizer/tests/test_swarm_plugin.py
+packages/localizer/tests/test_swarm_plugin_heuristic_wiring.py -q --no-cov` → 44 passed; `ruff check` on
+loader.py + test_swarm_plugin_heuristic_wiring.py → "No issues found"; `mypy loader.py` → "No issues
+found". Read the full diff: the non-empty-categories branch
+(`place_type = categories[0].get("name", "")`) is byte-for-byte unchanged, now paired with
+`else: place_type = _infer_place_type_from_name(place_name)`, called only when `categories` is
+empty/missing (`venue.get("categories", [])` defaults to `[]`) — a strict additive fallback, no
+regression risk. Verified all 4 ACs directly against the diff and tests: AC1 (unchanged branch,
+pre-existing `test_fetch_records_place_type_from_category` passes unmodified), AC2 (real
+unmocked airport test yields non-empty place_type containing "Airport"), AC3 (mocked
+wiring-contract test proves fetch_records() genuinely calls the heuristic and surfaces its `""`
+return rather than silently defaulting — a real unmocked call couldn't distinguish those two
+cases, so mocking here is deliberate test design, not a coverage gap, especially combined with
+Subtask 1's direct unit coverage of blank/punctuation input against the real function), AC4
+(both `{"items": [...]}` and `{"checkins": {"items": [...]}}` wrapper formats tested and passing,
+proving the fallback sits after wrapper normalization). Test Guidance fully covered: reused
+helpers, missing-key vs. empty-list variants, both wrapper formats, combined blank-name edge
+case, existing category-present test left untouched. No dead code, simplest possible change
+(one `else` branch). No issues found.
 
 ---
 
-### Subtask 4 — Remove the full-suite pytest requirement from the pre-push hook
+### Subtask 3 — End-to-end integration test proving dining/transit features populate, plus docs note
 
 **Status**: APPROVED
 
-**PR Group**: pytest-xdist-parallelization
+**PR Group**: venue-category-heuristics
 
-**Depends On**: none
+**Depends On**: 1, 2
 
 **Description**:
-**Replaces the original Subtasks 4-5** (a scoped-test-selection script wired into pre-push). Per
-explicit user direction mid-session ("let's remove the ... pre-push full CI requirement. This is a
-major hurdle for getting this work done"), the fix is simpler: remove the `pytest-push` hook
-entirely from `.pre-commit-config.yaml`, leaving only the fast `ruff-check-push`,
-`ruff-format-check-push`, and `mypy-push` hooks at the `pre-push` stage. CI's `quality` job remains
-the sole authoritative full-suite gate (already true — this doesn't change CI at all). Document the
-change in `CLAUDE.md`'s "Local Quality Gate" section.
-
-This was treated as a trivial, user-authorized direct fix (no design decision, obvious scope) per
-this repo's AGENTS.md trivial-change carve-out, rather than routed through the full
-planner/tester/coder/reviewer/owner pipeline — consistent with the user's explicit request to
-reduce process friction for this category of change.
+Add a new integration test file (`tests/test_venue_category_heuristic_integration.py`, root
+`tests/`, alongside other tests that already cross-import from the `localizer` package — e.g.
+`tests/test_localizer_broker.py`) that exercises the **full previously-broken pipeline**:
+`SwarmPlugin.fetch_records()` (synthetic empty-`categories` venues) → a DataFrame shaped like
+`core/localizer_frames.py::places_to_swarm_frame()`'s output → `analysis_utils.get_transit_days()`
+and `analysis_utils.get_dining_soundtrack_data()`. Assert both now return non-empty results for
+synthetic data that would have produced empty results before this fix (i.e., with `place_type`
+forced to `""`, matching the pre-fix behavior). Also add a short documentation note (in
+`packages/localizer/README.md`'s "places layer" section) describing the name-based fallback and
+its known limitation (approximate, name-pattern-based — real Foursquare category data, when
+present, is always preferred and unaffected).
 
 **Acceptance Criteria**:
-- [x] `.pre-commit-config.yaml`'s `pytest-push` hook block is removed entirely; `ruff-check-push`,
-  `ruff-format-check-push`, `mypy-push` remain unchanged.
-- [x] `pre-commit run --hook-stage pre-push --all-files` no longer invokes pytest — verified
-  directly: hook list now shows only ruff/mypy hooks, completing in ~5 seconds (down from
-  ~10-12 minutes).
-- [x] `CLAUDE.md`'s "Local Quality Gate" section documents that pre-push no longer runs the full
-  suite and that CI remains the authoritative full-suite gate.
-- [x] `.github/workflows/ci.yml` has zero diff from this subtask (CI unaffected).
+- [ ] A synthetic fixture built via `SwarmPlugin.fetch_records()` with empty-`categories`
+  checkins for an airport-style venue and a restaurant-style venue, converted into a `swarm_df`
+  matching `places_to_swarm_frame()`'s column shape, produces a non-empty result from
+  `get_transit_days(swarm_df)`.
+- [ ] The same fixture's restaurant-style checkin, combined with a small synthetic `lastfm_df`
+  containing listens within the dining time window, produces a non-empty result from
+  `get_dining_soundtrack_data(swarm_df, lastfm_df)` containing the expected bucket key (e.g.
+  `"Restaurants"`).
+- [ ] A control case using the same fixture but with `place_type`/`venue_category` forced to `""`
+  (simulating pre-fix behavior) demonstrates both functions return empty results — documenting
+  the before/after contrast explicitly rather than only asserting the fixed behavior.
+- [ ] `packages/localizer/README.md` documents the name-based fallback and its approximation
+  limitation in the existing "places layer" section (no new doc file created).
 
 **Files to Touch**:
-- `.pre-commit-config.yaml`
-- `CLAUDE.md`
+- `tests/test_venue_category_heuristic_integration.py` (new)
+- `packages/localizer/README.md`
 
-**Implementation Notes**: Removed the `pytest-push` hook block (id, name, entry: `pytest`, stages:
-[pre-push]) from `.pre-commit-config.yaml`. Added a paragraph to `CLAUDE.md`'s "Local Quality Gate"
-→ "Installing git hooks" section clarifying pre-push now runs only ruff/mypy, full suite is CI's
-job, and suggesting `pytest -n auto` as an optional manual local check. Verified directly:
-`rtk proxy pre-commit run --hook-stage pre-push --all-files` now shows only
-`ruff (legacy alias)`, `ruff format`, `mypy`, `ruff check (pre-push)`, `ruff format --check
-(pre-push)`, `mypy (pre-push)` — all Passed, total real time ~5.1s. Also ran `ruff check --fix .`
-and `ruff format .` to clean up minor import-order issues in the (now-deleted) test-ahead files for
-the old Subtasks 4-5, which were blocking a clean pre-push run.
+**Test Guidance**:
+- Build the fixture using only synthetic venue names (reuse the style from Subtasks 1-2's
+  fixtures — e.g. "O'Hare International Airport", "Joe's Pizza Place") — no real personal data.
+- Construct the intermediate `swarm_df` either by calling `places_to_swarm_frame()` directly on a
+  DataFrame shaped like `fetch_records()`'s output (preferred, since it exercises the real adapter
+  code path end-to-end) or by hand-building a DataFrame with the exact `SWARM_COLUMNS` shape if
+  wiring the two together proves awkward in a unit test — prefer the former for genuine
+  end-to-end coverage.
+- For the dining assertion, place at least one synthetic Last.fm listen timestamp within the
+  existing `_DINING_WINDOW_MINUTES` (30 min) window of the restaurant checkin's timestamp, per
+  `get_dining_soundtrack_data()`'s documented windowing behavior.
+- For the "before" control case, do not re-derive `place_type` from the heuristic — explicitly
+  construct it as `""` to simulate the documented pre-fix bug, then assert both downstream
+  functions return empty (`set()` / `{}`) on that input, confirming the contrast is real and not
+  incidental.
+- This subtask adds no new production code — it is test-and-docs only, so no risk-domain-specific
+  guidance (concurrency/network/DB/etc.) applies here.
 
-Deleted `tests/test_scoped_pytest.py` and `tests/test_pre_push_hook_wiring.py` (test-ahead files
-written by testers for the abandoned scoped-script design — they test a `tools/scoped_pytest.py`
-module that will never be built now).
+**Test Files**:
+- `tests/test_venue_category_heuristic_integration.py` (new) — 6 tests:
+  `test_transit_days_populate_after_fix`, `test_dining_soundtrack_data_populates_after_fix`,
+  `test_dining_soundtrack_data_top_artists_include_synthetic_listen` (all RED — exercise the real
+  `SwarmPlugin.fetch_records()` → `places_to_swarm_frame()` → `get_transit_days()`/
+  `get_dining_soundtrack_data()` pipeline with synthetic empty-categories venues, e.g. an
+  O'Hare-style airport checkin and a "Corner City Diner" checkin with a Last.fm listen inside the
+  dining window); `test_transit_days_empty_before_fix_control` and
+  `test_dining_soundtrack_data_empty_before_fix_control` (both pass now by design — the explicit
+  before/after control, with `place_type` forced to `""`); `test_readme_documents_name_based_fallback_limitation`
+  (RED — asserts `packages/localizer/README.md` mentions the name-based fallback and its
+  approximation limitation via a durable keyword check, not a pinned sentence). RED-confirmed: 4
+  failed (genuine assertion failures — all imports resolved cleanly since the target module
+  already exists, just not yet wired with the heuristic), 2 passed (the intentional controls).
 
-**Review Notes**: Approved directly by the orchestrator per the user's explicit request and the
-trivial-change carve-out in this repo's AGENTS.md — no separate reviewer/owner agent spawned for
-this subtask. The change was verified with real command output (hook list + timing), not just a
-diff review.
+**Implementation Notes**:
+This subtask required only test-verification (no new production code) plus one README
+doc addition, per its Files to Touch (`tests/test_venue_category_heuristic_integration.py`
+was already written by the tester; `packages/localizer/README.md` is the only file this
+coder edited).
+
+Ran the pre-written `tests/test_venue_category_heuristic_integration.py` first, before
+making any change: 5 of 6 tests already passed (`test_transit_days_populate_after_fix`,
+`test_dining_soundtrack_data_populates_after_fix`,
+`test_dining_soundtrack_data_top_artists_include_synthetic_listen`, plus the two
+before/after control tests) — confirming Subtasks 1+2's merged heuristic + wiring already
+make the real `SwarmPlugin.fetch_records()` -> `places_to_swarm_frame()` ->
+`get_transit_days()` / `get_dining_soundtrack_data()` pipeline work end-to-end with no
+further production-code changes needed. Only `test_readme_documents_name_based_fallback_limitation`
+was RED, failing because the README doc note didn't exist yet.
+
+Added a new paragraph to `packages/localizer/README.md`'s existing "### The places layer
+and location assumptions" section (after the existing "This means:" bullet list, no new
+section/file created) titled "Name-based `place_type` fallback (Swarm/Foursquare)"
+describing: (1) the real-world bug (empty `categories` on every venue breaking
+category-dependent features), (2) that `SwarmPlugin.fetch_records()` now falls back to a
+name-based heuristic (with example keywords: airport, pizza, metro station, coffee) when
+`categories` is empty/missing, (3) the explicit limitation that this is an approximation
+used only as a fallback, and (4) that real Foursquare category data, when present, is
+always preferred and completely unaffected. This satisfies the test's loose keyword
+checks (`"name"` + `"fallback"`/`"heuristic"`, and `"approximat"`/`"limitation"`) without
+pinning exact wording.
+
+No changes to `loader.py`, `test_swarm_plugin.py`, or
+`test_swarm_plugin_heuristic_wiring.py` — untouched, per the coder's scope boundary for
+this subtask.
+
+**Verification**:
+- `pytest tests/test_venue_category_heuristic_integration.py -v --no-cov` (before README
+  edit) → 5 passed, 1 failed (`test_readme_documents_name_based_fallback_limitation`)
+- `ruff check --fix .` (repo-wide) → "No issues found"
+- `ruff format .` (repo-wide) → "All files formatted correctly" (reformatted whitespace in
+  the untracked, tester-authored `tests/test_venue_category_heuristic_integration.py`; no
+  content/assertion changes, confirmed by full re-run below)
+- `pytest tests/test_venue_category_heuristic_integration.py -v --no-cov` (after README
+  edit) → 6 passed
+- Scoped set: `pytest tests/test_venue_category_heuristic_integration.py
+  packages/localizer/tests/test_swarm_plugin.py
+  packages/localizer/tests/test_swarm_plugin_heuristic_wiring.py -v --no-cov` → 50 passed
+  (6 + 34 + 10, no regressions)
+- `ruff check packages/localizer/README.md tests/test_venue_category_heuristic_integration.py`
+  → "No issues found"; `ruff format --check tests/test_venue_category_heuristic_integration.py`
+  → "1 file already formatted"
+
+**Review Notes**:
+Code Review: APPROVED — checks clean. `ruff check .` (repo-wide) → "No issues found"; `ruff
+format --check .` → "163 files already formatted"; `mypy` → "No issues found"; `pytest
+tests/test_venue_category_heuristic_integration.py -v --no-cov` → 6 passed. Full scoped
+regression set for the PR group — `pytest packages/localizer/tests/test_swarm_plugin.py
+packages/localizer/tests/test_swarm_plugin_heuristic_wiring.py
+tests/test_venue_category_heuristic_integration.py -v --no-cov` → 50 passed, 0 failed, no
+regressions across all 3 subtasks. Read the full test file: all 6 tests are genuine, not
+vacuous — `test_transit_days_populate_after_fix` /
+`test_dining_soundtrack_data_populates_after_fix` /
+`test_dining_soundtrack_data_top_artists_include_synthetic_listen` exercise the real
+`SwarmPlugin.fetch_records()` -> `places_to_swarm_frame()` -> `get_transit_days()`/
+`get_dining_soundtrack_data()` pipeline on synthetic empty-categories venues (airport +
+diner); the two control tests hand-construct `place_type=""` (not derived from the
+heuristic) to prove the before/after contrast is real, not incidental; the README test
+does a loose keyword check against the real file content. All 4 ACs verified against actual
+behavior: AC1 (transit_days non-empty via real pipeline), AC2 ("Restaurants" bucket with
+checkin_count/listen_count >= 1), AC3 (both functions return `set()`/`{}` on the forced-""
+control), AC4 (README paragraph present, read directly). README addition is accurate,
+correctly placed in the existing "### The places layer and location assumptions" section
+(single occurrence, immediately after the existing bullet list, before the `---`/##
+Installation break), not duplicative — no other mention of the name-based fallback exists
+elsewhere in the file. No dead code, no secrets/credentials, no N+1/hot-path concerns (test
+file only constructs small in-memory DataFrames). No issues found.
+
+Owner: APPROVED — independently re-ran the full scoped set: `pytest
+packages/localizer/tests/test_swarm_plugin.py
+packages/localizer/tests/test_swarm_plugin_heuristic_wiring.py
+tests/test_venue_category_heuristic_integration.py -q --no-cov` → 50 passed; `ruff check` on all
+touched files → "No issues found"; `mypy packages/localizer/src/localizer/plugins/swarm/loader.py`
+→ "No issues found". Read the full integration test file and the README diff. Confirmed
+`get_transit_days()`/`get_dining_soundtrack_data()` fixture design matches the real
+`analysis_utils.py` implementation (30-minute `_DINING_WINDOW_MINUTES`, `venue_category` column
+requirement) — the synthetic listen is placed 5 minutes after the dining checkin, safely inside
+the window. All 4 ACs verified against real behavior, not mocks: AC1 (`get_transit_days()`
+non-empty via the real `SwarmPlugin.fetch_records()` → `places_to_swarm_frame()` pipeline on an
+airport-style empty-categories checkin), AC2 ("Restaurants" bucket populated with
+checkin_count/listen_count >= 1 for a diner-style checkin), AC3 (both functions return
+`set()`/`{}` on the hand-constructed forced-`""` control, proving the before/after contrast is
+real, not incidental), AC4 (README paragraph at lines 49-59 of
+`packages/localizer/README.md`, correctly placed in the existing "places layer" section, accurate,
+documents the approximation/limitation as required). No dead code, no vacuous tests, no personal
+data in fixtures (all synthetic names).
+
+**Holistic plan assessment (issue #93, all 3 subtasks now APPROVED)**: The issue's confirmed root
+cause — real Foursquare/Swarm exports ship an empty `categories` array on every venue, making
+`venue_category` always `""` and silently breaking both the Dining Soundtrack (#81) and In Transit
+(#83) features — is fixed via exactly the issue's own "Approach 2: name-based heuristics", with
+the tradeoff (lower accuracy, documented as an approximation) explicitly called out in the README
+per the issue's own framing. The fix is offline-first with zero new dependencies (CLAUDE.md
+Section 3 and the issue's explicit runtime constraint), correctly scoped to the active
+`packages/localizer` plugin system only, requires zero changes to the shared, well-tested
+`analysis_utils.py` classifiers (smallest blast radius), and is proven end-to-end by a real
+pipeline integration test plus an explicit before/after control contrast. Nothing from the issue's
+original ask is missing. Recommend the orchestrator append `Closes #93` to the PR-group commit
+message per the standard workflow rule.
+
+**All 3 subtasks in PR Group `venue-category-heuristics` are now APPROVED. Plan Status: COMPLETE.**
 
 ---

--- a/packages/localizer/README.md
+++ b/packages/localizer/README.md
@@ -46,6 +46,18 @@ This means:
 - Editing `default_assumptions.json` takes effect the next time you open the dashboard — no sync needed.
 - The `places` table only contains explicit check-ins; inferred locations are computed on the fly.
 
+**Name-based `place_type` fallback (Swarm/Foursquare).** Real Foursquare/Swarm exports
+frequently ship an empty `categories` array on every venue, which used to leave
+`place_type` (and downstream `venue_category`) empty for every check-in — silently
+breaking category-dependent features like the dining soundtrack view and transit-day
+detection. `SwarmPlugin.fetch_records()` now falls back to inferring a `place_type` from
+the venue **name** (e.g. matching `"airport"`, `"pizza"`, `"metro station"`, `"coffee"`)
+whenever `categories` is empty or missing. This name-based fallback is a heuristic and
+therefore only an **approximation** — it is a lower-fidelity substitute used only when
+real category data is unavailable. Whenever a checkin's `categories` array is
+non-empty, that real Foursquare category data is always preferred and completely
+unaffected by this fallback.
+
 ---
 
 ## Installation

--- a/packages/localizer/src/localizer/plugins/swarm/loader.py
+++ b/packages/localizer/src/localizer/plugins/swarm/loader.py
@@ -15,6 +15,108 @@ from typing import Any
 from localizer.plugins import register
 from localizer.plugins.base import FetchMode, OutputTable, SourcePlugin
 
+# Name-pattern rule table for `_infer_place_type_from_name()` (issue #93).
+#
+# Real Foursquare/Swarm exports frequently ship an empty `categories` array on
+# venue objects, which makes the downstream `place_type` always `""`. As a
+# fallback (used only when `categories` is empty/missing — see
+# `fetch_records()`), this table matches lowercase substrings of the venue
+# *name* against Foursquare/Swarm naming conventions and synthesizes a
+# `place_type` string.
+#
+# Every synthesized value below intentionally reuses a substring from either
+# `analysis_utils._CATEGORY_RULES` (dining/nightlife buckets) or
+# `analysis_utils.TRANSIT_CATEGORY_KEYWORDS` (transit), so the existing
+# downstream classifiers recognize the synthesized value unchanged with zero
+# changes to `analysis_utils.py`.
+#
+# Rules are checked in order; the first match wins. Deliberately excludes a
+# bare "port" rule (would false-positive on names like "Portland" or "Import
+# Foods") and a bare "club" rule (too generic) — see handoff.md's Task
+# Overview non-overlap constraint for issue #93.
+_NAME_HEURISTIC_RULES: list[tuple[str, str]] = [
+    # Transit (mirrors TRANSIT_CATEGORY_KEYWORDS)
+    ("airport", "Airport"),
+    ("train station", "Train Station"),
+    ("metro station", "Metro Station"),
+    ("subway station", "Subway Station"),
+    ("bus station", "Bus Station"),
+    ("ferry terminal", "Ferry"),
+    ("rail station", "Rail Station"),
+    ("gas station", "Gas Station"),
+    ("truck stop", "Truck Stop"),
+    ("rest area", "Rest Area"),
+    ("rest stop", "Rest Stop"),
+    ("travel plaza", "Travel Plaza"),
+    ("service plaza", "Service Plaza"),
+    ("turnpike", "Turnpike"),
+    ("toll plaza", "Toll"),
+    # Dining / nightlife (mirrors _CATEGORY_RULES buckets)
+    ("pizza", "Pizza"),
+    ("burger", "Burger"),
+    ("fried chicken", "Fried Chicken"),
+    ("hot dog", "Hot Dog"),
+    ("sandwich", "Sandwich"),
+    ("brewery", "Brewery"),
+    ("nightclub", "Nightclub"),
+    ("pub", "Pub"),
+    ("wine bar", "Wine Bar"),
+    ("cocktail", "Cocktail Bar"),
+    ("lounge", "Lounge"),
+    ("coffee", "Coffee"),
+    ("café", "Cafe"),
+    ("cafe", "Cafe"),
+    ("tea room", "Tea Room"),
+    ("bakery", "Bakery"),
+    ("ice cream", "Ice Cream"),
+    ("juice bar", "Juice Bar"),
+    ("restaurant", "Restaurant"),
+    ("diner", "Diner"),
+    ("sushi", "Sushi"),
+    ("ramen", "Ramen"),
+    ("noodle", "Noodle"),
+    ("steakhouse", "Steakhouse"),
+    ("bbq", "BBQ"),
+    ("seafood", "Seafood"),
+    ("bistro", "Bistro"),
+    ("brasserie", "Brasserie"),
+    ("tapas", "Tapas"),
+    ("dim sum", "Dim Sum"),
+    ("buffet", "Buffet"),
+    ("grill", "Grill"),
+    ("kitchen", "Kitchen"),
+    ("eatery", "Eatery"),
+]
+
+
+def _infer_place_type_from_name(venue_name: str) -> str:
+    """Infer a synthesized ``place_type`` from a venue name via keyword heuristics.
+
+    Used as a fallback when a Swarm/Foursquare export's ``categories`` array is
+    empty or missing (issue #93). Checks ``venue_name`` (lower-cased) against
+    ``_NAME_HEURISTIC_RULES`` in order and returns the first matching rule's
+    synthesized value. Every synthesized value contains a substring already
+    recognized by ``analysis_utils._CATEGORY_RULES`` or
+    ``analysis_utils.TRANSIT_CATEGORY_KEYWORDS``, so downstream classifiers
+    work unchanged.
+
+    Args:
+        venue_name: The raw venue name string from the Swarm export. May be
+            empty or contain only punctuation/whitespace.
+
+    Returns:
+        The synthesized place_type string, or ``""`` if no rule matches (never
+        ``None``, never raises).
+    """
+    if not venue_name:
+        return ""
+
+    name_lower = venue_name.lower()
+    for needle, result in _NAME_HEURISTIC_RULES:
+        if needle in name_lower:
+            return result
+    return ""
+
 
 @register
 class SwarmPlugin(SourcePlugin):
@@ -164,9 +266,10 @@ class SwarmPlugin(SourcePlugin):
 
                 place_name = venue.get("name", "")
                 categories = venue.get("categories", [])
-                place_type = ""
                 if categories:
                     place_type = categories[0].get("name", "")
+                else:
+                    place_type = _infer_place_type_from_name(place_name)
 
                 yield {
                     "source_id": "swarm",

--- a/packages/localizer/tests/test_swarm_plugin.py
+++ b/packages/localizer/tests/test_swarm_plugin.py
@@ -329,3 +329,213 @@ def test_fetch_records_fetched_at_is_recent(tmp_path: Path) -> None:
     assert before - 5 <= fetched_at <= after + 5, (
         f"fetched_at {fetched_at} not close to now ({before}–{after})"
     )
+
+
+# ---------------------------------------------------------------------------
+# Subtask 1 (issue #93): name-based venue-category heuristic
+#
+# These tests target `_infer_place_type_from_name(venue_name: str) -> str`,
+# a new private, pure module-level function in
+# `packages/localizer/src/localizer/plugins/swarm/loader.py`. It is not wired
+# into `fetch_records()` yet (that is Subtask 2) — these tests call the
+# function directly.
+#
+# Reference vocabulary (copied from handoff.md's Task Overview, itself copied
+# from analysis_utils.py, so these tests do not depend on analysis_utils
+# imports and stay isolated per CLAUDE.md's test-isolation conventions):
+#   _CATEGORY_RULES buckets (lowercase substrings):
+#     Fast Food:  fast food, burger, pizza, fried chicken, hot dog, sandwich
+#     Bars:       bar, nightclub, pub, brewery, wine, cocktail, lounge, club
+#     Cafes:      cafe, café, coffee, tea room, bakery, dessert, ice cream,
+#                 juice bar
+#     Restaurant: restaurant, diner, food, sushi, ramen, noodle, steakhouse,
+#                 bbq, seafood, bistro, brasserie, tapas, dim sum, buffet,
+#                 grill, kitchen, eatery
+#   TRANSIT_CATEGORY_KEYWORDS (matched case-insensitively):
+#     Airport, Train Station, Transit, Bus Station, Metro, Subway, Ferry,
+#     Port, Rail, Rest Area, Rest Stop, Travel Plaza, Service Plaza,
+#     Turnpike, Toll, Gas Station, Truck Stop
+# ---------------------------------------------------------------------------
+
+_TRANSIT_KEYWORDS_LOWER = frozenset(
+    {
+        "airport",
+        "train station",
+        "transit",
+        "bus station",
+        "metro",
+        "subway",
+        "ferry",
+        "port",
+        "rail",
+        "rest area",
+        "rest stop",
+        "travel plaza",
+        "service plaza",
+        "turnpike",
+        "toll",
+        "gas station",
+        "truck stop",
+    }
+)
+
+
+def _contains_any(haystack_lower: str, needles: set[str]) -> bool:
+    """Return True if any needle substring is present in haystack_lower."""
+    return any(needle in haystack_lower for needle in needles)
+
+
+def test_infer_place_type_from_name_airport() -> None:
+    """An airport-style venue name must synthesize a place_type containing 'Airport'."""
+    from localizer.plugins.swarm.loader import _infer_place_type_from_name
+
+    result = _infer_place_type_from_name("O'Hare International Airport")
+    assert "Airport" in result, f"Expected 'Airport' substring, got {result!r}"
+
+
+def test_infer_place_type_from_name_train_or_metro_station() -> None:
+    """A metro/train-station-style venue name must synthesize a transit-keyword place_type."""
+    from localizer.plugins.swarm.loader import _infer_place_type_from_name
+
+    result = _infer_place_type_from_name("Downtown Metro Station")
+    assert result != "", "Expected a non-empty synthesized place_type"
+    assert _contains_any(result.lower(), _TRANSIT_KEYWORDS_LOWER), (
+        f"Expected a transit keyword substring (e.g. 'Metro'), got {result!r}"
+    )
+
+
+def test_infer_place_type_from_name_pizza() -> None:
+    """A pizza-style venue name must synthesize a place_type containing 'pizza' (lowercased)."""
+    from localizer.plugins.swarm.loader import _infer_place_type_from_name
+
+    result = _infer_place_type_from_name("Joe's Pizza Place")
+    assert "pizza" in result.lower(), f"Expected 'pizza' substring, got {result!r}"
+
+
+def test_infer_place_type_from_name_coffee() -> None:
+    """A coffee/cafe-style venue name must synthesize a place_type containing 'coffee'."""
+    from localizer.plugins.swarm.loader import _infer_place_type_from_name
+
+    result = _infer_place_type_from_name("Downtown Coffee Roasters")
+    assert "coffee" in result.lower(), f"Expected 'coffee' substring, got {result!r}"
+
+
+def test_infer_place_type_from_name_bar_or_pub() -> None:
+    """A bar/pub-style venue name must synthesize a place_type from the Bars & Nightlife bucket."""
+    from localizer.plugins.swarm.loader import _infer_place_type_from_name
+
+    bars_bucket = {
+        "bar",
+        "nightclub",
+        "pub",
+        "brewery",
+        "wine",
+        "cocktail",
+        "lounge",
+        "club",
+    }
+    result = _infer_place_type_from_name("The Rusty Anchor Pub")
+    assert result != "", "Expected a non-empty synthesized place_type"
+    assert _contains_any(result.lower(), bars_bucket), (
+        f"Expected a Bars & Nightlife keyword substring (e.g. 'pub'), got {result!r}"
+    )
+
+
+def test_infer_place_type_from_name_restaurant() -> None:
+    """A restaurant-style venue name must synthesize a place_type from the Restaurants bucket."""
+    from localizer.plugins.swarm.loader import _infer_place_type_from_name
+
+    restaurant_bucket = {
+        "restaurant",
+        "diner",
+        "food",
+        "sushi",
+        "ramen",
+        "noodle",
+        "steakhouse",
+        "bbq",
+        "seafood",
+        "bistro",
+        "brasserie",
+        "tapas",
+        "dim sum",
+        "buffet",
+        "grill",
+        "kitchen",
+        "eatery",
+    }
+    result = _infer_place_type_from_name("Golden Dragon Restaurant")
+    assert result != "", "Expected a non-empty synthesized place_type"
+    assert _contains_any(result.lower(), restaurant_bucket), (
+        f"Expected a Restaurants keyword substring (e.g. 'restaurant'), got {result!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "venue_name",
+    ["Generic City Museum", "Downtown Art Gallery"],
+)
+def test_infer_place_type_from_name_no_match_returns_empty_string(venue_name: str) -> None:
+    """A non-food/non-transit venue name must return exactly '' (never None, never raises)."""
+    from localizer.plugins.swarm.loader import _infer_place_type_from_name
+
+    result = _infer_place_type_from_name(venue_name)
+    assert result == "", f"Expected exactly '', got {result!r}"
+    assert result is not None
+
+
+def test_infer_place_type_from_name_false_positive_portland_pizza() -> None:
+    """'Portland Pizza Co.' must classify as pizza/dining, not trip a bare 'port' transit rule.
+
+    This guards the Task Overview's non-overlap constraint: the rule table must
+    not contain a bare "port" name-pattern rule, since "Portland" would then
+    false-positive as transit ("Port").
+    """
+    from localizer.plugins.swarm.loader import _infer_place_type_from_name
+
+    result = _infer_place_type_from_name("Portland Pizza Co.")
+    assert "pizza" in result.lower(), (
+        f"Expected 'pizza' substring (dining classification), got {result!r}"
+    )
+    assert "port" not in result.lower(), (
+        f"Synthesized place_type must not contain a bare 'port' transit false-positive, "
+        f"got {result!r}"
+    )
+
+
+def test_infer_place_type_from_name_case_insensitive_all_lowercase() -> None:
+    """Matching must be case-insensitive: an all-lowercase venue name still matches."""
+    from localizer.plugins.swarm.loader import _infer_place_type_from_name
+
+    result = _infer_place_type_from_name("downtown metro station")
+    assert result != "", "Expected all-lowercase input to still match the transit heuristic"
+    assert _contains_any(result.lower(), _TRANSIT_KEYWORDS_LOWER), (
+        f"Expected a transit keyword substring, got {result!r}"
+    )
+
+
+def test_infer_place_type_from_name_case_insensitive_mixed_case() -> None:
+    """Matching must be case-insensitive: a mixed/upper-case venue name still matches."""
+    from localizer.plugins.swarm.loader import _infer_place_type_from_name
+
+    result = _infer_place_type_from_name("DOWNTOWN COFFEE ROASTERS")
+    assert "coffee" in result.lower(), f"Expected 'coffee' substring, got {result!r}"
+
+
+def test_infer_place_type_from_name_empty_string_returns_empty_and_does_not_raise() -> None:
+    """An empty venue name must return '' and must not raise."""
+    from localizer.plugins.swarm.loader import _infer_place_type_from_name
+
+    result = _infer_place_type_from_name("")
+    assert result == "", f"Expected '', got {result!r}"
+
+
+@pytest.mark.parametrize("venue_name", ["   ", "!!!", "...,", "---"])
+def test_infer_place_type_from_name_punctuation_only_returns_empty_and_does_not_raise(
+    venue_name: str,
+) -> None:
+    """A venue name containing only punctuation/whitespace must return '' and not raise."""
+    from localizer.plugins.swarm.loader import _infer_place_type_from_name
+
+    result = _infer_place_type_from_name(venue_name)
+    assert result == "", f"Expected '', got {result!r}"

--- a/packages/localizer/tests/test_swarm_plugin_heuristic_wiring.py
+++ b/packages/localizer/tests/test_swarm_plugin_heuristic_wiring.py
@@ -1,0 +1,264 @@
+"""Failing tests for Subtask 2 (issue #93): wiring the name heuristic into
+``SwarmPlugin.fetch_records()``.
+
+Scope: this file tests ONLY the *wiring* in
+``packages/localizer/src/localizer/plugins/swarm/loader.py::fetch_records()``
+— i.e. that ``_infer_place_type_from_name(place_name)`` is called (and its
+return value used as ``place_type``) precisely when ``venue["categories"]``
+is empty or missing, and is never consulted when a real category is present.
+The heuristic's own keyword-matching *logic* is Subtask 1's responsibility
+and is fully covered by the parallel test file
+``packages/localizer/tests/test_swarm_plugin.py`` (see the
+``test_infer_place_type_from_name_*`` tests there) — this file must not
+duplicate that coverage.
+
+Kept in a new file, disjoint from ``test_swarm_plugin.py``, per the parallel
+test-ahead batch's single-writer-per-file discipline (see handoff.md's
+Shared-source-file note for Subtasks 1-2). This file imports and reuses the
+existing ``_make_checkin()`` / ``_write_checkins_json()`` helpers from
+``test_swarm_plugin.py`` rather than duplicating them, and defines its own
+sibling helpers for the empty/missing-``categories`` shapes those helpers
+don't produce, plus a nested-wrapper JSON writer for the wrapper-format
+coverage below.
+
+Two families of test live here:
+
+  1. Direct (unmocked) end-to-end tests that call ``fetch_records()`` and
+     assert on the real synthesized ``place_type``. These are genuinely RED
+     right now via a plain ``AssertionError`` (the fallback isn't wired up
+     yet, so ``place_type`` stays ``""``), independent of whether Subtask 1's
+     ``_infer_place_type_from_name`` has landed.
+
+  2. Mock-based wiring-contract tests that patch
+     ``localizer.plugins.swarm.loader._infer_place_type_from_name`` with
+     ``create=True`` (so patching succeeds whether or not Subtask 1's
+     function exists yet) and assert the call happens exactly when expected,
+     with the expected argument, and that its return value is threaded
+     through as ``place_type``. These exist because a few of the required
+     assertions (the "no match still returns ''" and "empty name still
+     returns '' and doesn't raise" cases) are invariant — true both before
+     and after this subtask's fix — so a plain end-to-end assertion on the
+     literal value would pass vacuously today. Mocking the call itself makes
+     those cases genuinely RED (the call is provably absent right now).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from tests.test_swarm_plugin import _make_checkin, _write_checkins_json
+
+_LOADER_HEURISTIC_TARGET = "localizer.plugins.swarm.loader._infer_place_type_from_name"
+
+
+# ---------------------------------------------------------------------------
+# Helpers — sibling to test_swarm_plugin.py's _make_checkin()/_write_checkins_json(),
+# covering shapes the shared helpers don't produce (empty/missing categories,
+# alternate wrapper formats). Defined here, not in test_swarm_plugin.py, to
+# keep this subtask's test file fully disjoint from Subtask 1's.
+# ---------------------------------------------------------------------------
+
+
+def _make_checkin_empty_categories(
+    *,
+    venue_name: str,
+    created_at: int = 1_700_000_000,
+    lat: float = 51.5074,
+    lng: float = -0.1278,
+) -> dict[str, Any]:
+    """Return a checkin dict whose venue has an explicit empty categories list."""
+    checkin = _make_checkin(created_at=created_at, lat=lat, lng=lng, venue_name=venue_name)
+    checkin["venue"]["categories"] = []
+    return checkin
+
+
+def _make_checkin_missing_categories_key(
+    *,
+    venue_name: str,
+    created_at: int = 1_700_000_000,
+    lat: float = 51.5074,
+    lng: float = -0.1278,
+) -> dict[str, Any]:
+    """Return a checkin dict whose venue has NO 'categories' key at all."""
+    checkin = _make_checkin(created_at=created_at, lat=lat, lng=lng, venue_name=venue_name)
+    del checkin["venue"]["categories"]
+    return checkin
+
+
+def _write_nested_checkins_json(path: Path, checkins: list[dict[str, Any]]) -> None:
+    """Write a Swarm export using the ``{"checkins": {"items": [...]}}`` wrapper shape."""
+    path.write_text(json.dumps({"checkins": {"items": checkins}}), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Direct end-to-end tests — real synthesized place_type, no mocking.
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_records_empty_categories_heuristic_match_airport(tmp_path: Path) -> None:
+    """AC2: empty categories + heuristic-matching name yields a non-empty, matching place_type."""
+    from localizer.plugins.swarm.loader import SwarmPlugin
+
+    checkin = _make_checkin_empty_categories(venue_name="O'Hare International Airport")
+    _write_checkins_json(tmp_path / "checkins_20231101.json", [checkin])
+
+    plugin = SwarmPlugin(swarm_dir=str(tmp_path))
+    records = list(plugin.fetch_records())
+
+    assert len(records) == 1
+    place_type = records[0]["place_type"]
+    assert place_type != "", "Expected a non-empty synthesized place_type"
+    assert "Airport" in place_type, f"Expected 'Airport' substring, got {place_type!r}"
+
+
+def test_fetch_records_missing_categories_key_heuristic_match_pizza(tmp_path: Path) -> None:
+    """A venue dict with no 'categories' key must also trigger the name heuristic."""
+    from localizer.plugins.swarm.loader import SwarmPlugin
+
+    checkin = _make_checkin_missing_categories_key(venue_name="Joe's Pizza Place")
+    _write_checkins_json(tmp_path / "checkins_20231101.json", [checkin])
+
+    plugin = SwarmPlugin(swarm_dir=str(tmp_path))
+    records = list(plugin.fetch_records())
+
+    assert len(records) == 1
+    place_type = records[0]["place_type"]
+    assert "pizza" in place_type.lower(), f"Expected 'pizza' substring, got {place_type!r}"
+
+
+def test_fetch_records_items_wrapper_empty_categories_heuristic_eligible(tmp_path: Path) -> None:
+    """AC4: the {"items": [...]} wrapper format supports the empty-categories fallback."""
+    from localizer.plugins.swarm.loader import SwarmPlugin
+
+    checkin = _make_checkin_empty_categories(venue_name="Downtown Metro Station")
+    # _write_checkins_json uses the {"items": [...]} wrapper shape.
+    _write_checkins_json(tmp_path / "checkins_20231101.json", [checkin])
+
+    plugin = SwarmPlugin(swarm_dir=str(tmp_path))
+    records = list(plugin.fetch_records())
+
+    assert len(records) == 1
+    place_type = records[0]["place_type"]
+    assert place_type != "", "Expected a non-empty synthesized place_type"
+
+
+def test_fetch_records_nested_checkins_items_wrapper_empty_categories_heuristic_eligible(
+    tmp_path: Path,
+) -> None:
+    """AC4: the {"checkins": {"items": [...]}} wrapper format also supports the fallback."""
+    from localizer.plugins.swarm.loader import SwarmPlugin
+
+    checkin = _make_checkin_empty_categories(venue_name="Downtown Coffee Roasters")
+    _write_nested_checkins_json(tmp_path / "checkins_20231101.json", [checkin])
+
+    plugin = SwarmPlugin(swarm_dir=str(tmp_path))
+    records = list(plugin.fetch_records())
+
+    assert len(records) == 1
+    place_type = records[0]["place_type"]
+    assert "coffee" in place_type.lower(), f"Expected 'coffee' substring, got {place_type!r}"
+
+
+# ---------------------------------------------------------------------------
+# Mock-based wiring-contract tests.
+#
+# `create=True` lets these patch `_infer_place_type_from_name` whether or not
+# Subtask 1's coder has landed the function yet (this subtask, per handoff.md,
+# `Depends On: 1` and its tester's function may not exist in the module at
+# test-authoring time). Regardless of that, these assertions are genuinely
+# RED right now because fetch_records() does not call anything by this name
+# yet at all.
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_records_calls_heuristic_and_uses_return_value_when_categories_empty(
+    tmp_path: Path,
+) -> None:
+    """Empty categories must call the heuristic with place_name and use its return value."""
+    from localizer.plugins.swarm.loader import SwarmPlugin
+
+    checkin = _make_checkin_empty_categories(venue_name="Some Synthetic Venue")
+    _write_checkins_json(tmp_path / "checkins_20231101.json", [checkin])
+
+    with mock.patch(
+        _LOADER_HEURISTIC_TARGET, create=True, return_value="Mocked Place Type"
+    ) as mock_infer:
+        plugin = SwarmPlugin(swarm_dir=str(tmp_path))
+        records = list(plugin.fetch_records())
+
+    assert len(records) == 1
+    mock_infer.assert_called_once_with("Some Synthetic Venue")
+    assert records[0]["place_type"] == "Mocked Place Type", (
+        "fetch_records() must use the heuristic's return value as place_type "
+        "when categories is empty"
+    )
+
+
+def test_fetch_records_calls_heuristic_when_categories_key_missing(tmp_path: Path) -> None:
+    """A venue dict missing the 'categories' key entirely must also trigger the heuristic call."""
+    from localizer.plugins.swarm.loader import SwarmPlugin
+
+    checkin = _make_checkin_missing_categories_key(venue_name="Another Synthetic Venue")
+    _write_checkins_json(tmp_path / "checkins_20231101.json", [checkin])
+
+    with mock.patch(
+        _LOADER_HEURISTIC_TARGET, create=True, return_value="Mocked Place Type"
+    ) as mock_infer:
+        plugin = SwarmPlugin(swarm_dir=str(tmp_path))
+        records = list(plugin.fetch_records())
+
+    assert len(records) == 1
+    mock_infer.assert_called_once_with("Another Synthetic Venue")
+    assert records[0]["place_type"] == "Mocked Place Type"
+
+
+def test_fetch_records_no_match_result_flows_through_as_empty_string(tmp_path: Path) -> None:
+    """AC3: when the heuristic itself returns '', fetch_records() must still call it and
+    surface '' as place_type — proving the no-match invariant is produced by real wiring,
+    not by fetch_records() simply skipping the call and defaulting to ''."""
+    from localizer.plugins.swarm.loader import SwarmPlugin
+
+    checkin = _make_checkin_empty_categories(venue_name="Generic City Museum")
+    _write_checkins_json(tmp_path / "checkins_20231101.json", [checkin])
+
+    with mock.patch(_LOADER_HEURISTIC_TARGET, create=True, return_value="") as mock_infer:
+        plugin = SwarmPlugin(swarm_dir=str(tmp_path))
+        records = list(plugin.fetch_records())
+
+    assert len(records) == 1
+    mock_infer.assert_called_once_with("Generic City Museum")
+    assert records[0]["place_type"] == "", f"Expected exactly '', got {records[0]['place_type']!r}"
+
+
+@pytest.mark.parametrize("venue_name", ["", "   ", "!!!"])
+def test_fetch_records_empty_categories_and_blank_name_does_not_raise(
+    tmp_path: Path, venue_name: str
+) -> None:
+    """Combined edge case: empty/missing categories AND an empty or punctuation-only venue
+    name must not raise, must still invoke the heuristic, and must surface '' as place_type
+    (Subtask 1 already covers empty-string input directly against
+    _infer_place_type_from_name; this proves the same guarantee holds through the full
+    fetch_records() wiring)."""
+    from localizer.plugins.swarm.loader import SwarmPlugin
+
+    checkin = _make_checkin_empty_categories(venue_name=venue_name)
+    _write_checkins_json(tmp_path / "checkins_20231101.json", [checkin])
+
+    with mock.patch(_LOADER_HEURISTIC_TARGET, create=True, return_value="") as mock_infer:
+        plugin = SwarmPlugin(swarm_dir=str(tmp_path))
+        try:
+            records = list(plugin.fetch_records())
+        except Exception as exc:  # noqa: BLE001
+            pytest.fail(
+                f"fetch_records() raised {type(exc).__name__} for blank venue name "
+                f"{venue_name!r}: {exc}"
+            )
+
+    assert len(records) == 1
+    mock_infer.assert_called_once_with(venue_name)
+    assert records[0]["place_type"] == "", f"Expected '', got {records[0]['place_type']!r}"

--- a/tests/test_venue_category_heuristic_integration.py
+++ b/tests/test_venue_category_heuristic_integration.py
@@ -1,0 +1,265 @@
+"""Failing tests for Subtask 3 (issue #93): end-to-end proof that the venue-category
+name heuristic (Subtasks 1-2) actually fixes ``get_transit_days()`` /
+``get_dining_soundtrack_data()`` for real-shaped Foursquare/Swarm exports where
+``categories`` is empty on every venue.
+
+This test exercises the full previously-broken pipeline:
+
+    SwarmPlugin.fetch_records()  (synthetic empty-``categories`` checkins)
+        -> a places_df shaped like fetch_records()'s output
+        -> core.localizer_frames.places_to_swarm_frame()
+        -> analysis_utils.get_transit_days() / get_dining_soundtrack_data()
+
+All venue names are synthetic/generic, per CLAUDE.md Section 3 (no real personal data).
+
+Until Subtasks 1-2 are implemented, ``SwarmPlugin.fetch_records()`` leaves
+``place_type`` as ``""`` whenever ``categories`` is empty (today's documented bug),
+so the "after fix" assertions below are expected to FAIL (RED) right now. The
+"before fix" control-case assertions are expected to PASS already -- they document
+the bug directly, not the fix, so they establish the necessary before/after contrast
+rather than accidentally validating the whole file as vacuously green.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+from localizer.plugins.swarm.loader import SwarmPlugin
+
+from analysis_utils import get_dining_soundtrack_data, get_transit_days
+from core.localizer_frames import places_to_swarm_frame
+
+# ---------------------------------------------------------------------------
+# Synthetic fixture helpers
+# ---------------------------------------------------------------------------
+
+# Fixed, arbitrary Unix timestamps (seconds) -- deterministic across runs/timezones.
+AIRPORT_CHECKIN_TS = 1_700_000_000  # 2023-11-14 22:13:20 UTC
+DINING_CHECKIN_TS = 1_700_100_000  # ~ a day later; well clear of the airport check-in
+DINING_LISTEN_TS = DINING_CHECKIN_TS + 5 * 60  # 5 minutes after the dining check-in
+
+
+def _make_empty_category_checkin(
+    created_at: int,
+    venue_name: str,
+    lat: float = 51.5074,
+    lng: float = -0.1278,
+) -> dict[str, Any]:
+    """Build a checkin dict with an empty ``categories`` list.
+
+    This mirrors the real, previously-broken Foursquare/Swarm export shape
+    described in the Task Overview: every venue's ``categories`` array is empty.
+    """
+    return {
+        "id": "synthetic-checkin",
+        "createdAt": created_at,
+        "lat": lat,
+        "lng": lng,
+        "venue": {
+            "id": "synthetic-venue",
+            "name": venue_name,
+            "location": {"lat": lat, "lng": lng},
+            "categories": [],
+        },
+        "timeZoneOffset": 0,
+    }
+
+
+def _write_checkins(path: Path, checkins: list[dict[str, Any]]) -> None:
+    path.write_text(json.dumps({"items": checkins}), encoding="utf-8")
+
+
+def _fetch_places_df(swarm_dir: Path) -> pd.DataFrame:
+    """Run the real SwarmPlugin.fetch_records() pipeline and shape a places_df.
+
+    Columns match the shape ``places_to_swarm_frame()`` expects (the same shape
+    documented as ``LocalizerBroker.get_places_frame()``'s output): timestamp, lat,
+    lng, place_name, place_type, source_id.
+    """
+    plugin = SwarmPlugin(swarm_dir=str(swarm_dir))
+    records = list(plugin.fetch_records())
+    assert records, "expected fetch_records() to yield the synthetic checkins"
+    return pd.DataFrame(records)[
+        ["timestamp", "lat", "lng", "place_name", "place_type", "source_id"]
+    ]
+
+
+def _lastfm_fixture_for_dining_window() -> pd.DataFrame:
+    """One synthetic Last.fm listen inside the dining check-in's ±30 min window."""
+    return pd.DataFrame(
+        {
+            "timestamp": [DINING_LISTEN_TS],
+            "date_text": [pd.to_datetime(DINING_LISTEN_TS, unit="s")],
+            "artist": ["Synthetic Artist"],
+            "track": ["Synthetic Track"],
+            "album": ["Synthetic Album"],
+            "source_id": ["lastfm"],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# "After" fixture: real fetch_records() pipeline over empty-categories checkins
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def swarm_df_from_real_pipeline(tmp_path: Path) -> pd.DataFrame:
+    """swarm_df built end-to-end from SwarmPlugin.fetch_records(), empty categories.
+
+    One airport-style venue (should trip TRANSIT_CATEGORY_KEYWORDS via the name
+    heuristic once Subtasks 1-2 land) and one restaurant-style venue (should trip
+    _CATEGORY_RULES' "Restaurants" bucket via the name heuristic).
+    """
+    checkins = [
+        _make_empty_category_checkin(
+            created_at=AIRPORT_CHECKIN_TS,
+            venue_name="O'Hare International Airport",
+            lat=41.9742,
+            lng=-87.9073,
+        ),
+        _make_empty_category_checkin(
+            created_at=DINING_CHECKIN_TS,
+            venue_name="Corner City Diner",
+            lat=51.5074,
+            lng=-0.1278,
+        ),
+    ]
+    _write_checkins(tmp_path / "checkins_synthetic.json", checkins)
+    places_df = _fetch_places_df(tmp_path)
+    return places_to_swarm_frame(places_df)
+
+
+# ---------------------------------------------------------------------------
+# "Before" control fixture: place_type forced to "" (documented pre-fix behavior)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def swarm_df_pre_fix_control() -> pd.DataFrame:
+    """swarm_df with place_type/venue_category explicitly forced to "".
+
+    This does NOT call the name heuristic at all -- it hand-constructs the exact
+    shape SwarmPlugin.fetch_records() produces *today*, before any fix, for
+    empty-categories venues (place_type stays "" unconditionally). It exists to
+    prove the "before" half of the before/after contrast is real, not incidental.
+    """
+    places_df = pd.DataFrame(
+        {
+            "timestamp": [AIRPORT_CHECKIN_TS, DINING_CHECKIN_TS],
+            "lat": [41.9742, 51.5074],
+            "lng": [-87.9073, -0.1278],
+            "place_name": ["O'Hare International Airport", "Corner City Diner"],
+            "place_type": ["", ""],
+            "source_id": ["swarm", "swarm"],
+        }
+    )
+    return places_to_swarm_frame(places_df)
+
+
+# ---------------------------------------------------------------------------
+# "After fix" assertions -- expected RED until Subtasks 1-2 are implemented
+# ---------------------------------------------------------------------------
+
+
+def test_transit_days_populate_after_fix(swarm_df_from_real_pipeline: pd.DataFrame) -> None:
+    """get_transit_days() must be non-empty once the name heuristic infers 'Airport'."""
+    transit_days = get_transit_days(swarm_df_from_real_pipeline)
+
+    assert transit_days != set(), (
+        "get_transit_days() returned empty for a synthetic airport-style check-in "
+        "with empty categories -- the name-based place_type heuristic "
+        "(_infer_place_type_from_name, Subtasks 1-2) is not yet wired up, or is not "
+        "producing a value containing a TRANSIT_CATEGORY_KEYWORDS substring."
+    )
+    expected_date = pd.to_datetime(AIRPORT_CHECKIN_TS, unit="s").strftime("%Y-%m-%d")
+    assert expected_date in transit_days
+
+
+def test_dining_soundtrack_data_populates_after_fix(
+    swarm_df_from_real_pipeline: pd.DataFrame,
+) -> None:
+    """get_dining_soundtrack_data() must be non-empty and bucket the diner as Restaurants."""
+    lastfm_df = _lastfm_fixture_for_dining_window()
+
+    result = get_dining_soundtrack_data(swarm_df_from_real_pipeline, lastfm_df)
+
+    assert result != {}, (
+        "get_dining_soundtrack_data() returned empty for a synthetic diner-style "
+        "check-in with empty categories -- the name-based place_type heuristic "
+        "(_infer_place_type_from_name, Subtasks 1-2) is not yet wired up, or is not "
+        "producing a value containing a _CATEGORY_RULES substring (e.g. 'diner')."
+    )
+    assert "Restaurants" in result
+    assert result["Restaurants"]["checkin_count"] >= 1
+    assert result["Restaurants"]["listen_count"] >= 1
+
+
+def test_dining_soundtrack_data_top_artists_include_synthetic_listen(
+    swarm_df_from_real_pipeline: pd.DataFrame,
+) -> None:
+    """The single synthetic listen inside the dining window must surface in top_artists."""
+    lastfm_df = _lastfm_fixture_for_dining_window()
+
+    result = get_dining_soundtrack_data(swarm_df_from_real_pipeline, lastfm_df)
+
+    assert "Restaurants" in result
+    top_artists = result["Restaurants"]["top_artists"]
+    assert not top_artists.empty
+    assert "Synthetic Artist" in top_artists["artist"].values
+
+
+# ---------------------------------------------------------------------------
+# "Before fix" control-case assertions -- expected to PASS already (they assert
+# the documented pre-fix bug, not the fix), establishing the explicit contrast.
+# ---------------------------------------------------------------------------
+
+
+def test_transit_days_empty_before_fix_control(swarm_df_pre_fix_control: pd.DataFrame) -> None:
+    """Control: with place_type forced to "", get_transit_days() returns empty (the bug)."""
+    assert get_transit_days(swarm_df_pre_fix_control) == set()
+
+
+def test_dining_soundtrack_data_empty_before_fix_control(
+    swarm_df_pre_fix_control: pd.DataFrame,
+) -> None:
+    """Control: with place_type forced to "", get_dining_soundtrack_data() returns empty."""
+    lastfm_df = _lastfm_fixture_for_dining_window()
+
+    assert get_dining_soundtrack_data(swarm_df_pre_fix_control, lastfm_df) == {}
+
+
+# ---------------------------------------------------------------------------
+# Documentation acceptance criterion: README's "places layer" section must
+# describe the name-based fallback and its approximation limitation.
+# ---------------------------------------------------------------------------
+
+
+def test_readme_documents_name_based_fallback_limitation() -> None:
+    """README's places-layer section must mention the name-based fallback + limitation.
+
+    Durable assertion: checks for the presence of the *concept* (name-based
+    inference is a fallback, and it is an approximation subordinate to real
+    Foursquare category data) via loose, case-insensitive keyword checks -- not a
+    pinned exact sentence -- so future wording tweaks don't spuriously fail this.
+    """
+    readme_path = Path(__file__).resolve().parents[1] / "packages" / "localizer" / "README.md"
+    readme_text = readme_path.read_text(encoding="utf-8").lower()
+
+    places_layer_idx = readme_text.find("places layer")
+    assert places_layer_idx != -1, "README is missing its 'places layer' section"
+
+    # Look for the doc note anywhere in the README (coder may place it in or near
+    # the places-layer section) -- the presence of both concept keywords is what
+    # we assert, not their exact location or wording.
+    assert "name" in readme_text and ("fallback" in readme_text or "heuristic" in readme_text), (
+        "README does not document the name-based place_type fallback/heuristic"
+    )
+    assert "approximat" in readme_text or "limitation" in readme_text, (
+        "README does not document the approximation/limitation of the name-based "
+        "fallback (i.e. that real Foursquare category data is preferred when present)"
+    )


### PR DESCRIPTION
## Summary

- Real Foursquare/Swarm exports always ship an empty venue `categories` array — confirmed by reading the actual export-handling code — which silently broke two shipped features: Dining Soundtrack (#81) and In Transit (#83), since their keyword classifiers in `analysis_utils.py` had nothing to match against.
- Adds an offline, name-based heuristic fallback (`_infer_place_type_from_name()`) in `packages/localizer/src/localizer/plugins/swarm/loader.py`'s `SwarmPlugin.fetch_records()`, used **only** when `categories` is empty/missing. When real category data is present, behavior is byte-for-byte unchanged.
- The synthesized `place_type` values reuse the exact keyword vocabulary already recognized by `analysis_utils.py`'s existing classifiers (`_CATEGORY_RULES`, `TRANSIT_CATEGORY_KEYWORDS`), so **zero changes** were needed downstream.
- No new dependencies, no network calls — consistent with this app's offline-first constraint.
- Documents the fallback and its known approximation limitation in `packages/localizer/README.md`.

## Test plan

- [x] New unit tests for `_infer_place_type_from_name()` covering airport/station/pizza/coffee/bar/restaurant matches, no-match fallback, false-positive guard (e.g. "Portland Pizza Co." doesn't trip a transit rule), case-insensitivity, and empty/punctuation-only input (`packages/localizer/tests/test_swarm_plugin.py`)
- [x] New wiring tests proving the heuristic fires only on empty/missing categories, across both documented export wrapper formats, with no regression to the existing category-present path (`packages/localizer/tests/test_swarm_plugin_heuristic_wiring.py`)
- [x] New end-to-end integration test exercising the full `fetch_records()` → `places_to_swarm_frame()` → `get_transit_days()`/`get_dining_soundtrack_data()` pipeline, including explicit before/after control cases (`tests/test_venue_category_heuristic_integration.py`)
- [x] Full root suite: `pytest -n auto` → 1005 passed
- [x] Full `packages/localizer` suite: `pytest -n auto` → 431 passed
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] `mypy` — clean

Closes #93